### PR TITLE
Normalize icon sizing with md-icon utility

### DIFF
--- a/src/components/lesson/Accordion.vue
+++ b/src/components/lesson/Accordion.vue
@@ -16,11 +16,7 @@
       >
         <span>{{ item.title }}</span>
         <ChevronDown
-          :style="{
-            height: 'var(--md-sys-icon-size-medium)',
-            width: 'var(--md-sys-icon-size-medium)',
-          }"
-          class="transform transition-transform duration-300 text-[var(--md-sys-color-on-surface-variant)]"
+          class="md-icon md-icon--md transform transition-transform duration-300 text-[var(--md-sys-color-on-surface-variant)]"
           :class="{ 'rotate-180': openIndex === index }"
         />
       </button>

--- a/src/pages/CourseHome.vue
+++ b/src/pages/CourseHome.vue
@@ -34,12 +34,7 @@
           type="button"
           @click="viewMode = 'grid'"
         >
-          <Grid3x3
-            :style="{
-              height: 'var(--md-sys-icon-size-small)',
-              width: 'var(--md-sys-icon-size-small)',
-            }"
-          />
+          <Grid3x3 class="md-icon md-icon--sm" />
           Grade
         </button>
         <button
@@ -48,12 +43,7 @@
           type="button"
           @click="viewMode = 'list'"
         >
-          <List
-            :style="{
-              height: 'var(--md-sys-icon-size-small)',
-              width: 'var(--md-sys-icon-size-small)',
-            }"
-          />
+          <List class="md-icon md-icon--sm" />
           Lista
         </button>
       </div>
@@ -99,11 +89,7 @@
             >
               <span>{{ item.cta }}</span>
               <ChevronRight
-                :style="{
-                  height: 'var(--md-sys-icon-size-small)',
-                  width: 'var(--md-sys-icon-size-small)',
-                }"
-                class="transition-transform duration-150 group-hover:translate-x-1"
+                class="md-icon md-icon--sm transition-transform duration-150 group-hover:translate-x-1"
               />
             </span>
           </template>

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -54,13 +54,7 @@
           @click="toggleFilters"
         >
           <template #leading>
-            <component
-              :is="filtersOpen ? ChevronUp : ChevronDown"
-              :style="{
-                height: 'var(--md-sys-icon-size-small)',
-                width: 'var(--md-sys-icon-size-small)',
-              }"
-            />
+            <component :is="filtersOpen ? ChevronUp : ChevronDown" class="md-icon md-icon--sm" />
           </template>
           {{ filtersOpen ? 'Ocultar filtros' : 'Mostrar filtros' }}
         </Md3Button>
@@ -79,11 +73,7 @@
                 >
                 <div class="relative">
                   <Search
-                    class="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[var(--md-sys-color-on-surface-variant)]"
-                    :style="{
-                      height: 'var(--md-sys-icon-size-small)',
-                      width: 'var(--md-sys-icon-size-small)',
-                    }"
+                    class="md-icon md-icon--sm pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[var(--md-sys-color-on-surface-variant)]"
                   />
                   <input
                     class="input pl-12"
@@ -104,11 +94,7 @@
                     <option v-for="option in institutions" :key="option">{{ option }}</option>
                   </select>
                   <ChevronDown
-                    class="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[var(--md-sys-color-on-surface-variant)]"
-                    :style="{
-                      height: 'var(--md-sys-icon-size-small)',
-                      width: 'var(--md-sys-icon-size-small)',
-                    }"
+                    class="md-icon md-icon--sm pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[var(--md-sys-color-on-surface-variant)]"
                   />
                 </div>
               </label>


### PR DESCRIPTION
## Summary
- replace inline icon sizing styles in Home and CourseHome with md-icon utility classes
- add md-icon modifiers to lucide icons so sizing is driven by the utility helpers
- update the accordion chevron icon to use the shared md-icon medium size

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9632776bc832c839668b0e93a5c25