### PR TITLE
chore: automate governance alerts in ci

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  issues: write
 
 jobs:
   build:
@@ -25,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Validate content and generate report
+      - name: Validar conteúdo e gerar relatório
         id: validate_report
         run: npm run validate:report
         continue-on-error: true
@@ -38,25 +39,103 @@ jobs:
           path: reports/content-validation-report.json
           if-no-files-found: error
 
-      - name: Fail if content validation failed
-        if: steps.validate_report.outcome == 'failure'
-        run: |
-          echo "Content validation failed. Consulte o artefato gerado para detalhes."
-          exit 1
-
       - name: Generate observability report
-        if: steps.validate_report.outcome == 'success'
         id: observability
         run: npm run report:observability:check
         continue-on-error: true
 
       - name: Upload observability report
-        if: steps.validate_report.outcome == 'success'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: content-observability-report
           path: reports/content-observability.json
           if-no-files-found: error
+
+      - name: Generate governance summary
+        if: always()
+        run: npm run report:governance
+
+      - name: Upload governance summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: content-governance-alert
+          path: |
+            reports/governance-alert.md
+            reports/governance-alert.json
+          if-no-files-found: error
+
+      - name: Atualizar issue de governança
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const core = require('@actions/core');
+            const fs = require('fs');
+            const path = require('path');
+            const issueTitle = 'Governança de conteúdo: alerta automático';
+            const summaryPath = path.join(process.cwd(), 'reports', 'governance-alert.md');
+            const metaPath = path.join(process.cwd(), 'reports', 'governance-alert.json');
+
+            if (!fs.existsSync(metaPath)) {
+              core.warning('Arquivo de metadados do alerta não encontrado. Pulando atualização de issue.');
+              return;
+            }
+
+            const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+            const body = fs.existsSync(summaryPath)
+              ? fs.readFileSync(summaryPath, 'utf8')
+              : 'Relatório de governança indisponível.';
+
+            const { data: existingIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const current = existingIssues.find((issue) => issue.title === issueTitle);
+
+            if (meta.flags.shouldOpenIssue) {
+              if (current) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: current.number,
+                  body,
+                  labels: ['governanca-automatica'],
+                });
+              } else {
+                await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: issueTitle,
+                  body,
+                  labels: ['governanca-automatica'],
+                });
+              }
+            } else if (current) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: current.number,
+                state: 'closed',
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: current.number,
+                body: '✅ Nenhum apontamento pendente. Issue fechada automaticamente.',
+              });
+            }
+
+      - name: Fail if content validation failed
+        if: steps.validate_report.outcome == 'failure'
+        run: |
+          echo "Content validation failed. Consulte o artefato gerado para detalhes."
+          exit 1
 
       - name: Fail if observability reported metadata gaps
         if: steps.observability.outcome == 'failure'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EDU · Courses Hub
+﻿# EDU · Courses Hub
 
 Vue 3 + Vite application that centralises the course material of Prof. Tiago Sombra. The interface follows Material Design 3, uses a shared utility library for typography/surfaces/elevations and renders structured JSON content through reusable Vue components.
 
@@ -71,6 +71,7 @@ Cards, chips, badges and buttons already consume these tokens internally. When b
 - `npm run report:observability` – consolida métricas de conteúdo em `reports/content-observability.json`, incluindo cobertura de blocos MD3 vs. legados, lições disponíveis por curso e status dos metadados de exercícios/suplementos.
 - `npm run report:observability -- --output <arquivo>` – grava o relatório em outro caminho; combine com `--check` para falhar quando houver exercícios ou suplementos sem metadados obrigatórios (`generatedBy`, `model`, `timestamp`).
 - `npm run report:observability:check` – atalho para rodar o relatório com a verificação de metadados (usado no CI/CD).
+- `npm run report:governance` – gera `reports/governance-alert.{md,json}` cruzando validação e observabilidade para destacar cursos com problemas/avisos, blocos legados e lacunas de metadados.
 - O relatório consolidado pode ser consultado diretamente na interface em `/relatorios/validacao-conteudo`, acessível pelo atalho "Relatório de validação" no cabeçalho.
 
 These scripts are optional; new content should be authored directly in the structured JSON format.
@@ -85,6 +86,7 @@ These scripts are optional; new content should be authored directly in the struc
 
 - The project uses `vite-plugin-pwa` with SPA fallback for GitHub Pages.
 - O workflow em `.github/workflows/deploy.yml` valida o conteúdo com `npm run validate:report`, gera o relatório de observabilidade com `npm run report:observability:check` e publica ambos os artefatos. Caso algum curso tenha exercícios ou suplementos sem metadados obrigatórios, a pipeline falha antes do build/deploy.
+- Independentemente do resultado, o workflow produz `reports/governance-alert.md`/`.json` e atualiza uma issue automática (`governanca-automatica`) com o resumo das pendências (problemas, avisos, blocos legados, metadados faltantes) para facilitar o acompanhamento contínuo.
 
 ## Quality Checklist
 

--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -71,6 +71,7 @@
 ### 4.2 Observabilidade
 
 - Incluir metadados no JSON (`generatedBy`, `model`, `timestamp`) para auditar quando uma aula veio de LLM e exigir revisão antes do publish.
+- Consolidar validação + observabilidade via `npm run report:governance`, gerando o par `reports/governance-alert.{md,json}`; o workflow do GitHub Actions publica esses artefatos e mantém uma issue automática com o resumo das pendências (problemas, avisos, blocos legados e metadados faltantes).
 
 ## 5. Material Design 3
 

--- a/docs/CONTENT_AUTHORING_GUIDE.md
+++ b/docs/CONTENT_AUTHORING_GUIDE.md
@@ -85,6 +85,8 @@ Inside legacy sections the renderer automatically wraps blocks with MD3 cards (`
 - Após rodar `npm run validate:report`, consulte `reports/content-validation-report.json` para ver o consolidado por curso (totais por autor/modelo, intervalo temporal e entradas individuais) antes de enviar mudanças.
 - Use `npm run report:observability` para acompanhar quantas lições continuam com blocos legados, qual a cobertura de blocos MD3 em cada curso e se exercícios/suplementos mantêm metadados completos.
 - Rode `npm run report:observability:check` quando quiser reproduzir o mesmo guardrail do CI/CD; o workflow de deploy falha automaticamente se encontrar exercícios ou suplementos sem `metadata` obrigatório.
+- Execute `npm run report:governance` para gerar `reports/governance-alert.md`/`.json` com um resumo dos cursos que ainda têm problemas/avisos, blocos legados e lacunas de metadados (combinação direta dos dois relatórios anteriores).
+- O GitHub Actions atualiza automaticamente uma issue com label `governanca-automatica` a cada execução da pipeline, usando esse resumo para indicar prioridades e acompanhar a redução de blocos legados ao longo do tempo.
 - A página `/relatorios/validacao-conteudo` exibe os mesmos dados com cobertura por curso, autores recorrentes e modelos utilizados, facilitando a conferência visual dos metadados antes do deploy.
 
 ### Automating HTML-first lessons

--- a/docs/LLM_PROMPT_PLAYBOOK.md
+++ b/docs/LLM_PROMPT_PLAYBOOK.md
@@ -9,6 +9,7 @@ Guia operacional para gerar e manter conteúdo do EDU com apoio de modelos de li
 - Responder em português para o conteúdo e em inglês para comentários no código.
 - Após gerar, execute `npm run validate:content` (ou `npm run validate:report` para guardar o relatório consolidado com os metadados) e revise manualmente antes de publicar.
 - Gere `npm run report:observability` para confirmar quantas lições ainda dependem de blocos legados e se os metadados de exercícios/suplementos continuam completos.
+- Gere `npm run report:governance` para cruzar validação + observabilidade e obter um resumo por curso dos blocos legados, avisos/problemas e metadados pendentes (o arquivo `.md` é usado pela automação de governança).
 - Quando salvar o relatório, verifique a seção `generation` (ou a página `/relatorios/validacao-conteudo`) para confirmar autoria, modelo e timestamps de cada exercício/suplemento antes do envio.
 - Preserve `meta.json` com `id` alinhado ao diretório, `institution` dentro da lista canônica e descrições com pelo menos 60 caracteres úteis sempre que ajustar informações do curso.
 - Quando precisar de destaques visuais em grade, use `cardGrid` com `cards[]` (cada item precisa de `title` + `content`/`body`) e variantes canônicas (`info`, `good-practice`, `primary`, etc.).
@@ -87,6 +88,7 @@ Retorne apenas o trecho Vue modificado.
 - [ ] JSON valida contra schema oficial (`npm run validate:content` ou `npm run validate:report`).
 - [ ] Relatório consolidado (`reports/content-validation-report.json`) exibe autoria/modelo coerentes para as entradas alteradas.
 - [ ] Relatório de observabilidade (`reports/content-observability.json`) mostra redução contínua de blocos legados e metadados completos.
+- [ ] Relatório de governança (`reports/governance-alert.md`) reflete o estado esperado e destaca apenas pendências conhecidas (issue `governanca-automatica` sem surpresas).
 - [ ] `npm run report:observability:check` passa localmente (garante que a pipeline não falhará por metadados ausentes).
 - [ ] Pelo menos um bloco de engajamento (`callout`, `checklist`, `timeline`).
 - [ ] Se houver `cardGrid`, todos os cartões têm título + texto e variantes dentro do conjunto permitido.

--- a/docs/WORK_STATUS.md
+++ b/docs/WORK_STATUS.md
@@ -91,13 +91,18 @@ Esses materiais dão visibilidade sobre o estado atual do projeto e aceleram a c
 - O workflow de deploy agora roda `npm run report:observability:check` após a validação, publica `reports/content-observability.json` como artefato e falha quando há exercícios ou suplementos sem metadados obrigatórios.
 - Mantém os snapshots de validação e observabilidade disponíveis para download direto no GitHub Actions, reforçando a rastreabilidade das métricas a cada execução.
 
+20. **Governança automatizada em CI/CD**
+
+- `npm run report:governance` cruza validação e observabilidade gerando `reports/governance-alert.md`/`.json` com problemas, avisos, blocos legados e lacunas de metadados por curso.
+- O workflow de deploy publica o alerta como artefato e mantém atualizada uma issue automática (`governanca-automatica`) com o resumo das pendências, facilitando o acompanhamento contínuo da redução de blocos legados.
+
 ## O que ainda pode ser feito
 
 A partir das recomendações listadas na revisão de arquitetura, seguem frentes prioritárias:
 
 1. **Automação e validação**
-   - Disparar notificações ou abrir issues automaticamente quando a pipeline falhar, destacando o curso afetado e o tipo de problema (validação vs. metadados).
-   - Estender os relatórios para cruzar métricas de observabilidade com progresso de migrações MD3 (ex.: evolução semanal de blocos legados).
+   - Complementar o alerta automático com comparação histórica (ex.: anexar diferença de blocos legados entre execuções) e publicar snapshot semanal em `reports/`.
+   - Estender os relatórios para incluir séries temporais e evolução percentual da migração MD3.
 2. **Refinamento do front-end**
    - Montar Storybook ou Chromatic para validar visualmente componentes críticos e garantir regressão visual sobre os novos utilitários.
    - Converter wrappers `.vue` redundantes para carregamento dinâmico baseado em JSON, reduzindo retrabalho.
@@ -120,3 +125,4 @@ Seguir essas etapas transforma a revisão em plano operacional, permitindo que a
 | Observabilidade de conteúdo                   | ✅ Concluída | `npm run report:observability` gera métricas sobre blocos MD3 x legados, lições disponíveis e cobertura de metadados.              |
 | Observabilidade automatizada no CI            | ✅ Concluída | Workflow gera o relatório, publica artefato dedicado e falha quando faltam metadados obrigatórios em exercícios/suplementos.       |
 | Proveniência exibida no painel                | ✅ Concluída | Painel traz cobertura de metadados, autores recorrentes e modelos utilizados por curso.                                            |
+| Governança automática no CI                   | ✅ Concluída | Workflow gera `reports/governance-alert.{md,json}` e mantém issue `governanca-automatica` com problemas/avisos e blocos legados.   |

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "validate:content": "node scripts/validate-content.mjs",
     "validate:report": "node scripts/validate-content.mjs --report",
     "report:observability": "node scripts/report-content-metrics.mjs",
-    "report:observability:check": "node scripts/report-content-metrics.mjs --check"
+    "report:observability:check": "node scripts/report-content-metrics.mjs --check",
+    "report:governance": "node scripts/generate-governance-alert.mjs"
   },
   "dependencies": {
     "@vueuse/head": "^2.0.0",

--- a/reports/content-observability.json
+++ b/reports/content-observability.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-26T19:31:44.317Z",
+  "generatedAt": "2025-09-26T21:24:29.932Z",
   "totals": {
     "courses": 5,
     "lessons": {

--- a/reports/content-validation-report.json
+++ b/reports/content-validation-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-26T19:31:40.241Z",
+  "generatedAt": "2025-09-26T21:24:28.267Z",
   "status": "passed-with-warnings",
   "totals": {
     "courses": 5,

--- a/reports/governance-alert.json
+++ b/reports/governance-alert.json
@@ -1,0 +1,102 @@
+{
+  "generatedAt": "2025-09-26T21:24:32.537Z",
+  "hasValidationReport": true,
+  "hasObservabilityReport": true,
+  "validationStatus": "passed-with-warnings",
+  "validationTotals": {
+    "problems": 0,
+    "warnings": 4,
+    "lessonsWithIssues": 4
+  },
+  "observabilityTotals": {
+    "legacyBlocks": 28,
+    "legacyLessons": 27,
+    "md3Blocks": 520,
+    "lessonsTotal": 92,
+    "courses": 5,
+    "exercisesWithoutMetadata": 0,
+    "supplementsWithoutMetadata": 0
+  },
+  "metadataIssues": [],
+  "courses": [
+    {
+      "id": "tgs",
+      "problems": 0,
+      "warnings": 2,
+      "lessonsWithIssues": 2,
+      "legacyBlocks": 8,
+      "legacyLessons": 8,
+      "legacyLessonIds": [
+        "lesson-06",
+        "lesson-07",
+        "lesson-10",
+        "lesson-11",
+        "lesson-12",
+        "lesson-13",
+        "lesson-14",
+        "lesson-15"
+      ],
+      "exercisesWithoutMetadata": 0,
+      "supplementsWithoutMetadata": 0
+    },
+    {
+      "id": "ddm",
+      "problems": 0,
+      "warnings": 1,
+      "lessonsWithIssues": 1,
+      "legacyBlocks": 8,
+      "legacyLessons": 8,
+      "legacyLessonIds": [
+        "lesson-03",
+        "lesson-06",
+        "lesson-07",
+        "lesson-08",
+        "lesson-09",
+        "lesson-10",
+        "lesson-13",
+        "lesson-14"
+      ],
+      "exercisesWithoutMetadata": 0,
+      "supplementsWithoutMetadata": 0
+    },
+    {
+      "id": "tdjd",
+      "problems": 0,
+      "warnings": 1,
+      "lessonsWithIssues": 1,
+      "legacyBlocks": 5,
+      "legacyLessons": 5,
+      "legacyLessonIds": ["lesson-02", "lesson-10", "lesson-11", "lesson-12", "lesson-13"],
+      "exercisesWithoutMetadata": 0,
+      "supplementsWithoutMetadata": 0
+    },
+    {
+      "id": "algi",
+      "problems": 0,
+      "warnings": 0,
+      "lessonsWithIssues": 0,
+      "legacyBlocks": 6,
+      "legacyLessons": 5,
+      "legacyLessonIds": ["lesson-04", "lesson-14", "lesson-15", "lesson-29", "lesson-39"],
+      "exercisesWithoutMetadata": 0,
+      "supplementsWithoutMetadata": 0
+    },
+    {
+      "id": "lpoo",
+      "problems": 0,
+      "warnings": 0,
+      "lessonsWithIssues": 0,
+      "legacyBlocks": 1,
+      "legacyLessons": 1,
+      "legacyLessonIds": ["lesson-01"],
+      "exercisesWithoutMetadata": 0,
+      "supplementsWithoutMetadata": 0
+    }
+  ],
+  "flags": {
+    "hasProblems": false,
+    "hasWarnings": true,
+    "totalLegacyBlocks": 28,
+    "shouldOpenIssue": true
+  }
+}

--- a/reports/governance-alert.md
+++ b/reports/governance-alert.md
@@ -1,0 +1,31 @@
+# Alerta de governança de conteúdo
+
+_Gerado em 2025-09-26 21:24:32.537 UTC_
+
+## Diagnóstico rápido
+
+- **Status da validação**: ⚠️ aprovado com avisos com 0 problema(s) e 4 aviso(s).
+- **Blocos legados**: 28 em 27 lição(ões) (total de 92 lições mapeadas).
+- **Metadados obrigatórios**: 0 exercícios e 0 suplementos pendentes.
+
+## Cursos com apontamentos
+
+| Curso | Problemas | Avisos | Blocos legados | Lições afetadas                                                                        | Exercícios s/ metadados | Suplementos s/ metadados |
+| ----- | --------- | ------ | -------------- | -------------------------------------------------------------------------------------- | ----------------------- | ------------------------ |
+| tgs   | 0         | 2      | 8              | lesson-06, lesson-07, lesson-10, lesson-11, lesson-12, lesson-13, lesson-14, lesson-15 | 0                       | 0                        |
+| ddm   | 0         | 1      | 8              | lesson-03, lesson-06, lesson-07, lesson-08, lesson-09, lesson-10, lesson-13, lesson-14 | 0                       | 0                        |
+| tdjd  | 0         | 1      | 5              | lesson-02, lesson-10, lesson-11, lesson-12, lesson-13                                  | 0                       | 0                        |
+| algi  | 0         | 0      | 6              | lesson-04, lesson-14, lesson-15, lesson-29, lesson-39                                  | 0                       | 0                        |
+| lpoo  | 0         | 0      | 1              | lesson-01                                                                              | 0                       | 0                        |
+
+### Tipos mais frequentes
+
+**Avisos**
+
+- legacy-block: 4
+
+### Próximas ações sugeridas
+
+- Priorizar a migração dos blocos legados listados acima para componentes MD3 equivalentes.
+- Corrigir apontamentos de validação para liberar a publicação sem retrabalho.
+- Completar metadados de exercícios e suplementos para garantir rastreabilidade.

--- a/scripts/generate-governance-alert.mjs
+++ b/scripts/generate-governance-alert.mjs
@@ -1,0 +1,466 @@
+#!/usr/bin/env node
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const reportsRoot = path.join(repoRoot, 'reports');
+
+const defaultValidationPath = path.join(reportsRoot, 'content-validation-report.json');
+const defaultObservabilityPath = path.join(reportsRoot, 'content-observability.json');
+const defaultMarkdownPath = path.join(reportsRoot, 'governance-alert.md');
+const defaultMetaPath = path.join(reportsRoot, 'governance-alert.json');
+
+function parseArgs(argv) {
+  const options = {
+    validationPath: defaultValidationPath,
+    observabilityPath: defaultObservabilityPath,
+    markdownPath: defaultMarkdownPath,
+    metaPath: defaultMetaPath,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--validation' && argv[i + 1]) {
+      options.validationPath = path.resolve(repoRoot, argv[i + 1]);
+      i += 1;
+    } else if (arg === '--observability' && argv[i + 1]) {
+      options.observabilityPath = path.resolve(repoRoot, argv[i + 1]);
+      i += 1;
+    } else if ((arg === '--output' || arg === '--markdown') && argv[i + 1]) {
+      options.markdownPath = path.resolve(repoRoot, argv[i + 1]);
+      i += 1;
+    } else if (arg === '--meta' && argv[i + 1]) {
+      options.metaPath = path.resolve(repoRoot, argv[i + 1]);
+      i += 1;
+    } else if (arg === '--help' || arg === '-h') {
+      printUsage();
+      process.exit(0);
+    }
+  }
+
+  return options;
+}
+
+function printUsage() {
+  console.log(
+    `Uso: node scripts/generate-governance-alert.mjs [opções]\n\n` +
+      'Opções:\n' +
+      '  --validation <arquivo>      Caminho para o JSON de validação (padrão: reports/content-validation-report.json)\n' +
+      '  --observability <arquivo>   Caminho para o JSON de observabilidade (padrão: reports/content-observability.json)\n' +
+      '  --output <arquivo>          Caminho do Markdown gerado (padrão: reports/governance-alert.md)\n' +
+      '  --meta <arquivo>            Caminho do JSON de metadados gerado (padrão: reports/governance-alert.json)\n'
+  );
+}
+
+async function readJson(filePath) {
+  const contents = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(contents);
+}
+
+async function fileExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function formatNumber(value) {
+  return new Intl.NumberFormat('pt-BR').format(value);
+}
+
+function collectValidationSummary(validationReport) {
+  if (!validationReport || typeof validationReport !== 'object') {
+    return {
+      status: 'missing',
+      totals: { problems: 0, warnings: 0, lessonsWithIssues: 0 },
+      courses: [],
+      warningTypes: new Map(),
+      problemTypes: new Map(),
+    };
+  }
+
+  const warningTypes = new Map();
+  const problemTypes = new Map();
+  const courses = [];
+
+  for (const course of Array.isArray(validationReport.courses) ? validationReport.courses : []) {
+    const courseWarnings = [];
+    const courseProblems = [];
+    for (const lesson of Array.isArray(course.lessons) ? course.lessons : []) {
+      for (const problem of Array.isArray(lesson.problems) ? lesson.problems : []) {
+        problemTypes.set(problem.type, (problemTypes.get(problem.type) ?? 0) + 1);
+        courseProblems.push({
+          lessonId: lesson.lessonId,
+          message: problem.message,
+          type: problem.type,
+        });
+      }
+      for (const warning of Array.isArray(lesson.warnings) ? lesson.warnings : []) {
+        warningTypes.set(warning.type, (warningTypes.get(warning.type) ?? 0) + 1);
+        courseWarnings.push({
+          lessonId: lesson.lessonId,
+          message: warning.message,
+          type: warning.type,
+        });
+      }
+    }
+
+    courses.push({
+      id: course.id,
+      problems: course.problems ?? courseProblems.length,
+      warnings: course.warnings ?? courseWarnings.length,
+      lessonsWithIssues: course.lessonsWithIssues ?? 0,
+      problemsDetail: courseProblems,
+      warningsDetail: courseWarnings,
+    });
+  }
+
+  return {
+    status: validationReport.status ?? 'unknown',
+    totals: {
+      problems: validationReport.totals?.problems ?? 0,
+      warnings: validationReport.totals?.warnings ?? 0,
+      lessonsWithIssues: validationReport.totals?.lessonsWithIssues ?? 0,
+    },
+    courses,
+    warningTypes,
+    problemTypes,
+  };
+}
+
+function collectObservabilitySummary(observabilityReport) {
+  if (!observabilityReport || typeof observabilityReport !== 'object') {
+    return {
+      totals: {
+        legacyBlocks: 0,
+        legacyLessons: 0,
+        md3Blocks: 0,
+        lessonsTotal: 0,
+        courses: 0,
+      },
+      courses: new Map(),
+      metadataIssues: [],
+    };
+  }
+
+  const coursesMap = new Map();
+  const metadataIssues = [];
+  for (const course of Array.isArray(observabilityReport.courses)
+    ? observabilityReport.courses
+    : []) {
+    const lessons = course.lessons ?? {};
+    const exercises = course.exercises ?? {};
+    const supplements = course.supplements ?? {};
+
+    if (exercises.total > (exercises.withMetadata ?? 0)) {
+      metadataIssues.push(
+        `Curso ${course.id}: ${exercises.total - exercises.withMetadata} exercício(s) sem metadados obrigatórios.`
+      );
+    }
+    if (supplements.total > (supplements.withMetadata ?? 0)) {
+      metadataIssues.push(
+        `Curso ${course.id}: ${supplements.total - supplements.withMetadata} suplemento(s) sem metadados obrigatórios.`
+      );
+    }
+
+    coursesMap.set(course.id, {
+      legacyBlocks: lessons.legacyBlocks ?? 0,
+      legacyLessons: lessons.legacyLessons ?? 0,
+      legacyLessonIds: Array.isArray(lessons.legacyLessonIds) ? lessons.legacyLessonIds : [],
+      md3Blocks: lessons.md3Blocks ?? 0,
+      totalBlocks: lessons.totalBlocks ?? 0,
+      exercisesWithoutMetadata: Math.max(0, (exercises.total ?? 0) - (exercises.withMetadata ?? 0)),
+      supplementsWithoutMetadata: Math.max(
+        0,
+        (supplements.total ?? 0) - (supplements.withMetadata ?? 0)
+      ),
+    });
+  }
+
+  const totals = {
+    legacyBlocks: observabilityReport.totals?.lessons?.legacyBlocks ?? 0,
+    legacyLessons: observabilityReport.totals?.lessons?.legacyLessons ?? 0,
+    md3Blocks: observabilityReport.totals?.lessons?.md3Blocks ?? 0,
+    lessonsTotal: observabilityReport.totals?.lessons?.total ?? 0,
+    courses: observabilityReport.totals?.courses ?? coursesMap.size,
+    exercisesWithoutMetadata: Math.max(
+      0,
+      (observabilityReport.totals?.exercises?.total ?? 0) -
+        (observabilityReport.totals?.exercises?.withMetadata ?? 0)
+    ),
+    supplementsWithoutMetadata: Math.max(
+      0,
+      (observabilityReport.totals?.supplements?.total ?? 0) -
+        (observabilityReport.totals?.supplements?.withMetadata ?? 0)
+    ),
+  };
+
+  return { totals, courses: coursesMap, metadataIssues };
+}
+
+function buildMarkdown(summary) {
+  const lines = [];
+  lines.push('# Alerta de governança de conteúdo');
+  lines.push('');
+  lines.push(`_Gerado em ${summary.generatedAt.replace('T', ' ').replace('Z', ' UTC')}_`);
+  lines.push('');
+
+  if (!summary.hasValidationReport && !summary.hasObservabilityReport) {
+    lines.push(
+      'Nenhum relatório de validação ou observabilidade foi encontrado. Execute os scripts antes de gerar este alerta.'
+    );
+    return lines.join('\n');
+  }
+
+  lines.push('## Diagnóstico rápido');
+  lines.push('');
+  if (summary.hasValidationReport) {
+    lines.push(
+      `- **Status da validação**: ${formatStatus(summary.validation.status)} com ${formatNumber(
+        summary.validation.totals.problems
+      )} problema(s) e ${formatNumber(summary.validation.totals.warnings)} aviso(s).`
+    );
+  } else {
+    lines.push('- Relatório de validação indisponível.');
+  }
+  if (summary.hasObservabilityReport) {
+    lines.push(
+      `- **Blocos legados**: ${formatNumber(summary.observability.totals.legacyBlocks)} em ${formatNumber(
+        summary.observability.totals.legacyLessons
+      )} lição(ões) (total de ${formatNumber(summary.observability.totals.lessonsTotal)} lições mapeadas).`
+    );
+    lines.push(
+      `- **Metadados obrigatórios**: ${formatNumber(
+        summary.observability.totals.exercisesWithoutMetadata
+      )} exercícios e ${formatNumber(summary.observability.totals.supplementsWithoutMetadata)} suplementos pendentes.`
+    );
+  } else {
+    lines.push('- Relatório de observabilidade indisponível.');
+  }
+  lines.push('');
+
+  if (summary.courses.length === 0) {
+    lines.push('Nenhum curso com apontamentos registrado nos relatórios mais recentes.');
+    return lines.join('\n');
+  }
+
+  lines.push('## Cursos com apontamentos');
+  lines.push('');
+  lines.push(
+    '| Curso | Problemas | Avisos | Blocos legados | Lições afetadas | Exercícios s/ metadados | Suplementos s/ metadados |'
+  );
+  lines.push(
+    '| ----- | --------- | ------ | -------------- | ---------------- | ------------------------ | ------------------------- |'
+  );
+  for (const course of summary.courses) {
+    lines.push(
+      `| ${course.id} | ${formatNumber(course.problems)} | ${formatNumber(course.warnings)} | ${formatNumber(
+        course.legacyBlocks
+      )} | ${course.legacyLessonIds.length > 0 ? course.legacyLessonIds.join(', ') : '—'} | ${formatNumber(
+        course.exercisesWithoutMetadata
+      )} | ${formatNumber(course.supplementsWithoutMetadata)} |`
+    );
+  }
+  lines.push('');
+
+  if (
+    summary.validation.warningBreakdown.length > 0 ||
+    summary.validation.problemBreakdown.length > 0
+  ) {
+    lines.push('### Tipos mais frequentes');
+    lines.push('');
+    if (summary.validation.problemBreakdown.length > 0) {
+      lines.push('**Problemas**');
+      for (const item of summary.validation.problemBreakdown) {
+        lines.push(`- ${item.type}: ${formatNumber(item.count)}`);
+      }
+      lines.push('');
+    }
+    if (summary.validation.warningBreakdown.length > 0) {
+      lines.push('**Avisos**');
+      for (const item of summary.validation.warningBreakdown) {
+        lines.push(`- ${item.type}: ${formatNumber(item.count)}`);
+      }
+      lines.push('');
+    }
+  }
+
+  if (summary.metadataIssues.length > 0) {
+    lines.push('### Metadados pendentes');
+    lines.push('');
+    for (const issue of summary.metadataIssues) {
+      lines.push(`- ${issue}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('### Próximas ações sugeridas');
+  lines.push('');
+  lines.push(
+    '- Priorizar a migração dos blocos legados listados acima para componentes MD3 equivalentes.'
+  );
+  lines.push('- Corrigir apontamentos de validação para liberar a publicação sem retrabalho.');
+  lines.push('- Completar metadados de exercícios e suplementos para garantir rastreabilidade.');
+
+  return lines.join('\n');
+}
+
+function formatStatus(status) {
+  switch (status) {
+    case 'passed':
+      return '✅ aprovado';
+    case 'passed-with-warnings':
+      return '⚠️ aprovado com avisos';
+    case 'failed':
+      return '❌ reprovado';
+    case 'failed-with-warnings':
+      return '❌ reprovado com avisos';
+    default:
+      return status;
+  }
+}
+
+function buildMeta({
+  validation,
+  observability,
+  metadataIssues,
+  courses,
+  generatedAt,
+  hasValidationReport,
+  hasObservabilityReport,
+}) {
+  const hasProblems = validation.totals.problems > 0;
+  const hasWarnings =
+    validation.totals.warnings > 0 || courses.some((course) => course.warnings > 0);
+  const totalLegacyBlocks = observability.totals.legacyBlocks;
+  const shouldOpenIssue = hasProblems || metadataIssues.length > 0 || totalLegacyBlocks > 0;
+
+  return {
+    generatedAt,
+    hasValidationReport,
+    hasObservabilityReport,
+    validationStatus: validation.status,
+    validationTotals: validation.totals,
+    observabilityTotals: observability.totals,
+    metadataIssues,
+    courses,
+    flags: {
+      hasProblems,
+      hasWarnings,
+      totalLegacyBlocks,
+      shouldOpenIssue,
+    },
+  };
+}
+
+function breakdownFromMap(map) {
+  return Array.from(map.entries())
+    .map(([type, count]) => ({ type, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  await fs.mkdir(path.dirname(options.markdownPath), { recursive: true });
+  await fs.mkdir(path.dirname(options.metaPath), { recursive: true });
+
+  const hasValidation = await fileExists(options.validationPath);
+  const hasObservability = await fileExists(options.observabilityPath);
+
+  const validationReport = hasValidation ? await readJson(options.validationPath) : null;
+  const observabilityReport = hasObservability ? await readJson(options.observabilityPath) : null;
+
+  const validation = collectValidationSummary(validationReport);
+  const observability = collectObservabilitySummary(observabilityReport);
+
+  const generatedAt = new Date().toISOString();
+
+  const courses = mergeCourseSummaries(validation.courses, observability.courses);
+  const summary = {
+    generatedAt,
+    hasValidationReport: hasValidation,
+    hasObservabilityReport: hasObservability,
+    validation: {
+      status: validation.status,
+      totals: validation.totals,
+      warningBreakdown: breakdownFromMap(validation.warningTypes),
+      problemBreakdown: breakdownFromMap(validation.problemTypes),
+    },
+    observability,
+    metadataIssues: observability.metadataIssues,
+    courses,
+  };
+
+  const markdown = buildMarkdown(summary);
+  const meta = buildMeta(summary);
+
+  await fs.writeFile(options.markdownPath, `${markdown}\n`, 'utf8');
+  await fs.writeFile(options.metaPath, `${JSON.stringify(meta, null, 2)}\n`, 'utf8');
+
+  console.log(`Resumo de governança salvo em ${path.relative(repoRoot, options.markdownPath)}`);
+  console.log(`Metadados do alerta salvos em ${path.relative(repoRoot, options.metaPath)}`);
+}
+
+function mergeCourseSummaries(validationCourses, observabilityCoursesMap) {
+  const courses = [];
+  const seen = new Set();
+
+  for (const course of validationCourses) {
+    const observability = observabilityCoursesMap.get(course.id) ?? {
+      legacyBlocks: 0,
+      legacyLessons: 0,
+      legacyLessonIds: [],
+      exercisesWithoutMetadata: 0,
+      supplementsWithoutMetadata: 0,
+    };
+
+    courses.push({
+      id: course.id,
+      problems: course.problems,
+      warnings: course.warnings,
+      lessonsWithIssues: course.lessonsWithIssues,
+      legacyBlocks: observability.legacyBlocks,
+      legacyLessons: observability.legacyLessons,
+      legacyLessonIds: observability.legacyLessonIds,
+      exercisesWithoutMetadata: observability.exercisesWithoutMetadata,
+      supplementsWithoutMetadata: observability.supplementsWithoutMetadata,
+    });
+    seen.add(course.id);
+  }
+
+  for (const [courseId, observability] of observabilityCoursesMap.entries()) {
+    if (seen.has(courseId)) continue;
+    courses.push({
+      id: courseId,
+      problems: 0,
+      warnings: 0,
+      lessonsWithIssues: 0,
+      legacyBlocks: observability.legacyBlocks,
+      legacyLessons: observability.legacyLessons,
+      legacyLessonIds: observability.legacyLessonIds,
+      exercisesWithoutMetadata: observability.exercisesWithoutMetadata,
+      supplementsWithoutMetadata: observability.supplementsWithoutMetadata,
+    });
+  }
+
+  courses.sort((a, b) => {
+    if (b.problems !== a.problems) {
+      return b.problems - a.problems;
+    }
+    if (b.warnings !== a.warnings) {
+      return b.warnings - a.warnings;
+    }
+    return b.legacyBlocks - a.legacyBlocks;
+  });
+
+  return courses;
+}
+
+main().catch((error) => {
+  console.error('Falha ao gerar alerta de governança:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a governance alert generator that merges validation and observability reports into Markdown/JSON outputs and expose it via npm run report:governance
- extend the deploy workflow to always upload the governance summary and update an automatic issue with the latest validation/observability findings
- refresh documentation, status logs, and report snapshots to describe the new alert flow and capture the latest metrics

## Testing
- npm run validate:content
- npm run validate:report
- npm run report:observability:check
- npm run report:governance
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d685904fac832ca7808024582e3a9f