### PR TITLE
Refine inline code surface styling

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -2065,20 +2065,31 @@ code {
     'Fira Code', 'JetBrains Mono', 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
   font-size: 0.875em;
   font-weight: 500;
-  background-color: var(--md-sys-color-surface-container);
+  background: color-mix(
+    in srgb,
+    var(--md-sys-color-surface-container) 88%,
+    var(--md-sys-color-outline-variant) 12%
+  );
   color: var(--md-sys-color-on-surface);
-  padding: 0.125rem 0.375rem;
+  padding: 0.125rem 0.3rem;
   border-radius: 0.375rem;
-  border: 1px solid var(--md-sys-color-outline);
-  box-shadow: var(--shadow-elevation-1);
-  transition: all 150ms ease;
+  border: none;
+  outline: 1px solid color-mix(in srgb, var(--md-sys-color-outline-variant) 48%, transparent);
+  outline-offset: 0;
+  box-shadow: none;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    outline-color 150ms ease;
 }
 
 code-text:hover,
 code:hover {
-  background-color: var(--md-sys-color-surface-container-high);
-  box-shadow: var(--shadow-elevation-2);
-  transform: translateY(-1px);
+  background: color-mix(
+    in srgb,
+    var(--md-sys-color-surface-container) 80%,
+    var(--md-sys-color-outline-variant) 20%
+  );
 }
 
 /* Estilos específicos para code-text (tags customizadas) */
@@ -2091,45 +2102,35 @@ code-text {
 /* Estilos para code dentro de elementos maiores */
 .lesson-content code,
 .prose code {
-  background-color: var(--md-sys-color-surface-container);
-  color: var(--md-sys-color-on-surface);
-  border: 1px solid var(--md-sys-color-outline);
-  border-radius: 0.375rem;
-  padding: 0.125rem 0.25rem;
-  font-size: 0.875em;
+  font-size: 0.9em;
   font-weight: 500;
-  box-shadow: var(--shadow-elevation-1);
-}
-
-.lesson-content code:hover,
-.prose code:hover {
-  background-color: var(--md-sys-color-surface-container-high);
-  box-shadow: var(--shadow-elevation-2);
+  padding: 0.125rem 0.3rem;
 }
 
 /* Estilos para modo escuro */
 html[data-theme='dark'] code-text,
 html[data-theme='dark'] code {
-  background-color: var(--md-sys-color-surface-container);
+  background: color-mix(
+    in srgb,
+    var(--md-sys-color-surface-container) 78%,
+    var(--md-sys-color-outline-variant) 22%
+  );
   color: var(--md-sys-color-on-surface);
-  border-color: var(--md-sys-color-outline);
+  outline-color: color-mix(in srgb, var(--md-sys-color-outline-variant) 60%, transparent);
 }
 
 html[data-theme='dark'] code-text:hover,
 html[data-theme='dark'] code:hover {
-  background-color: var(--md-sys-color-surface-container-high);
+  background: color-mix(
+    in srgb,
+    var(--md-sys-color-surface-container) 70%,
+    var(--md-sys-color-outline-variant) 30%
+  );
 }
 
 html[data-theme='dark'] .lesson-content code,
 html[data-theme='dark'] .prose code {
-  background-color: var(--md-sys-color-surface-container);
-  color: var(--md-sys-color-on-surface);
-  border-color: var(--md-sys-color-outline);
-}
-
-html[data-theme='dark'] .lesson-content code:hover,
-html[data-theme='dark'] .prose code:hover {
-  background-color: var(--md-sys-color-surface-container-high);
+  padding: 0.125rem 0.3rem;
 }
 .bg-primary-50 {
   background-color: color-mix(


### PR DESCRIPTION
## Summary
- replace inline code borders and shadows with tonal backgrounds and subtle outline-variant contour
- align inline code spacing in lesson content and prose so examples maintain readability in light and dark themes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d95ef9537c832caaf4355ff0e77dfb