### PR TITLE
Fix LessonView lesson content typing

### DIFF
--- a/src/pages/LessonView.vue
+++ b/src/pages/LessonView.vue
@@ -51,6 +51,7 @@ import { useRoute } from 'vue-router';
 import { ChevronRight } from 'lucide-vue-next';
 import Prism from 'prismjs';
 import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import type { LessonBlock } from '@/components/lesson/blockRegistry';
 
 import 'prismjs/components/prism-markup';
 import 'prismjs/components/prism-javascript';
@@ -84,7 +85,7 @@ interface LessonContent {
   id: string;
   title: string;
   objective?: string;
-  content: unknown[];
+  content: LessonBlock[];
 }
 
 const lessonData = shallowRef<LessonContent | null>(null);


### PR DESCRIPTION
## Summary
- align LessonView's lesson content typing with the LessonRenderer expectation by reusing LessonBlock
- ensure fetched lesson JSON payloads type-check correctly against the renderer contract

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7f7efb5ec832ca3f04fbc5af58cb5