### PR TITLE
Clean up lesson code block visuals

### DIFF
--- a/src/components/lesson/Callout.stories.ts
+++ b/src/components/lesson/Callout.stories.ts
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import Callout from './Callout.vue';
+
+const meta: Meta<typeof Callout> = {
+  title: 'Lesson/Blocks/Callout',
+  component: Callout,
+};
+
+export default meta;
+type Story = StoryObj<typeof Callout>;
+
+export const WithCodeSample: Story = {
+  args: {
+    variant: 'info',
+    title: 'Dica de implementação',
+    content: [
+      {
+        type: 'paragraph',
+        text: 'Quando precisar compartilhar trechos de código, mantenha-os dentro do fluxo do conteúdo.',
+      },
+      {
+        type: 'code',
+        code: `if (!user.isAuthenticated()) {
+  throw new Error('Faça login para continuar');
+}`,
+        language: 'javascript',
+      },
+      {
+        type: 'paragraph',
+        text: 'O espaçamento do bloco se adapta automaticamente ao contexto do callout e pode ser ajustado por token.',
+      },
+    ],
+  },
+  render: (args) => ({
+    components: { Callout },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div class="lesson-block-story md-stack md-stack-6" style="max-width: 48rem; margin: 0 auto; padding: 2rem;">
+        <Callout v-bind="args" />
+      </div>
+    `,
+  }),
+};

--- a/src/components/lesson/Callout.vue
+++ b/src/components/lesson/Callout.vue
@@ -241,7 +241,10 @@ function isPlainText(language?: string) {
   list-style: disc;
 }
 
-.callout__code,
+.callout__code {
+  --code-block-spacing: var(--md-sys-spacing-3);
+}
+
 .callout__roadmap {
   margin-top: var(--md-sys-spacing-1);
 }

--- a/src/components/lesson/CodeBlock.stories.ts
+++ b/src/components/lesson/CodeBlock.stories.ts
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import CodeBlock from './CodeBlock.vue';
+
+const meta: Meta<typeof CodeBlock> = {
+  title: 'Lesson/Blocks/CodeBlock',
+  component: CodeBlock,
+  args: {
+    code: `function greet(name) {
+  return \`Hello, \${name}\`;
+}
+
+console.log(greet('Mundo'));
+`,
+    language: 'javascript',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CodeBlock>;
+
+export const DefaultSpacing: Story = {
+  render: (args) => ({
+    components: { CodeBlock },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div class="lesson-block-story md-stack md-stack-6" style="max-width: 48rem; margin: 0 auto; padding: 2rem;">
+        <p class="md-typescale-body-large text-[var(--md-sys-color-on-surface-variant)]">
+          O componente usa o espaçamento natural do layout quando inserido em uma pilha Material Design.
+        </p>
+        <CodeBlock v-bind="args" />
+        <p class="md-typescale-body-large text-[var(--md-sys-color-on-surface-variant)]">
+          Blocos subsequentes permanecem alinhados pelo <code>gap</code> da pilha, sem margens colapsadas.
+        </p>
+      </div>
+    `,
+  }),
+};
+
+export const WithCustomSpacing: Story = {
+  render: (args) => ({
+    components: { CodeBlock },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div class="lesson-block-story md-stack md-stack-6" style="max-width: 48rem; margin: 0 auto; padding: 2rem;">
+        <p class="md-typescale-body-large text-[var(--md-sys-color-on-surface-variant)]">
+          Também é possível sobrescrever o token <code>--code-block-spacing</code> quando for preciso mais respiro.
+        </p>
+        <div style="--code-block-spacing: var(--md-sys-spacing-6);">
+          <CodeBlock v-bind="args" />
+        </div>
+        <p class="md-typescale-body-large text-[var(--md-sys-color-on-surface-variant)]">
+          O espaçamento adicional é aplicado apenas a este bloco, mantendo o restante da pilha intacto.
+        </p>
+      </div>
+    `,
+  }),
+};

--- a/src/components/lesson/CodeBlock.vue
+++ b/src/components/lesson/CodeBlock.vue
@@ -1,10 +1,7 @@
 <template>
   <div :class="['code-block group', { 'plain-text-mode': plainText }]">
-    <div
-      class="flex justify-end items-center py-2 px-3 bg-[var(--md-sys-color-surface-container-high)] border-b border-[var(--md-sys-color-outline)]"
-    >
+    <div class="code-block__toolbar">
       <Md3Button
-        class="code-block__copy"
         variant="text"
         icon
         type="button"
@@ -18,7 +15,7 @@
       </Md3Button>
     </div>
     <pre
-      class="p-4 pt-0 m-0"
+      class="code-block__pre"
     ><code :class="plainText ? 'plain-text' : `language-${language}`" ref="codeElement">{{ code }}</code></pre>
   </div>
 </template>
@@ -116,37 +113,41 @@ watch(
 
 /* Base code block style */
 .code-block {
+  --_toolbar-padding-inline: clamp(1.25rem, 3vw, 1.75rem);
+  --_toolbar-padding-block: var(--md-sys-spacing-3);
+  --_content-padding-inline: clamp(1.25rem, 3vw, 1.75rem);
+  --_content-padding-block: var(--md-sys-spacing-4);
+
   background-color: var(--md-sys-color-surface-container);
-  border-radius: 1rem;
+  border-radius: var(--md-sys-border-radius-extra-large, 1rem);
+  margin-block: var(--code-block-spacing, 0);
   overflow: hidden;
-  margin: 1.5rem 0;
-  border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 65%, transparent);
   position: relative;
+  display: flex;
+  flex-direction: column;
 }
 
-/* Button container styling */
-.code-block > div:first-child {
-  background-color: var(--md-sys-color-surface-container-high);
-  border-bottom: 1px solid var(--md-sys-color-outline);
+.code-block__toolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding-inline: var(--_toolbar-padding-inline);
+  padding-block: var(--_toolbar-padding-block);
+  padding-bottom: 0;
 }
 
-.code-block__copy.md3-button--icon {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: var(--md-sys-border-radius-large);
-  border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 55%, transparent);
-  background-color: var(--md-sys-color-surface);
-  color: var(--md-sys-color-on-surface-variant);
+.code-block__pre {
+  margin: 0;
+  padding-inline: var(--_content-padding-inline);
+  padding-block: var(--_content-padding-block);
+  padding-top: var(--md-sys-spacing-2);
+  overflow-x: auto;
 }
 
-.code-block__copy.md3-button--icon:hover {
-  color: var(--md-sys-color-on-primary-container);
-  border-color: color-mix(in srgb, var(--md-sys-color-primary) 60%, transparent);
-  background-color: color-mix(in srgb, var(--md-sys-color-primary-container) 85%, transparent);
-}
-
-.code-block__copy.md3-button--icon::after {
-  background: var(--md-sys-state-layer-on-surface);
+.code-block code {
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  background: none;
 }
 
 /* Plain text styling - no syntax highlighting */
@@ -183,7 +184,7 @@ watch(
   border-radius: 0 !important;
 }
 
-.code-block.plain-text-mode > div:first-child {
+.code-block.plain-text-mode .code-block__toolbar {
   display: none !important; /* Hide the button container */
 }
 

--- a/src/components/lesson/LessonRenderer.vue
+++ b/src/components/lesson/LessonRenderer.vue
@@ -1,5 +1,8 @@
 <template>
-  <section v-if="data && data.content && data.content.length" class="md-stack md-stack-6">
+  <section
+    v-if="data && data.content && data.content.length"
+    class="lesson-renderer md-stack md-stack-6"
+  >
     <template v-for="(entry, index) in resolvedBlocks" :key="index">
       <component v-if="entry.component" :is="entry.component" v-bind="entry.props" />
       <div v-else class="prose max-w-none text-[var(--md-sys-color-on-surface-variant)]">
@@ -39,3 +42,11 @@ const resolvedBlocks = computed(() => {
   });
 });
 </script>
+
+<style scoped>
+.lesson-renderer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--md-sys-spacing-6);
+}
+</style>


### PR DESCRIPTION
## Summary
- simplify the lesson code block markup so the toolbar and body rely on dedicated styles
- let the copy button reuse the default MD3 icon appearance and strip borders/hover chrome from block code
- keep plain-text mode overrides aligned with the new structure while preserving the spacing token

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d956ce4eb4832c916edbd9640b37b0