### PR TITLE
feat: automate professor git push flow

### DIFF
--- a/docs/professor-module/README.md
+++ b/docs/professor-module/README.md
@@ -11,14 +11,19 @@ Este documento acompanha a implementação incremental da nova área administrat
   - ✅ Editor visual em `/professor/editor` com edição de metadados e blocos (`lessonPlan`, `callout`, `cardGrid`, `contentBlock`).
   - ✅ Validação automática no editor reaproveitando o `lesson.schema.json` para alertar violações do schema durante a edição.
   - ✅ Painel `/professor/validacao` com registro de execuções, notas da rodada e importação de relatórios oficiais.
-  - ✅ Pacote de publicação em `/professor/publicacao` para planejar branches, commits, validações e gerar resumo de PR.
-  - ✅ Serviço auxiliar `npm run teacher:service` expõe API local para executar scripts oficiais e sincronizar relatórios com o painel.
+- ✅ Pacote de publicação em `/professor/publicacao` para planejar branches, commits, validações e gerar resumo de PR.
+- ✅ Botão "Buscar atualizações da main" sincroniza o workspace via backend antes da rodada de commits.
+- ✅ Botão "Criar branch automaticamente" prepara a branch de trabalho a partir da `main` diretamente na SPA.
+- ✅ Automação de `git add` e `git commit` a partir dos caminhos cadastrados no painel de publicação.
+- ✅ Envio automático de `git push` com configuração de upstream direto do painel de publicação.
+- ✅ Serviço auxiliar `npm run teacher:service` expõe API local para executar scripts oficiais e sincronizar relatórios com o painel.
   - ✅ Histórico de execuções remotas disponível diretamente no painel de validação ao integrar com o `teacher:service`.
+  - ✅ Autenticação por token no serviço auxiliar para permitir exposição controlada além do ambiente local.
 
 - **Próximos passos imediatos**
-  - 🔒 Adicionar autenticação mínima ao serviço backend antes de compartilhá-lo com o time ampliado.
-  - 🧩 Conectar o pacote de publicação às automações para preparar branches, commits e PRs diretamente da SPA.
+- 🧩 Automatizar abertura de PRs diretamente pelo painel de publicação.
   - 🗃️ Definir estratégia de permissões e governança para expor a API em ambientes compartilhados.
+  - 🔐 Definir política de rotação/armazenamento seguro do token do serviço auxiliar.
 
 ## Atualização em curso — Iteração 2 (Ingestão de JSON)
 
@@ -42,6 +47,7 @@ Este documento acompanha a implementação incremental da nova área administrat
 - ✅ Importação de `content-validation-report.json`, `content-observability.json` e `governance-alert.json` com resumos automáticos.
 - ✅ Serviço backend local (`npm run teacher:service`) permite disparar scripts oficiais e baixar relatórios sem sair da SPA.
 - ✅ Histórico de execuções remotas consumido direto da API (`/api/teacher/scripts/history`).
+- ✅ Editor visual sincroniza os alertas registrados e bloqueia exportações com falhas críticas.
 - 🚧 Autenticação e fila de execução do backend auxiliar em planejamento.
 - 📓 Registro contínuo em [`iteration-04.md`](./iteration-04.md).
 
@@ -50,7 +56,11 @@ Este documento acompanha a implementação incremental da nova área administrat
 - ✅ Lançado o pacote `/professor/publicacao` com checklist de validações e geração de comandos para Git/PR.
 - ✅ Sugestão automática de mensagem de commit e corpo do PR a partir dos conteúdos cadastrados.
 - ✅ Integração com o serviço backend para sincronizar status dos scripts obrigatórios e download dos relatórios.
-- 🚧 Backend para criação de branches e PRs automatizados permanece no roadmap.
+- ✅ Botão "Buscar atualizações da main" aciona `git fetch` via backend e atualiza divergências automaticamente.
+- ✅ Checkout automático de branch a partir da `main` via backend para alinhar o workspace antes dos commits.
+- ✅ Painel executa `git add` e `git commit` diretamente pela API, reaproveitando o checklist de conteúdos cadastrados.
+- ✅ Painel envia a branch ativa com `git push`, configurando o upstream na primeira execução quando necessário.
+- 🚧 Backend para abertura de PRs automatizados permanece no roadmap.
 - 📓 Registro contínuo em [`iteration-05.md`](./iteration-05.md).
 
 ## 1. Mapeamento de requisitos e workflows

--- a/docs/professor-module/README.md
+++ b/docs/professor-module/README.md
@@ -11,14 +11,14 @@ Este documento acompanha a implementação incremental da nova área administrat
   - ✅ Editor visual em `/professor/editor` com edição de metadados e blocos (`lessonPlan`, `callout`, `cardGrid`, `contentBlock`).
   - ✅ Validação automática no editor reaproveitando o `lesson.schema.json` para alertar violações do schema durante a edição.
   - ✅ Painel `/professor/validacao` com registro de execuções, notas da rodada e importação de relatórios oficiais.
-- ✅ Pacote de publicação em `/professor/publicacao` para planejar branches, commits, validações e gerar resumo de PR.
-- ✅ Botão "Buscar atualizações da main" sincroniza o workspace via backend antes da rodada de commits.
-- ✅ Botão "Criar branch automaticamente" prepara a branch de trabalho a partir da `main` diretamente na SPA.
-- ✅ Automação de `git add` e `git commit` a partir dos caminhos cadastrados no painel de publicação.
-- ✅ Envio automático de `git push` com configuração de upstream direto do painel de publicação.
-- ✅ Serviço auxiliar `npm run teacher:service` expõe API local para executar scripts oficiais e sincronizar relatórios com o painel.
-  - ✅ Histórico de execuções remotas disponível diretamente no painel de validação ao integrar com o `teacher:service`.
-  - ✅ Autenticação por token no serviço auxiliar para permitir exposição controlada além do ambiente local.
+  - ✅ Pacote de publicação em `/professor/publicacao` para planejar branches, commits, validações e gerar resumo de PR.
+  - ✅ Botão "Buscar atualizações da main" sincroniza o workspace via backend antes da rodada de commits.
+  - ✅ Botão "Criar branch automaticamente" prepara a branch de trabalho a partir da `main` diretamente na SPA.
+  - ✅ Automação de `git add` e `git commit` a partir dos caminhos cadastrados no painel de publicação.
+  - ✅ Envio automático de `git push` com configuração de upstream direto do painel de publicação.
+  - ✅ Serviço auxiliar `npm run teacher:service` expõe API local para executar scripts oficiais e sincronizar relatórios com o painel.
+    - ✅ Histórico de execuções remotas disponível diretamente no painel de validação ao integrar com o `teacher:service`.
+    - ✅ Autenticação por token no serviço auxiliar para permitir exposição controlada além do ambiente local.
 
 - **Próximos passos imediatos**
 - 🧩 Automatizar abertura de PRs diretamente pelo painel de publicação.

--- a/docs/professor-module/automation-backend.md
+++ b/docs/professor-module/automation-backend.md
@@ -15,6 +15,7 @@ O serviço exposto pelo script `npm run teacher:service` roda um servidor HTTP e
 - preparar checkout/abertura de branch a partir da `main` para alinhar o fluxo da iteração 5.
 - adicionar arquivos ao staging com `git add` validando caminhos informados na SPA.
 - registrar commits reutilizando a mensagem configurada no painel de publicação.
+- enviar a branch ativa ao remoto com `git push`, configurando upstream quando necessário.
 
 A configuração padrão atende ao desenvolvimento local. Para expor o serviço em ambientes compartilhados, habilite o token descrito abaixo e acompanhe as diretrizes de governança registradas na [iteração 4](./iteration-04.md#próximos-passos--pendências).
 

--- a/docs/professor-module/automation-backend.md
+++ b/docs/professor-module/automation-backend.md
@@ -10,8 +10,13 @@ O serviço exposto pelo script `npm run teacher:service` roda um servidor HTTP e
 - centralizar os logs retornados pelos scripts e informar código de saída, duração e horários;
 - permitir que a SPA baixe os relatórios gerados diretamente do diretório `reports/` sem precisar subir arquivos manualmente.
 - armazenar um histórico leve das execuções disparadas remotamente para consulta na SPA.
+- consultar o status atual do workspace Git (branch, divergências e alterações locais) para orientar o fluxo de publicação.
+- acionar `git fetch` controlado para sincronizar a branch principal antes de gerar commits e PRs.
+- preparar checkout/abertura de branch a partir da `main` para alinhar o fluxo da iteração 5.
+- adicionar arquivos ao staging com `git add` validando caminhos informados na SPA.
+- registrar commits reutilizando a mensagem configurada no painel de publicação.
 
-A configuração padrão atende ao desenvolvimento local. Antes de expor o serviço em ambientes compartilhados, ainda será necessário adicionar autenticação e governança (ver [próximos passos](./iteration-04.md#próximos-passos--pendências)).
+A configuração padrão atende ao desenvolvimento local. Para expor o serviço em ambientes compartilhados, habilite o token descrito abaixo e acompanhe as diretrizes de governança registradas na [iteração 4](./iteration-04.md#próximos-passos--pendências).
 
 ## Como executar
 
@@ -30,8 +35,10 @@ Variáveis de ambiente suportadas:
 | `TEACHER_SERVICE_PORT`          | Porta TCP usada pelo servidor HTTP.                                                  | `4178`      |
 | `TEACHER_SERVICE_HOST`          | Host/interface de escuta. Ajuste para `0.0.0.0` se quiser receber chamadas externas. | `127.0.0.1` |
 | `TEACHER_SERVICE_HISTORY_LIMIT` | Quantidade máxima de execuções armazenadas no histórico local.                       | `50`        |
+| `TEACHER_SERVICE_TOKEN`         | Token obrigatório para autenticar chamadas da SPA.                                   | _(vazio)_   |
 
 Para que a SPA utilize a API é necessário definir `VITE_TEACHER_API_URL` apontando para o endereço exposto pelo serviço. Exemplo: `VITE_TEACHER_API_URL=http://127.0.0.1:4178`.
+Quando o token estiver habilitado, defina também `VITE_TEACHER_API_TOKEN` para que a SPA envie o header `X-Teacher-Token` automaticamente.
 
 ## Endpoints disponíveis
 
@@ -71,6 +78,110 @@ Retorna o histórico das execuções registradas pelo serviço. Aceita filtro op
 
 Cada item inclui os mesmos campos do retorno de execução (`key`, `exitCode`, `output`, `durationMs`, `recordedAt`, `success`, etc.). O arquivo é persistido em `reports/teacher-script-history.json` com limite configurável via `TEACHER_SERVICE_HISTORY_LIMIT`.
 
+### `GET /api/teacher/git/status`
+
+Realiza um `git status --short --branch` no workspace do serviço e retorna um resumo com:
+
+- branch atual e upstream configurado;
+- contagem de commits à frente/atrás do remoto;
+- lista dos arquivos com alterações pendentes (incluindo renomes);
+- saída completa do comando para depuração.
+
+A SPA usa esses dados para preencher o painel de publicação com o estado atual antes de gerar os comandos sugeridos.
+
+### `POST /api/teacher/git/fetch`
+
+Executa um `git fetch` direcionado e retorna o resultado consolidado. O corpo aceita parâmetros opcionais:
+
+```json
+{
+  "remote": "origin",
+  "branch": "main"
+}
+```
+
+- `remote` – nome do remote a ser consultado (padrão `origin`).
+- `branch` – branch remota a ser atualizada (padrão `main`). Informe `null` para executar `git fetch <remote>` sem branch específica.
+
+O retorno inclui `success`, `exitCode`, `stdout`, `stderr`, `command` e, quando o comando conclui com sucesso, o status atualizado do workspace (`status`) já no mesmo formato de `/api/teacher/git/status`.
+
+Na interface de publicação, o botão **Buscar atualizações da main** utiliza este endpoint para sincronizar a `main` antes de seguir com a rodada de commits.
+
+### `POST /api/teacher/git/checkout`
+
+Permite criar ou alternar para uma branch de trabalho controlada pelo serviço. Exemplo de corpo:
+
+```json
+{
+  "branch": "feat/ajustes-aula-calculo",
+  "create": true,
+  "startPoint": "main"
+}
+```
+
+- `branch` – obrigatório. Nome da branch local desejada.
+- `create` – opcional. Quando `true`, executa `git checkout -b` criando a branch a partir do ponto informado.
+- `startPoint` – opcional. Caso omitido em conjunto com `create: true`, o serviço usa `main` como base. Informe `null` para reutilizar o HEAD atual.
+
+O retorno replica o padrão dos demais comandos Git: `success`, `exitCode`, `stdout`, `stderr`, `command` e, quando bem-sucedido, o status atualizado do workspace (`status`). O painel de publicação usa essa rota para gerar a branch informada no formulário sem sair da SPA.
+
+### `POST /api/teacher/git/stage`
+
+Executa `git add` controlado pelo serviço. O corpo aceita:
+
+```json
+{
+  "paths": ["src/content/courses/.../lessons/introducao.json"],
+  "all": false
+}
+```
+
+- `paths` – lista de caminhos a serem adicionados ao staging. O serviço valida se cada entrada aponta para dentro do workspace e remove duplicados.
+- `all` – opcional. Quando `true`, executa `git add --all` ignorando a lista de caminhos.
+
+O retorno segue o padrão de `success`, `exitCode`, `stdout`, `stderr`, `command`, `paths` e `status` (com o `git status` atualizado quando o comando conclui com sucesso). A SPA usa esta rota para replicar o `git add` dos conteúdos listados na rodada diretamente pelo painel.
+
+### `POST /api/teacher/git/commit`
+
+Gera um commit reutilizando a mensagem configurada no painel de publicação. Exemplo de corpo:
+
+```json
+{
+  "message": "feat: atualizar plano de aula de limites",
+  "stagePaths": ["src/content/courses/calculo-1/lessons/limites.json"]
+}
+```
+
+- `message` – obrigatório. O serviço higieniza a mensagem e suporta múltiplos parágrafos separados por linhas em branco.
+- `stagePaths` – opcional. Quando informado, executa `git add -- <paths>` antes do commit, reaproveitando a mesma validação do endpoint anterior.
+- `allowEmpty` – opcional. Quando `true`, repassa `--allow-empty` para permitir commits vazios controlados.
+
+O retorno inclui `success`, `skipped` (indica se o commit foi abortado por falha no `git add`), `exitCode`, `stdout`, `stderr`, `command`, `messageParts`, `stage` (resultado do `git add` quando executado) e `status` com o `git status` após a tentativa. O painel usa esse endpoint para registrar commits sem sair da SPA.
+
+### `POST /api/teacher/git/push`
+
+Envia a branch atual para o remoto configurado.
+
+```json
+{
+  "remote": "origin",
+  "branch": "feat/professor-publicacao",
+  "setUpstream": true
+}
+```
+
+- `remote` – opcional. Padrão `origin`. O serviço higieniza o valor para evitar parâmetros inválidos.
+- `branch` – obrigatório. Nome da branch local que será enviada.
+- `setUpstream` – opcional. Quando `true`, acrescenta `-u` para configurar o upstream durante o primeiro push.
+
+O retorno segue o padrão de `success`, `exitCode`, `stdout`, `stderr`, `command`, `remote`, `branch`, `setUpstream` e `status` (quando o comando conclui com sucesso). O painel marca `setUpstream: true` apenas quando o workspace ainda não possui upstream configurado.
+
+## Autenticação
+
+- Defina `TEACHER_SERVICE_TOKEN` ao iniciar o serviço; requisições aos endpoints `/api/teacher/` passam a exigir o header `X-Teacher-Token` com o mesmo valor.
+- Configure `VITE_TEACHER_API_TOKEN` na SPA para que as chamadas automáticas incluam o token.
+- O endpoint `/health` continua público para diagnósticos locais. Avalie reverse proxy ou VPN caso exponha o serviço externamente.
+
 ## Integração com a SPA
 
 - Quando `VITE_TEACHER_API_URL` está configurada, o painel `/professor/validacao` mostra o botão **Executar via backend** para cada script.
@@ -83,4 +194,6 @@ Cada item inclui os mesmos campos do retorno de execução (`key`, `exitCode`, `
 - Autenticação e autorização antes de expor o serviço além do ambiente local.
 - Auditoria enriquecida com identificação do usuário, branch e artefatos publicados.
 - Suporte a filas de execução e cancelamento seguro.
-- Extensão da API para cobrir operações Git (branches, commits, criação de PRs) alinhadas à [Iteração 5](./iteration-05.md).
+- Evoluir das operações de checkout para automações completas de `git add`, `commit`, `push` e abertura de PR alinhadas à [Iteração 5](./iteration-05.md).
+  - ✅ `git add`, `git commit` e `git push` já expostos na API e integrados ao painel de publicação.
+  - 🚧 Abertura automática de PRs permanece no backlog.

--- a/docs/professor-module/iteration-04.md
+++ b/docs/professor-module/iteration-04.md
@@ -61,6 +61,7 @@
 - [ ] Ensaiar integração com Git (branches temporárias, diffs e PRs) aproveitando as notas registradas no painel.
 - [x] Registrar histórico de execuções no serviço backend e disponibilizar consulta na SPA.
 - [x] Acrescentar autenticação mínima ao serviço backend antes de expô-lo fora do ambiente local.
+- [ ] Evoluir o modelo de autenticação para múltiplos perfis e auditoria detalhada.
 
 ## Referências úteis
 

--- a/docs/professor-module/iteration-04.md
+++ b/docs/professor-module/iteration-04.md
@@ -15,8 +15,10 @@
 - Indicadores automáticos de status (pendente, avisos, falhas) baseados no conteúdo dos logs fornecidos.
 - Upload e leitura dos relatórios `content-validation-report.json`, `content-observability.json` e `governance-alert.json`, exibindo métricas-chave e disciplinas com apontamentos.
 - Serviço backend leve (`npm run teacher:service`) expõe endpoints REST para disparar scripts, sincronizar logs e baixar relatórios direto no painel.
+- Autenticação mínima via header `X-Teacher-Token` exigida pelo serviço auxiliar.
 - Registro de próximos aprimoramentos no painel (execução remota, download automático e integração com o editor visual).
 - Histórico de execuções remotas armazenado em `reports/teacher-script-history.json` e exibido em linha do tempo na SPA.
+- Editor visual bloqueia exportações enquanto houver falhas registradas pelos scripts oficiais.
 
 ### Linha do tempo
 
@@ -26,6 +28,8 @@
 - **2024-07-06** — Publicação da documentação da iteração e ajuste do roadmap destacando próximos passos para backend e Git.
 - **2024-07-11** — Serviço backend disponível; painel passa a executar scripts remotamente e baixar relatórios sem upload manual.
 - **2024-07-13** — Histórico das execuções remotas passa a ser armazenado e listado diretamente no painel.
+- **2024-07-14** — Token de autenticação habilitado no serviço backend para permitir chamadas autenticadas via SPA.
+- **2024-07-15** — Editor visual sincroniza alertas do painel e bloqueia exportações com falhas críticas registradas.
 
 ## Fluxo sugerido
 
@@ -47,16 +51,16 @@
 - ✅ Centralização dos logs e notas reduziu perdas de contexto entre execuções consecutivas dos scripts.
 - ✅ Upload dos relatórios evitou abrir múltiplos arquivos JSON/MD ao validar cursos com avisos.
 - ⚠️ A detecção de avisos/erros ainda depende de heurísticas locais; integração com backend deverá fornecer status mais preciso.
-- ⚠️ O serviço backend ainda roda apenas em ambiente local e não possui autenticação ou segregação de permissões.
+- ⚠️ O serviço backend segue orientado a ambiente local; o token único ainda precisa evoluir para múltiplos usuários e perfis de permissão.
 
 ## Próximos passos / pendências
 
 - [x] Implementar serviço backend que execute os scripts e retorne logs estruturados para o painel.
 - [x] Disponibilizar download direto dos relatórios mais recentes sem necessidade de upload manual.
-- [ ] Integrar alertas do painel com o editor visual, bloqueando exportações com erros críticos.
+- [x] Integrar alertas do painel com o editor visual, bloqueando exportações com erros críticos.
 - [ ] Ensaiar integração com Git (branches temporárias, diffs e PRs) aproveitando as notas registradas no painel.
 - [x] Registrar histórico de execuções no serviço backend e disponibilizar consulta na SPA.
-- [ ] Acrescentar autenticação mínima ao serviço backend antes de expô-lo fora do ambiente local.
+- [x] Acrescentar autenticação mínima ao serviço backend antes de expô-lo fora do ambiente local.
 
 ## Referências úteis
 

--- a/docs/professor-module/iteration-05.md
+++ b/docs/professor-module/iteration-05.md
@@ -57,6 +57,7 @@
 
 ## Próximos passos / pendências
 
+- [x] Implementar backend auxiliar que execute `git status`, `fetch`, `checkout`, `add`, `commit` e `push` diretamente a partir da SPA.
 - [ ] Evoluir o backend auxiliar para preparar PRs completos reutilizando a branch criada automaticamente.
 - [ ] Registrar no painel os diffs gerados para facilitar a revisão visual antes do commit.
 - [ ] Adicionar integração com serviços de PR (ex.: GitHub) para preencher título e corpo automaticamente via API.

--- a/docs/professor-module/iteration-05.md
+++ b/docs/professor-module/iteration-05.md
@@ -16,6 +16,11 @@
 - Template de PR com título sugerido, resumo e checklist alinhados aos scripts marcados como obrigatórios.
 - Checklist final destacando governança (proveniência, revisão cruzada, anexos de relatórios).
 - Integração com o serviço backend permite marcar scripts obrigatórios e executar validações diretamente pelo painel.
+- Cartão de publicação consulta o backend para exibir branch, divergência e arquivos pendentes via `git status` em tempo real.
+- Botão **Buscar atualizações da main** aciona `git fetch` via backend e já devolve o status atualizado do workspace.
+- Botão **Criar branch automaticamente** usa o backend para abrir a branch de trabalho a partir da `main` sem sair da SPA.
+- Automação de `git add` e `git commit` reaproveitando os caminhos cadastrados e a mensagem configurada no painel.
+- Botão **Enviar branch com git push** usa o backend para configurar o upstream e publicar a branch direto da SPA.
 
 ### Linha do tempo
 
@@ -23,6 +28,9 @@
 - **2024-07-08** — Protótipo de formulário para branch/commit e experimentos com geração de comandos.
 - **2024-07-09** — Inclusão da lista de conteúdos + resumo automático para descrição do PR.
 - **2024-07-10** — Integração com dashboard, navegação e documentação viva destacando a nova iteração.
+- **2024-07-12** — Checkout automatizado integrado ao painel de publicação após validar fluxos de token/autenticação.
+- **2024-07-13** — Automação de staging e commit integrada ao serviço auxiliar e ao painel de publicação.
+- **2024-07-14** — `git push` automatizado com detecção de upstream e feedback no painel de publicação.
 
 ## Fluxo sugerido
 
@@ -43,12 +51,13 @@
 
 - ✅ Ter o checklist de validações e comandos num único lugar facilita orientar novos professores no fluxo de publicação.
 - ✅ O resumo automático do PR reduz divergências no momento de revisar os arquivos alterados.
+- ✅ Sincronizar a `main` pela própria SPA ajuda a lembrar de atualizar o workspace antes de gerar commits.
 - ⚠️ Ainda é necessário copiar manualmente os comandos de Git; próximo passo é expor automações no backend.
 - ⚠️ Precisamos sincronizar seções de validação e publicação com o status retornado pelo serviço para bloquear envios incompletos.
 
 ## Próximos passos / pendências
 
-- [ ] Implementar backend auxiliar que execute comandos Git e scripts diretamente a partir da SPA.
+- [ ] Evoluir o backend auxiliar para preparar PRs completos reutilizando a branch criada automaticamente.
 - [ ] Registrar no painel os diffs gerados para facilitar a revisão visual antes do commit.
 - [ ] Adicionar integração com serviços de PR (ex.: GitHub) para preencher título e corpo automaticamente via API.
 - [ ] Expandir checklist para cobrir publicação de múltiplas branches/PRs em paralelo.

--- a/docs/professor-module/status-overview.md
+++ b/docs/professor-module/status-overview.md
@@ -10,10 +10,9 @@ Este resumo rápido compila o estado atual das entregas documentadas no plano in
 - Exportação do editor condicionada aos scripts oficiais registrados no painel de validações.
 - Painel `/professor/validacao` para consolidar execuções, notas e relatórios oficiais.
 - Pacote `/professor/publicacao` com checklist de validações, status Git em tempo real, geração de comandos e preparo de resumo de PR.
-- Botão "Buscar atualizações da main" no painel de publicação sincroniza o workspace via `git fetch` controlado.
-- Botão "Criar branch automaticamente" usa o backend para preparar a branch de trabalho diretamente da SPA.
-- Painel executa `git add` e `git commit` automaticamente com base nos conteúdos listados na rodada.
-- Painel envia a branch ativa com `git push`, configurando o upstream na primeira execução quando necessário.
+  - Botão "Buscar atualizações da main" sincroniza o workspace via `git fetch` controlado.
+  - Botão "Criar branch automaticamente" usa o backend para preparar a branch de trabalho diretamente da SPA.
+  - Painel executa `git add`, `git commit` e `git push` com feedback reaproveitando a API auxiliar.
 - Serviço auxiliar `npm run teacher:service` para disparo de scripts e sincronização de relatórios diretamente da SPA.
 
 ## O que falta fazer

--- a/docs/professor-module/status-overview.md
+++ b/docs/professor-module/status-overview.md
@@ -7,14 +7,19 @@ Este resumo rápido compila o estado atual das entregas documentadas no plano in
 - Rota protegida `/professor` com dashboard e navegação dedicados.
 - Workbench de ingestão `/professor/ingestao` com validação client-side e checklist operacional.
 - Editor visual `/professor/editor` com suporte aos blocos principais e validação inline.
+- Exportação do editor condicionada aos scripts oficiais registrados no painel de validações.
 - Painel `/professor/validacao` para consolidar execuções, notas e relatórios oficiais.
-- Pacote `/professor/publicacao` com checklist de validações, geração de comandos Git e preparo de resumo de PR.
+- Pacote `/professor/publicacao` com checklist de validações, status Git em tempo real, geração de comandos e preparo de resumo de PR.
+- Botão "Buscar atualizações da main" no painel de publicação sincroniza o workspace via `git fetch` controlado.
+- Botão "Criar branch automaticamente" usa o backend para preparar a branch de trabalho diretamente da SPA.
+- Painel executa `git add` e `git commit` automaticamente com base nos conteúdos listados na rodada.
+- Painel envia a branch ativa com `git push`, configurando o upstream na primeira execução quando necessário.
 - Serviço auxiliar `npm run teacher:service` para disparo de scripts e sincronização de relatórios diretamente da SPA.
 
 ## O que falta fazer
 
-- Evoluir o serviço backend para guardar histórico, autenticar usuários e suportar filas de execução.
-- Automatizar criação de branches, commits e PRs a partir do pacote de publicação na SPA.
+- Evoluir o serviço backend para oferecer autorização multiusuário, filas de execução e auditoria detalhada.
+- Automatizar abertura de PRs a partir do pacote de publicação na SPA.
 - Definir política de permissões, auditoria e governança para expor a API em ambientes compartilhados.
 - Ampliar o editor visual para cobrir blocos avançados e oferecer pré-visualização renderizada.
 - Consolidar suíte de testes (unitários e e2e) cobrindo ingestão, edição, validação e publicação.

--- a/src/components/TeacherModeGate.vue
+++ b/src/components/TeacherModeGate.vue
@@ -12,14 +12,9 @@
               {{ description }}
             </p>
           </header>
-          <Md3Button
-            class="w-full md:w-auto"
-            variant="filled"
-            type="button"
-            @click="enableTeacherMode"
-          >
+          <button class="btn btn-filled w-full md:w-auto" type="button" @click="enableTeacherMode">
             {{ ctaLabel }}
-          </Md3Button>
+          </button>
           <p class="md-typescale-body-small text-on-surface-variant">
             Também é possível ativar adicionando <code>?teacher=1</code> à URL ou pelo atalho
             <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>P</kbd>.
@@ -33,7 +28,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useTeacherMode } from '../composables/useTeacherMode';
-import Md3Button from './Md3Button.vue';
 
 withDefaults(
   defineProps<{

--- a/src/components/TeacherModeGate.vue
+++ b/src/components/TeacherModeGate.vue
@@ -12,9 +12,14 @@
               {{ description }}
             </p>
           </header>
-          <button class="btn btn-filled w-full md:w-auto" type="button" @click="enableTeacherMode">
+          <Md3Button
+            class="w-full md:w-auto"
+            variant="filled"
+            type="button"
+            @click="enableTeacherMode"
+          >
             {{ ctaLabel }}
-          </button>
+          </Md3Button>
           <p class="md-typescale-body-small text-on-surface-variant">
             Também é possível ativar adicionando <code>?teacher=1</code> à URL ou pelo atalho
             <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>P</kbd>.
@@ -28,6 +33,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useTeacherMode } from '../composables/useTeacherMode';
+import Md3Button from './Md3Button.vue';
 
 withDefaults(
   defineProps<{

--- a/src/pages/professor/EditorWorkbench.vue
+++ b/src/pages/professor/EditorWorkbench.vue
@@ -51,11 +51,13 @@
             </label>
 
             <div class="flex flex-wrap gap-3">
-              <button type="button" class="btn btn-tonal" :disabled="!rawInput" @click="formatRaw">
+              <Md3Button type="button" variant="tonal" :disabled="!rawInput" @click="formatRaw">
                 Formatar JSON
-              </button>
-              <label class="btn btn-outlined inline-flex cursor-pointer items-center gap-2">
-                <UploadCloud class="md-icon md-icon--sm" aria-hidden="true" />
+              </Md3Button>
+              <Md3Button variant="outlined" :as="'label'" class="cursor-pointer">
+                <template #leading>
+                  <UploadCloud class="md-icon md-icon--sm" aria-hidden="true" />
+                </template>
                 <span>Importar arquivo</span>
                 <input
                   id="editor-file-input"
@@ -64,15 +66,15 @@
                   class="sr-only"
                   @change="handleFileInput"
                 />
-              </label>
-              <button
+              </Md3Button>
+              <Md3Button
                 type="button"
-                class="btn btn-filled"
+                variant="filled"
                 :disabled="!rawInput"
                 @click="loadForEditing"
               >
                 Carregar no editor
-              </button>
+              </Md3Button>
             </div>
             <p v-if="lastFileName" class="text-sm text-on-surface-variant">
               Último arquivo carregado: <strong>{{ lastFileName }}</strong>
@@ -358,23 +360,25 @@
           class="rounded-3xl border border-outline bg-surface-container-high p-4 font-mono text-sm text-on-surface"
         ></textarea>
         <div class="flex flex-wrap gap-3">
-          <button
+          <Md3Button
             type="button"
-            class="btn btn-filled inline-flex items-center gap-2"
+            variant="filled"
             :disabled="!exportAvailable"
             @click="copyFormatted"
           >
-            <ClipboardCopy class="md-icon md-icon--sm" aria-hidden="true" />
+            <template #leading>
+              <ClipboardCopy class="md-icon md-icon--sm" aria-hidden="true" />
+            </template>
             <span>{{ copyLabel }}</span>
-          </button>
-          <button
+          </Md3Button>
+          <Md3Button
             type="button"
-            class="btn btn-tonal"
+            variant="tonal"
             :disabled="!exportAvailable"
             @click="downloadJson"
           >
             Baixar arquivo
-          </button>
+          </Md3Button>
         </div>
       </section>
     </TeacherModeGate>
@@ -403,6 +407,7 @@ import {
 } from './utils/validationStatus';
 import { validationScriptsList } from './utils/validationScripts';
 import TeacherModeGate from '../../components/TeacherModeGate.vue';
+import Md3Button from '@/components/Md3Button.vue';
 
 interface LessonPlanCard {
   icon?: string;

--- a/src/pages/professor/PublicationWorkbench.vue
+++ b/src/pages/professor/PublicationWorkbench.vue
@@ -29,6 +29,168 @@
       <section class="card flex flex-col gap-6 p-6 md:p-8">
         <header class="flex flex-col gap-2">
           <h2 class="md-typescale-title-large font-semibold text-on-surface">
+            Status do workspace Git
+          </h2>
+          <p class="supporting-text text-on-surface-variant">
+            Acompanhe a branch atual, divergências e arquivos pendentes antes de iniciar a rodada.
+          </p>
+        </header>
+
+        <div
+          class="rounded-3xl border border-outline-variant bg-[var(--md-sys-color-surface-container-highest)] p-5"
+        >
+          <template v-if="!teacherAutomationEnabled">
+            <p class="md-typescale-body-medium text-on-surface">
+              Configure <code>VITE_TEACHER_API_URL</code> e <code>VITE_TEACHER_API_TOKEN</code> para
+              consultar o serviço auxiliar. O painel exibirá o status do Git automaticamente quando
+              estiver ativo.
+            </p>
+          </template>
+          <template v-else>
+            <div class="flex flex-col gap-4">
+              <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div class="flex flex-col gap-1">
+                  <p
+                    class="md-typescale-body-large font-semibold text-on-surface"
+                    aria-live="polite"
+                  >
+                    {{ gitBranchSummary }}
+                  </p>
+                  <p v-if="gitUpstreamSummary" class="text-sm text-on-surface-variant">
+                    {{ gitUpstreamSummary }}
+                  </p>
+                  <p v-if="gitDivergenceSummary" class="text-sm text-on-surface-variant">
+                    {{ gitDivergenceSummary }}
+                  </p>
+                </div>
+                <div class="flex flex-wrap gap-2 self-start md:self-auto">
+                  <button
+                    type="button"
+                    class="btn btn-text inline-flex items-center gap-2"
+                    :disabled="gitStatusLoading"
+                    @click="refreshGitStatus"
+                  >
+                    <RefreshCcw class="md-icon md-icon--sm" aria-hidden="true" />
+                    {{ gitStatusLoading ? 'Atualizando…' : 'Atualizar status' }}
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-tonal inline-flex items-center gap-2"
+                    :disabled="gitFetchLoading"
+                    @click="verifyMainUpdates"
+                  >
+                    <Download class="md-icon md-icon--sm" aria-hidden="true" />
+                    {{ gitFetchLoading ? 'Verificando main…' : 'Buscar atualizações da main' }}
+                  </button>
+                </div>
+              </div>
+
+              <div
+                v-if="gitFetchError"
+                class="flex flex-col gap-3 rounded-2xl bg-error-container p-4 text-on-error-container"
+              >
+                <div class="flex items-start gap-3">
+                  <AlertCircle class="md-icon md-icon--sm" aria-hidden="true" />
+                  <div class="flex flex-col gap-1">
+                    <p class="text-sm font-medium">{{ gitFetchError }}</p>
+                    <p v-if="gitFetchResult" class="text-xs">
+                      Comando executado:
+                      <code class="font-mono">{{ gitFetchResult.command }}</code>
+                    </p>
+                  </div>
+                </div>
+                <pre
+                  v-if="gitFetchOutput"
+                  class="rounded-2xl bg-surface p-3 font-mono text-xs text-on-surface shadow-inner"
+                  aria-live="polite"
+                  >{{ gitFetchOutput }}
+                </pre>
+              </div>
+
+              <div
+                v-else-if="gitFetchResult"
+                class="flex flex-col gap-3 rounded-2xl bg-success-container p-4 text-on-success-container"
+              >
+                <div class="flex items-start gap-3">
+                  <CheckCircle2 class="md-icon md-icon--sm" aria-hidden="true" />
+                  <div class="flex flex-col gap-1">
+                    <p class="text-sm font-medium">{{ gitFetchSuccessMessage }}</p>
+                    <p class="text-xs">
+                      Comando executado:
+                      <code class="font-mono">{{ gitFetchResult.command }}</code>
+                    </p>
+                  </div>
+                </div>
+                <pre
+                  v-if="gitFetchOutput"
+                  class="rounded-2xl bg-surface p-3 font-mono text-xs text-on-surface shadow-inner"
+                  aria-live="polite"
+                  >{{ gitFetchOutput }}
+                </pre>
+              </div>
+
+              <div
+                v-if="gitStatusError"
+                class="flex items-start gap-3 rounded-2xl bg-error-container p-4"
+              >
+                <AlertCircle
+                  class="md-icon md-icon--sm text-on-error-container"
+                  aria-hidden="true"
+                />
+                <p class="text-sm text-on-error-container">{{ gitStatusError }}</p>
+              </div>
+
+              <p v-else-if="gitStatusLoading" class="text-sm text-on-surface-variant">
+                Consultando Git…
+              </p>
+
+              <template v-else-if="gitStatus">
+                <p v-if="gitStatus.clean" class="text-sm text-on-surface">
+                  Nenhuma alteração pendente no workspace. Você pode seguir para a configuração da
+                  rodada.
+                </p>
+
+                <div v-else class="flex flex-col gap-3">
+                  <p class="text-sm text-on-surface">Arquivos com alterações pendentes:</p>
+                  <ul class="grid gap-2 text-sm text-on-surface">
+                    <li
+                      v-for="change in gitStatus.changes"
+                      :key="`${change.status}-${change.path}`"
+                      class="flex flex-col rounded-2xl border border-outline bg-surface p-3"
+                    >
+                      <span
+                        class="font-mono text-xs uppercase tracking-wide text-on-surface-variant"
+                      >
+                        {{ change.status }}
+                      </span>
+                      <span class="font-medium text-on-surface">{{ change.path }}</span>
+                      <span v-if="change.renamedFrom" class="text-xs text-on-surface-variant">
+                        Renomeado de {{ change.renamedFrom }}
+                      </span>
+                    </li>
+                  </ul>
+                </div>
+
+                <details
+                  class="rounded-2xl border border-outline-variant bg-surface p-4 text-sm text-on-surface"
+                >
+                  <summary class="cursor-pointer font-medium text-on-surface">
+                    Saída completa do git status
+                  </summary>
+                  <pre
+                    class="mt-3 whitespace-pre-wrap break-all font-mono text-xs text-on-surface-variant"
+                    >{{ gitStatus.raw }}
+                  </pre>
+                </details>
+              </template>
+            </div>
+          </template>
+        </div>
+      </section>
+
+      <section class="card flex flex-col gap-6 p-6 md:p-8">
+        <header class="flex flex-col gap-2">
+          <h2 class="md-typescale-title-large font-semibold text-on-surface">
             Configurar branch e resumo da rodada
           </h2>
           <p class="supporting-text text-on-surface-variant">
@@ -63,6 +225,291 @@
               Resuma a alteração principal no formato convencional de mensagens de commit.
             </span>
           </label>
+        </div>
+
+        <div
+          v-if="teacherAutomationEnabled"
+          class="flex flex-col gap-4 rounded-3xl border border-outline-variant bg-[var(--md-sys-color-surface-container-high)] p-5"
+        >
+          <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <p class="text-sm text-on-surface">
+              Peça para o serviço auxiliar criar ou alternar automaticamente para a branch informada
+              a partir da <code>main</code> atualizada.
+            </p>
+            <button
+              type="button"
+              class="btn btn-filled inline-flex items-center gap-2 self-start md:self-auto"
+              :disabled="gitCheckoutLoading"
+              @click="createWorkingBranch"
+            >
+              <GitBranch class="md-icon md-icon--sm" aria-hidden="true" />
+              {{ gitCheckoutLoading ? 'Criando branch…' : 'Criar branch automaticamente' }}
+            </button>
+          </div>
+
+          <div
+            v-if="gitCheckoutError"
+            class="flex flex-col gap-3 rounded-2xl bg-error-container p-4 text-on-error-container"
+          >
+            <div class="flex items-start gap-3">
+              <AlertCircle class="md-icon md-icon--sm" aria-hidden="true" />
+              <div class="flex flex-col gap-1">
+                <p class="text-sm font-medium">{{ gitCheckoutError }}</p>
+                <p v-if="gitCheckoutResult" class="text-xs">
+                  Comando executado:
+                  <code class="font-mono">{{ gitCheckoutResult.command }}</code>
+                </p>
+              </div>
+            </div>
+            <pre
+              v-if="gitCheckoutOutput"
+              class="rounded-2xl bg-surface p-3 font-mono text-xs text-on-surface shadow-inner"
+              aria-live="polite"
+              >{{ gitCheckoutOutput }}
+            </pre>
+          </div>
+
+          <div
+            v-else-if="gitCheckoutResult"
+            class="flex flex-col gap-3 rounded-2xl bg-success-container p-4 text-on-success-container"
+          >
+            <div class="flex items-start gap-3">
+              <CheckCircle2 class="md-icon md-icon--sm" aria-hidden="true" />
+              <div class="flex flex-col gap-1">
+                <p class="text-sm font-medium">{{ gitCheckoutSuccessMessage }}</p>
+                <p class="text-xs">
+                  Comando executado:
+                  <code class="font-mono">{{ gitCheckoutResult.command }}</code>
+                </p>
+              </div>
+            </div>
+            <pre
+              v-if="gitCheckoutOutput"
+              class="rounded-2xl bg-surface p-3 font-mono text-xs text-on-surface shadow-inner"
+              aria-live="polite"
+              >{{ gitCheckoutOutput }}
+            </pre>
+          </div>
+
+          <p class="text-xs text-on-surface-variant">
+            O serviço executa <code>git checkout -b {{ sanitizedBranch }}</code> usando a
+            <code>main</code> como ponto de partida. Ajuste manualmente se precisar de outra base.
+          </p>
+        </div>
+        <p
+          v-else
+          class="rounded-3xl border border-outline-variant bg-[var(--md-sys-color-surface-container-high)] p-4 text-sm text-on-surface-variant"
+        >
+          Configure <code>VITE_TEACHER_API_URL</code> para criar a branch automaticamente pelo
+          painel ou siga os comandos sugeridos abaixo.
+        </p>
+
+        <div
+          v-if="teacherAutomationEnabled"
+          class="flex flex-col gap-4 rounded-3xl border border-outline-variant bg-[var(--md-sys-color-surface-container-high)] p-5"
+        >
+          <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div class="flex flex-col gap-2">
+              <p class="text-sm text-on-surface">
+                Use os caminhos listados na seção de conteúdos para enviar os arquivos ao staging e
+                gerar o commit automaticamente.
+              </p>
+              <p class="text-xs text-on-surface-variant">
+                O serviço executa <code>git add</code> com os caminhos preenchidos e reutiliza o
+                título de commit configurado acima.
+              </p>
+            </div>
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <button
+                type="button"
+                class="btn btn-tonal inline-flex items-center gap-2"
+                :disabled="gitStageLoading || artifactPaths.length === 0"
+                @click="stageCurrentArtifacts"
+              >
+                {{ gitStageLoading ? 'Adicionando…' : 'Adicionar com git add' }}
+              </button>
+              <button
+                type="button"
+                class="btn btn-filled inline-flex items-center gap-2"
+                :disabled="gitCommitLoading"
+                @click="commitCurrentArtifacts"
+              >
+                {{ gitCommitLoading ? 'Registrando commit…' : 'Gerar commit agora' }}
+              </button>
+              <button
+                type="button"
+                class="btn btn-filled inline-flex items-center gap-2"
+                :disabled="gitPushLoading || !canPushAutomatically"
+                @click="pushCurrentBranch"
+              >
+                <UploadCloud class="md-icon md-icon--sm" aria-hidden="true" />
+                {{ gitPushLoading ? 'Enviando branch…' : 'Enviar branch com git push' }}
+              </button>
+            </div>
+          </div>
+
+          <div class="rounded-2xl border border-outline bg-surface p-4 text-sm text-on-surface">
+            <p class="font-medium">Caminhos enviados para o git add automático:</p>
+            <ul v-if="artifactPaths.length > 0" class="mt-2 grid gap-2">
+              <li
+                v-for="path in artifactPaths"
+                :key="path"
+                class="rounded-xl bg-[var(--md-sys-color-surface-container-highest)] px-3 py-2 font-mono text-xs text-on-surface"
+              >
+                {{ path }}
+              </li>
+            </ul>
+            <p v-else class="mt-2 text-xs text-on-surface-variant">
+              Preencha a seção “Conteúdos incluídos nesta rodada” para habilitar o git add
+              automático.
+            </p>
+          </div>
+
+          <div
+            v-if="gitStageError"
+            class="flex flex-col gap-3 rounded-2xl bg-error-container p-4 text-on-error-container"
+          >
+            <div class="flex items-start gap-3">
+              <AlertCircle class="md-icon md-icon--sm" aria-hidden="true" />
+              <div class="flex flex-col gap-1">
+                <p class="text-sm font-medium">{{ gitStageError }}</p>
+                <p v-if="gitStageResult" class="text-xs">
+                  Comando executado:
+                  <code class="font-mono">{{ gitStageResult.command }}</code>
+                </p>
+              </div>
+            </div>
+            <pre
+              v-if="gitStageOutput"
+              class="rounded-2xl bg-surface p-3 font-mono text-xs text-on-surface shadow-inner"
+              aria-live="polite"
+              >{{ gitStageOutput }}
+            </pre>
+          </div>
+          <div
+            v-else-if="gitStageResult"
+            class="flex flex-col gap-3 rounded-2xl bg-success-container p-4 text-on-success-container"
+          >
+            <div class="flex items-start gap-3">
+              <CheckCircle2 class="md-icon md-icon--sm" aria-hidden="true" />
+              <div class="flex flex-col gap-1">
+                <p class="text-sm font-medium">{{ gitStageSuccessMessage }}</p>
+                <p class="text-xs">
+                  Comando executado:
+                  <code class="font-mono">{{ gitStageResult.command }}</code>
+                </p>
+              </div>
+            </div>
+            <pre
+              v-if="gitStageOutput"
+              class="rounded-2xl bg-surface p-3 font-mono text-xs text-on-surface shadow-inner"
+              aria-live="polite"
+              >{{ gitStageOutput }}
+            </pre>
+          </div>
+
+          <div
+            v-if="gitCommitError"
+            class="flex flex-col gap-3 rounded-2xl bg-error-container p-4 text-on-error-container"
+          >
+            <div class="flex items-start gap-3">
+              <AlertCircle class="md-icon md-icon--sm" aria-hidden="true" />
+              <div class="flex flex-col gap-1">
+                <p class="text-sm font-medium">{{ gitCommitError }}</p>
+                <p class="text-xs">
+                  Comando executado:
+                  <code class="font-mono">{{
+                    gitCommitResult?.command ?? `git commit -m "${sanitizedCommitTitle}"`
+                  }}</code>
+                </p>
+                <p v-if="gitCommitSkippedMessage" class="text-xs">{{ gitCommitSkippedMessage }}</p>
+                <p v-if="gitCommitResult?.stage && !gitCommitResult.stage.success" class="text-xs">
+                  git add executado com:
+                  <code class="font-mono">{{ gitCommitResult.stage.command }}</code>
+                </p>
+              </div>
+            </div>
+            <pre
+              v-if="gitCommitOutput"
+              class="rounded-2xl bg-surface p-3 font-mono text-xs text-on-surface shadow-inner"
+              aria-live="polite"
+              >{{ gitCommitOutput }}
+            </pre>
+          </div>
+          <div
+            v-else-if="gitCommitResult"
+            class="flex flex-col gap-3 rounded-2xl bg-success-container p-4 text-on-success-container"
+          >
+            <div class="flex items-start gap-3">
+              <CheckCircle2 class="md-icon md-icon--sm" aria-hidden="true" />
+              <div class="flex flex-col gap-1">
+                <p class="text-sm font-medium">{{ gitCommitSuccessMessage }}</p>
+                <p class="text-xs">
+                  Comando executado:
+                  <code class="font-mono">{{ gitCommitResult.command }}</code>
+                </p>
+              </div>
+            </div>
+            <pre
+              v-if="gitCommitOutput"
+              class="rounded-2xl bg-surface p-3 font-mono text-xs text-on-surface shadow-inner"
+              aria-live="polite"
+              >{{ gitCommitOutput }}
+            </pre>
+          </div>
+
+          <div
+            v-if="gitPushError"
+            class="flex flex-col gap-3 rounded-2xl bg-error-container p-4 text-on-error-container"
+          >
+            <div class="flex items-start gap-3">
+              <AlertCircle class="md-icon md-icon--sm" aria-hidden="true" />
+              <div class="flex flex-col gap-1">
+                <p class="text-sm font-medium">{{ gitPushError }}</p>
+                <p v-if="gitPushResult" class="text-xs">
+                  Comando executado:
+                  <code class="font-mono">{{ gitPushResult.command }}</code>
+                </p>
+              </div>
+            </div>
+            <pre
+              v-if="gitPushOutput"
+              class="rounded-2xl bg-surface p-3 font-mono text-xs text-on-surface shadow-inner"
+              aria-live="polite"
+              >{{ gitPushOutput }}
+            </pre>
+          </div>
+          <div
+            v-else-if="gitPushResult"
+            class="flex flex-col gap-3 rounded-2xl bg-success-container p-4 text-on-success-container"
+          >
+            <div class="flex items-start gap-3">
+              <CheckCircle2 class="md-icon md-icon--sm" aria-hidden="true" />
+              <div class="flex flex-col gap-1">
+                <p class="text-sm font-medium">{{ gitPushSuccessMessage }}</p>
+                <p class="text-xs">
+                  Comando executado:
+                  <code class="font-mono">{{ gitPushResult.command }}</code>
+                </p>
+              </div>
+            </div>
+            <pre
+              v-if="gitPushOutput"
+              class="rounded-2xl bg-surface p-3 font-mono text-xs text-on-surface shadow-inner"
+              aria-live="polite"
+              >{{ gitPushOutput }}
+            </pre>
+          </div>
+
+          <p class="text-xs text-on-surface-variant">
+            O serviço executa <code>{{ gitPushCommandPreview }}</code
+            >. {{ gitPushBehaviorHint }}
+          </p>
+
+          <p class="text-xs text-on-surface-variant">
+            Revise o diff local após executar o commit automático e antes de enviar a branch para o
+            repositório remoto.
+          </p>
         </div>
 
         <label class="flex flex-col gap-2">
@@ -256,10 +703,36 @@ $ {{ gitCommands.join('\n$ ') }}
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, ref } from 'vue';
-import { Copy, Plus, Trash2 } from 'lucide-vue-next';
+import { computed, onMounted, reactive, ref } from 'vue';
+import {
+  AlertCircle,
+  CheckCircle2,
+  Copy,
+  Download,
+  GitBranch,
+  Plus,
+  RefreshCcw,
+  Trash2,
+  UploadCloud,
+} from 'lucide-vue-next';
 import TeacherModeGate from '../../components/TeacherModeGate.vue';
 import Md3Button from '@/components/Md3Button.vue';
+import {
+  TeacherAutomationError,
+  checkoutTeacherGitBranch,
+  commitTeacherGitChanges,
+  fetchTeacherGitStatus,
+  fetchTeacherGitUpdates,
+  pushTeacherGitBranch,
+  stageTeacherGitPaths,
+  teacherAutomationEnabled,
+  type TeacherGitCheckoutResult,
+  type TeacherGitCommitResult,
+  type TeacherGitFetchResult,
+  type TeacherGitPushResult,
+  type TeacherGitStageResult,
+  type TeacherGitStatus,
+} from './utils/automation';
 
 type ArtifactType = 'lesson' | 'exercise' | 'supplement' | 'component' | 'assessment' | 'other';
 
@@ -282,6 +755,489 @@ const branchName = ref('');
 const commitTitle = ref('');
 const prDescription = ref('');
 const copyLabel = ref('Copiar comandos');
+
+const gitStatus = ref<TeacherGitStatus | null>(null);
+const gitStatusError = ref<string | null>(null);
+const gitStatusLoading = ref(false);
+const gitFetchResult = ref<TeacherGitFetchResult | null>(null);
+const gitFetchError = ref<string | null>(null);
+const gitFetchLoading = ref(false);
+const gitCheckoutResult = ref<TeacherGitCheckoutResult | null>(null);
+const gitCheckoutError = ref<string | null>(null);
+const gitCheckoutLoading = ref(false);
+const gitStageResult = ref<TeacherGitStageResult | null>(null);
+const gitStageError = ref<string | null>(null);
+const gitStageLoading = ref(false);
+const gitCommitResult = ref<TeacherGitCommitResult | null>(null);
+const gitCommitError = ref<string | null>(null);
+const gitCommitLoading = ref(false);
+const gitPushResult = ref<TeacherGitPushResult | null>(null);
+const gitPushError = ref<string | null>(null);
+const gitPushLoading = ref(false);
+
+const gitBranchSummary = computed(() => {
+  if (!gitStatus.value) {
+    return 'Workspace não consultado ainda';
+  }
+  if (gitStatus.value.detached) {
+    return gitStatus.value.branch ?? 'HEAD destacado';
+  }
+  return gitStatus.value.branch
+    ? `Branch atual: ${gitStatus.value.branch}`
+    : 'Branch atual não identificada';
+});
+
+const gitUpstreamSummary = computed(() => {
+  if (!gitStatus.value?.upstream) {
+    return '';
+  }
+  return `Upstream configurado: ${gitStatus.value.upstream}`;
+});
+
+const gitDivergenceSummary = computed(() => {
+  if (!gitStatus.value) {
+    return '';
+  }
+  const { ahead, behind } = gitStatus.value;
+  if (!ahead && !behind) {
+    return 'Workspace alinhado com o upstream configurado.';
+  }
+  if (ahead && behind) {
+    return `Divergência: ${ahead} commit(s) à frente e ${behind} atrás.`;
+  }
+  if (ahead) {
+    return `Divergência: ${ahead} commit(s) à frente do upstream.`;
+  }
+  return `Divergência: ${behind} commit(s) atrás do upstream.`;
+});
+
+const gitFetchOutput = computed(() => {
+  if (!gitFetchResult.value) {
+    return '';
+  }
+
+  const parts = [gitFetchResult.value.stdout, gitFetchResult.value.stderr]
+    .map((chunk) => (chunk ?? '').trim())
+    .filter((part) => part.length > 0);
+
+  return parts.join('\n\n');
+});
+
+const gitFetchSuccessMessage = computed(() => {
+  if (!gitFetchResult.value?.success) {
+    return '';
+  }
+
+  const status = gitFetchResult.value.status;
+  if (!status) {
+    return 'Fetch executado com sucesso. Consulte o status para confirmar divergências.';
+  }
+
+  if (status.behind > 0) {
+    return `Fetch concluído. Workspace ainda ${status.behind} commit(s) atrás do upstream.`;
+  }
+
+  if (status.ahead > 0) {
+    return `Fetch concluído. Workspace ${status.ahead} commit(s) à frente do upstream.`;
+  }
+
+  return 'Fetch executado com sucesso. Workspace alinhado com o upstream configurado.';
+});
+
+const gitCheckoutOutput = computed(() => {
+  if (!gitCheckoutResult.value) {
+    return '';
+  }
+
+  const stdout = gitCheckoutResult.value.stdout?.trim?.() ?? '';
+  const stderr = gitCheckoutResult.value.stderr?.trim?.() ?? '';
+  return [stdout, stderr].filter(Boolean).join('\n');
+});
+
+const gitCheckoutSuccessMessage = computed(() => {
+  if (!gitCheckoutResult.value?.success) {
+    return '';
+  }
+
+  const branch = gitCheckoutResult.value.branch;
+  const startPoint = gitCheckoutResult.value.startPoint ?? 'HEAD atual';
+
+  if (gitCheckoutResult.value.create) {
+    return `Branch ${branch} criada a partir de ${startPoint}.`;
+  }
+
+  return `Checkout para ${branch} concluído.`;
+});
+
+const gitStageOutput = computed(() => {
+  if (!gitStageResult.value) {
+    return '';
+  }
+
+  const stdout = gitStageResult.value.stdout?.trim?.() ?? '';
+  const stderr = gitStageResult.value.stderr?.trim?.() ?? '';
+  return [stdout, stderr].filter(Boolean).join('\n');
+});
+
+const gitStageSuccessMessage = computed(() => {
+  if (!gitStageResult.value?.success) {
+    return '';
+  }
+
+  if (gitStageResult.value.all) {
+    return 'git add --all executado com sucesso.';
+  }
+
+  if (gitStageResult.value.paths.length > 0) {
+    return `Arquivos adicionados ao staging: ${gitStageResult.value.paths.join(', ')}`;
+  }
+
+  return 'git add executado com sucesso.';
+});
+
+const gitCommitOutput = computed(() => {
+  if (!gitCommitResult.value) {
+    return '';
+  }
+
+  const stdout = gitCommitResult.value.stdout?.trim?.() ?? '';
+  const stderr = gitCommitResult.value.stderr?.trim?.() ?? '';
+  return [stdout, stderr].filter(Boolean).join('\n');
+});
+
+const gitCommitSuccessMessage = computed(() => {
+  if (!gitCommitResult.value?.success) {
+    return '';
+  }
+
+  const subject = gitCommitResult.value.messageParts?.[0] ?? gitCommitResult.value.message;
+  return `Commit criado com a mensagem: ${subject}`;
+});
+
+const gitCommitSkippedMessage = computed(() => {
+  if (!gitCommitResult.value?.skipped) {
+    return '';
+  }
+
+  return 'Commit não executado porque o git add automático falhou.';
+});
+
+const gitPushOutput = computed(() => {
+  if (!gitPushResult.value) {
+    return '';
+  }
+
+  const stdout = gitPushResult.value.stdout?.trim?.() ?? '';
+  const stderr = gitPushResult.value.stderr?.trim?.() ?? '';
+  return [stdout, stderr].filter(Boolean).join('\n');
+});
+
+const gitPushSuccessMessage = computed(() => {
+  if (!gitPushResult.value?.success) {
+    return '';
+  }
+
+  const branch = gitPushResult.value.branch;
+  const remote = gitPushResult.value.remote;
+  if (branch && remote) {
+    return gitPushResult.value.setUpstream
+      ? `Branch ${branch} enviada para ${remote} com upstream configurado.`
+      : `Branch ${branch} enviada para ${remote}.`;
+  }
+
+  return 'git push executado com sucesso.';
+});
+
+async function refreshGitStatus() {
+  if (!teacherAutomationEnabled) {
+    return;
+  }
+
+  gitStatusLoading.value = true;
+  gitStatusError.value = null;
+
+  try {
+    gitStatus.value = await fetchTeacherGitStatus();
+  } catch (error) {
+    if (error instanceof TeacherAutomationError) {
+      gitStatusError.value = error.message;
+    } else if (error instanceof Error) {
+      gitStatusError.value = error.message;
+    } else {
+      gitStatusError.value = 'Falha inesperada ao consultar o serviço de automação.';
+    }
+  } finally {
+    gitStatusLoading.value = false;
+  }
+}
+
+async function verifyMainUpdates() {
+  if (!teacherAutomationEnabled) {
+    return;
+  }
+
+  gitFetchLoading.value = true;
+  gitFetchError.value = null;
+  gitFetchResult.value = null;
+
+  try {
+    const result = await fetchTeacherGitUpdates({ remote: 'origin', branch: 'main' });
+    gitFetchResult.value = result;
+
+    if (!result.success) {
+      const stderrMessage = result.stderr?.trim?.() ?? '';
+      const stdoutMessage = result.stdout?.trim?.() ?? '';
+      gitFetchError.value =
+        stderrMessage || stdoutMessage || 'Não foi possível buscar atualizações da branch main.';
+    } else {
+      gitFetchError.value = null;
+    }
+
+    if (result.status) {
+      gitStatus.value = result.status;
+    } else if (result.success) {
+      await refreshGitStatus();
+    }
+  } catch (error) {
+    gitFetchResult.value = null;
+    if (error instanceof TeacherAutomationError) {
+      gitFetchError.value = error.message;
+    } else if (error instanceof Error) {
+      gitFetchError.value = error.message;
+    } else {
+      gitFetchError.value = 'Falha inesperada ao buscar atualizações do Git.';
+    }
+  } finally {
+    gitFetchLoading.value = false;
+  }
+}
+
+async function createWorkingBranch() {
+  if (!teacherAutomationEnabled) {
+    gitCheckoutError.value =
+      'Serviço de automação não configurado. Defina VITE_TEACHER_API_URL para habilitar a criação automática.';
+    return;
+  }
+
+  gitCheckoutLoading.value = true;
+  gitCheckoutError.value = null;
+  gitCheckoutResult.value = null;
+
+  try {
+    const result = await checkoutTeacherGitBranch({
+      branch: sanitizedBranch.value,
+      create: true,
+      startPoint: 'main',
+    });
+
+    gitCheckoutResult.value = result;
+
+    if (!result.success) {
+      const stderrMessage = result.stderr?.trim?.() ?? '';
+      const stdoutMessage = result.stdout?.trim?.() ?? '';
+      gitCheckoutError.value =
+        stderrMessage || stdoutMessage || 'Não foi possível preparar a branch solicitada.';
+    } else {
+      gitCheckoutError.value = null;
+    }
+
+    if (result.status) {
+      gitStatus.value = result.status;
+      if (result.status.branch) {
+        branchName.value = result.status.branch;
+      }
+    } else if (result.success) {
+      await refreshGitStatus();
+    }
+  } catch (error) {
+    gitCheckoutResult.value = null;
+    if (error instanceof TeacherAutomationError) {
+      gitCheckoutError.value = error.message;
+    } else if (error instanceof Error) {
+      gitCheckoutError.value = error.message;
+    } else {
+      gitCheckoutError.value = 'Falha inesperada ao preparar a branch.';
+    }
+  } finally {
+    gitCheckoutLoading.value = false;
+  }
+}
+
+async function stageCurrentArtifacts() {
+  if (!teacherAutomationEnabled) {
+    gitStageError.value =
+      'Serviço de automação não configurado. Defina VITE_TEACHER_API_URL para habilitar o git add automático.';
+    return;
+  }
+
+  const paths = artifactPaths.value;
+  if (paths.length === 0) {
+    gitStageError.value =
+      'Preencha ao menos um caminho na seção de conteúdos para enviar ao staging automaticamente.';
+    return;
+  }
+
+  gitStageLoading.value = true;
+  gitStageError.value = null;
+  gitStageResult.value = null;
+
+  try {
+    const result = await stageTeacherGitPaths({ paths });
+    gitStageResult.value = result;
+
+    if (!result.success) {
+      const stderrMessage = result.stderr?.trim?.() ?? '';
+      const stdoutMessage = result.stdout?.trim?.() ?? '';
+      gitStageError.value =
+        stderrMessage || stdoutMessage || 'Não foi possível adicionar os arquivos ao staging.';
+    } else {
+      gitStageError.value = null;
+    }
+
+    if (result.status) {
+      gitStatus.value = result.status;
+    } else if (result.success) {
+      await refreshGitStatus();
+    }
+  } catch (error) {
+    gitStageResult.value = null;
+    if (error instanceof TeacherAutomationError) {
+      gitStageError.value = error.message;
+    } else if (error instanceof Error) {
+      gitStageError.value = error.message;
+    } else {
+      gitStageError.value = 'Falha inesperada ao executar git add.';
+    }
+  } finally {
+    gitStageLoading.value = false;
+  }
+}
+
+async function commitCurrentArtifacts() {
+  if (!teacherAutomationEnabled) {
+    gitCommitError.value =
+      'Serviço de automação não configurado. Defina VITE_TEACHER_API_URL para habilitar commits automáticos.';
+    return;
+  }
+
+  gitCommitLoading.value = true;
+  gitCommitError.value = null;
+  gitCommitResult.value = null;
+
+  try {
+    const result = await commitTeacherGitChanges({
+      message: sanitizedCommitTitle.value,
+      stagePaths: artifactPaths.value,
+    });
+
+    gitCommitResult.value = result;
+
+    if (!result.success) {
+      if (result.skipped && result.stage && !result.stage.success) {
+        const stderrMessage = result.stage.stderr?.trim?.() ?? '';
+        const stdoutMessage = result.stage.stdout?.trim?.() ?? '';
+        gitCommitError.value =
+          stderrMessage ||
+          stdoutMessage ||
+          'Não foi possível adicionar os arquivos ao staging antes do commit.';
+        gitStageError.value =
+          stderrMessage || stdoutMessage || 'Não foi possível adicionar os arquivos ao staging.';
+      } else {
+        const stderrMessage = result.stderr?.trim?.() ?? '';
+        const stdoutMessage = result.stdout?.trim?.() ?? '';
+        gitCommitError.value =
+          stderrMessage || stdoutMessage || 'Não foi possível concluir o commit solicitado.';
+      }
+    } else {
+      gitCommitError.value = null;
+    }
+
+    if (result.stage) {
+      gitStageResult.value = result.stage;
+      if (result.stage.success) {
+        gitStageError.value = null;
+      }
+    }
+
+    if (result.status) {
+      gitStatus.value = result.status;
+    } else {
+      await refreshGitStatus();
+    }
+  } catch (error) {
+    gitCommitResult.value = null;
+    if (error instanceof TeacherAutomationError) {
+      gitCommitError.value = error.message;
+    } else if (error instanceof Error) {
+      gitCommitError.value = error.message;
+    } else {
+      gitCommitError.value = 'Falha inesperada ao executar git commit.';
+    }
+  } finally {
+    gitCommitLoading.value = false;
+  }
+}
+
+async function pushCurrentBranch() {
+  if (!teacherAutomationEnabled) {
+    gitPushError.value =
+      'Serviço de automação não configurado. Defina VITE_TEACHER_API_URL para habilitar git push automático.';
+    return;
+  }
+
+  const branch = gitPushBranchCandidate.value;
+  if (!branch) {
+    gitPushError.value =
+      'Informe o nome da branch na seção acima ou consulte o status do Git antes de enviar com git push.';
+    return;
+  }
+
+  gitPushLoading.value = true;
+  gitPushError.value = null;
+  gitPushResult.value = null;
+
+  try {
+    const result = await pushTeacherGitBranch({
+      remote: 'origin',
+      branch,
+      setUpstream: !gitStatus.value?.upstream,
+    });
+
+    gitPushResult.value = result;
+
+    if (!result.success) {
+      const stderrMessage = result.stderr?.trim?.() ?? '';
+      const stdoutMessage = result.stdout?.trim?.() ?? '';
+      gitPushError.value =
+        stderrMessage || stdoutMessage || 'Não foi possível enviar a branch ao repositório remoto.';
+    } else {
+      gitPushError.value = null;
+    }
+
+    if (result.status) {
+      gitStatus.value = result.status;
+    } else if (result.success) {
+      await refreshGitStatus();
+    }
+  } catch (error) {
+    gitPushResult.value = null;
+    if (error instanceof TeacherAutomationError) {
+      gitPushError.value = error.message;
+    } else if (error instanceof Error) {
+      gitPushError.value = error.message;
+    } else {
+      gitPushError.value = 'Falha inesperada ao executar git push.';
+    }
+  } finally {
+    gitPushLoading.value = false;
+  }
+}
+
+onMounted(() => {
+  if (teacherAutomationEnabled) {
+    refreshGitStatus();
+  }
+});
 
 const artifactTypeOptions: Array<{ value: ArtifactType; label: string }> = [
   { value: 'lesson', label: 'Aula (lesson)' },
@@ -361,7 +1317,49 @@ const sanitizedCommitTitle = computed(
   () => commitTitle.value.trim() || 'chore: preparar pacote de publicação'
 );
 
+const gitPushBranchCandidate = computed(() => {
+  const explicit = branchName.value.trim();
+  if (explicit) {
+    return explicit;
+  }
+
+  const statusBranchRaw = gitStatus.value?.branch ?? '';
+  if (typeof statusBranchRaw === 'string') {
+    const trimmed = statusBranchRaw.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return '';
+});
+
+const canPushAutomatically = computed(() => gitPushBranchCandidate.value.length > 0);
+
+const gitPushCommandPreview = computed(() => {
+  const branch = gitPushBranchCandidate.value;
+  const hasUpstream = Boolean(gitStatus.value?.upstream);
+
+  if (!branch) {
+    return 'git push -u origin <branch>';
+  }
+
+  return hasUpstream ? `git push origin ${branch}` : `git push -u origin ${branch}`;
+});
+
+const gitPushBehaviorHint = computed(() => {
+  if (gitStatus.value?.upstream) {
+    return 'O upstream já está configurado; o serviço reaproveita essa configuração.';
+  }
+
+  return 'Sem upstream configurado, o serviço usa -u para definir o rastreamento automaticamente.';
+});
+
 const enabledValidations = computed(() => validationSteps.filter((step) => step.enabled));
+
+const artifactPaths = computed(() =>
+  artifacts.map((item) => item.path.trim()).filter((path) => path.length > 0)
+);
 
 const artifactSummaries = computed(() =>
   artifacts
@@ -390,7 +1388,7 @@ const gitCommands = computed(() => {
     commands.push(step.command);
   });
 
-  const filesToAdd = artifacts.map((item) => item.path.trim()).filter((path) => Boolean(path));
+  const filesToAdd = artifactPaths.value;
 
   if (filesToAdd.length > 0) {
     commands.push('git status');
@@ -402,7 +1400,7 @@ const gitCommands = computed(() => {
   }
 
   commands.push(`git commit -m "${sanitizedCommitTitle.value}"`);
-  commands.push(`git push -u origin ${sanitizedBranch.value}`);
+  commands.push(gitPushCommandPreview.value);
   commands.push('gh pr create --web');
 
   return commands;

--- a/src/pages/professor/PublicationWorkbench.vue
+++ b/src/pages/professor/PublicationWorkbench.vue
@@ -64,24 +64,30 @@
                   </p>
                 </div>
                 <div class="flex flex-wrap gap-2 self-start md:self-auto">
-                  <button
+                  <Md3Button
                     type="button"
-                    class="btn btn-text inline-flex items-center gap-2"
+                    variant="text"
+                    class="inline-flex items-center gap-2"
                     :disabled="gitStatusLoading"
                     @click="refreshGitStatus"
                   >
-                    <RefreshCcw class="md-icon md-icon--sm" aria-hidden="true" />
+                    <template #leading>
+                      <RefreshCcw class="md-icon md-icon--sm" aria-hidden="true" />
+                    </template>
                     {{ gitStatusLoading ? 'Atualizando…' : 'Atualizar status' }}
-                  </button>
-                  <button
+                  </Md3Button>
+                  <Md3Button
                     type="button"
-                    class="btn btn-tonal inline-flex items-center gap-2"
+                    variant="tonal"
+                    class="inline-flex items-center gap-2"
                     :disabled="gitFetchLoading"
                     @click="verifyMainUpdates"
                   >
-                    <Download class="md-icon md-icon--sm" aria-hidden="true" />
+                    <template #leading>
+                      <Download class="md-icon md-icon--sm" aria-hidden="true" />
+                    </template>
                     {{ gitFetchLoading ? 'Verificando main…' : 'Buscar atualizações da main' }}
-                  </button>
+                  </Md3Button>
                 </div>
               </div>
 
@@ -236,15 +242,18 @@
               Peça para o serviço auxiliar criar ou alternar automaticamente para a branch informada
               a partir da <code>main</code> atualizada.
             </p>
-            <button
+            <Md3Button
               type="button"
-              class="btn btn-filled inline-flex items-center gap-2 self-start md:self-auto"
+              variant="filled"
+              class="inline-flex items-center gap-2 self-start md:self-auto"
               :disabled="gitCheckoutLoading"
               @click="createWorkingBranch"
             >
-              <GitBranch class="md-icon md-icon--sm" aria-hidden="true" />
+              <template #leading>
+                <GitBranch class="md-icon md-icon--sm" aria-hidden="true" />
+              </template>
               {{ gitCheckoutLoading ? 'Criando branch…' : 'Criar branch automaticamente' }}
-            </button>
+            </Md3Button>
           </div>
 
           <div
@@ -320,31 +329,36 @@
               </p>
             </div>
             <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
-              <button
+              <Md3Button
                 type="button"
-                class="btn btn-tonal inline-flex items-center gap-2"
+                variant="tonal"
+                class="inline-flex items-center gap-2"
                 :disabled="gitStageLoading || artifactPaths.length === 0"
                 @click="stageCurrentArtifacts"
               >
                 {{ gitStageLoading ? 'Adicionando…' : 'Adicionar com git add' }}
-              </button>
-              <button
+              </Md3Button>
+              <Md3Button
                 type="button"
-                class="btn btn-filled inline-flex items-center gap-2"
+                variant="filled"
+                class="inline-flex items-center gap-2"
                 :disabled="gitCommitLoading"
                 @click="commitCurrentArtifacts"
               >
                 {{ gitCommitLoading ? 'Registrando commit…' : 'Gerar commit agora' }}
-              </button>
-              <button
+              </Md3Button>
+              <Md3Button
                 type="button"
-                class="btn btn-filled inline-flex items-center gap-2"
+                variant="filled"
+                class="inline-flex items-center gap-2"
                 :disabled="gitPushLoading || !canPushAutomatically"
                 @click="pushCurrentBranch"
               >
-                <UploadCloud class="md-icon md-icon--sm" aria-hidden="true" />
+                <template #leading>
+                  <UploadCloud class="md-icon md-icon--sm" aria-hidden="true" />
+                </template>
                 {{ gitPushLoading ? 'Enviando branch…' : 'Enviar branch com git push' }}
-              </button>
+              </Md3Button>
             </div>
           </div>
 

--- a/src/pages/professor/ValidationWorkbench.vue
+++ b/src/pages/professor/ValidationWorkbench.vue
@@ -575,6 +575,7 @@ import {
   TeacherAutomationError,
   type TeacherScriptHistoryEntry,
 } from './utils/automation';
+import { persistValidationStatuses, type ValidationStatusMap } from './utils/validationStatus';
 
 const dateTimeFormatter = new Intl.DateTimeFormat('pt-BR', {
   dateStyle: 'long',
@@ -750,6 +751,37 @@ const scriptsStatus = computed<Record<ValidationScriptKey, StatusInfo>>(() => ({
   observability: analyzeLog(observabilityLog.value),
   governance: analyzeLog(governanceLog.value),
 }));
+
+const validationStatusesSnapshot = computed<ValidationStatusMap>(() => ({
+  content: {
+    status: scriptsStatus.value.content.status,
+    description: scriptsStatus.value.content.description,
+    updatedAt: timestamps.content.value,
+  },
+  report: {
+    status: scriptsStatus.value.report.status,
+    description: scriptsStatus.value.report.description,
+    updatedAt: timestamps.report.value,
+  },
+  observability: {
+    status: scriptsStatus.value.observability.status,
+    description: scriptsStatus.value.observability.description,
+    updatedAt: timestamps.observability.value,
+  },
+  governance: {
+    status: scriptsStatus.value.governance.status,
+    description: scriptsStatus.value.governance.description,
+    updatedAt: timestamps.governance.value,
+  },
+}));
+
+watch(
+  validationStatusesSnapshot,
+  (value) => {
+    persistValidationStatuses(value);
+  },
+  { deep: true, immediate: true }
+);
 
 const statusMeta: Record<CheckStatus, { label: string; chipClass: string; icon: unknown }> = {
   pending: {

--- a/src/pages/professor/utils/validation.ts
+++ b/src/pages/professor/utils/validation.ts
@@ -1,5 +1,7 @@
-import Ajv, { type ErrorObject } from 'ajv';
+import Ajv2020 from 'ajv/dist/2020';
+import type { ErrorObject } from 'ajv';
 import addFormats from 'ajv-formats';
+import draft2020Schema from 'ajv/dist/refs/json-schema-2020-12/schema.json';
 
 export interface FormattedAjvError {
   message: string;
@@ -8,7 +10,8 @@ export interface FormattedAjvError {
 }
 
 export function createAjvInstance() {
-  const ajv = new Ajv({ allErrors: true, strict: false });
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  ajv.addMetaSchema(draft2020Schema);
   addFormats(ajv);
   return ajv;
 }

--- a/src/pages/professor/utils/validationStatus.ts
+++ b/src/pages/professor/utils/validationStatus.ts
@@ -1,0 +1,110 @@
+import { onBeforeUnmount, onMounted, ref, type Ref } from 'vue';
+import type { ValidationScriptKey } from './validationScripts';
+
+export type ValidationCheckStatus = 'pending' | 'success' | 'warning' | 'error';
+
+export interface ValidationStatusEntry {
+  status: ValidationCheckStatus;
+  description: string;
+  updatedAt: string | null;
+}
+
+export type ValidationStatusMap = Record<ValidationScriptKey, ValidationStatusEntry>;
+
+const STORAGE_KEY = 'professor.validation.status';
+
+const defaultEntry: ValidationStatusEntry = {
+  status: 'pending',
+  description: 'Aguardando execução do script.',
+  updatedAt: null,
+};
+
+function createDefaultStatusMap(): ValidationStatusMap {
+  return {
+    content: { ...defaultEntry },
+    report: { ...defaultEntry },
+    observability: { ...defaultEntry },
+    governance: { ...defaultEntry },
+  };
+}
+
+function sanitizeEntry(value: unknown): ValidationStatusEntry {
+  if (!value || typeof value !== 'object') return { ...defaultEntry };
+  const { status, description, updatedAt } = value as Partial<ValidationStatusEntry>;
+  const normalizedStatus: ValidationCheckStatus =
+    status === 'success' || status === 'warning' || status === 'error' ? status : 'pending';
+  return {
+    status: normalizedStatus,
+    description:
+      typeof description === 'string' && description.trim().length > 0
+        ? description
+        : defaultEntry.description,
+    updatedAt: typeof updatedAt === 'string' ? updatedAt : null,
+  };
+}
+
+function readFromStorage(): ValidationStatusMap {
+  if (typeof window === 'undefined') return createDefaultStatusMap();
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) return createDefaultStatusMap();
+  try {
+    const parsed = JSON.parse(raw) as Partial<Record<ValidationScriptKey, unknown>>;
+    return {
+      content: sanitizeEntry(parsed.content),
+      report: sanitizeEntry(parsed.report),
+      observability: sanitizeEntry(parsed.observability),
+      governance: sanitizeEntry(parsed.governance),
+    } satisfies ValidationStatusMap;
+  } catch (error) {
+    console.warn('[validationStatus] Falha ao ler estado persistido', error);
+    return createDefaultStatusMap();
+  }
+}
+
+export function persistValidationStatuses(statuses: ValidationStatusMap) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(statuses));
+  } catch (error) {
+    console.warn('[validationStatus] Não foi possível persistir o status de validação', error);
+  }
+}
+
+export function useValidationStatuses(): Ref<ValidationStatusMap> {
+  const state = ref<ValidationStatusMap>(readFromStorage());
+
+  function handleStorage(event: StorageEvent) {
+    if (event.storageArea !== window.localStorage) return;
+    if (event.key && event.key !== STORAGE_KEY) return;
+    state.value = readFromStorage();
+  }
+
+  onMounted(() => {
+    state.value = readFromStorage();
+    window.addEventListener('storage', handleStorage);
+  });
+
+  onBeforeUnmount(() => {
+    window.removeEventListener('storage', handleStorage);
+  });
+
+  return state;
+}
+
+export function hasBlockingValidation(statuses: ValidationStatusMap) {
+  return Object.values(statuses).some((entry) => entry.status === 'error');
+}
+
+export function formatUpdatedAt(value: string | null) {
+  if (!value) return null;
+  try {
+    return new Intl.DateTimeFormat('pt-BR', {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    }).format(new Date(value));
+  } catch (error) {
+    return null;
+  }
+}
+
+export { STORAGE_KEY as VALIDATION_STATUS_STORAGE_KEY };


### PR DESCRIPTION
## Summary
- add a sanitized `/api/teacher/git/push` endpoint to the teacher automation server and expose it through the SPA automation helpers
- extend the publication workbench with push controls, upstream-aware previews, and feedback that reuses the backend response
- document the new git push capability across the professor module plan, status overview, iteration log, and backend API contract
- rebase the work branch onto the latest `origin/main` to incorporate upstream updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d82cdbf4f4832cbd58adf4e82e7b67