### PR TITLE
Add MD3 shape utilities and apply card variants

### DIFF
--- a/docs/design-system/tokens.md
+++ b/docs/design-system/tokens.md
@@ -10,7 +10,7 @@ Os tokens do tema Material You foram centralizados em `src/theme/tokens.ts` para
 - **Tipografia** – `TYPOGRAPHY_SCALE` define tamanhos, pesos e tracking para display/headline/title/body/label, aplicados como variáveis CSS.
 - **Espaçamento e dimensões** – `SPACING_SCALE` e `DIMENSION_SCALE` criam variáveis `--md-sys-spacing-*` e `--md-sys-icon-size-*` alinhadas às diretrizes MD3.
 - **Layout responsivo** – `BREAKPOINTS`, `LAYOUT_CONTAINERS` e `APP_BAR_HEIGHTS` publicam `--md-sys-breakpoint-*`, `--md-sys-layout-container-*` e `--md-sys-app-bar-height-*`, sincronizando grids, app bars e shells responsivos.
-- **Curvas** – `SHAPE_SCALE` publica `--md-sys-shape-*` e `--md-sys-shape-corner-*`, permitindo migrações graduais dos componentes antigos.
+- **Curvas** – `SHAPE_SCALE` publica `--md-sys-shape-*` e `--md-sys-shape-corner-*`, permitindo migrações graduais dos componentes antigos e habilitando utilitárias como `.md-shape-large`/`.md-shape-extra-large` e variantes de card (`card--compact`).
 
 ## Convenções de uso
 
@@ -18,6 +18,7 @@ Os tokens do tema Material You foram centralizados em `src/theme/tokens.ts` para
 2. **Evitar valores mágicos**; quando um novo token for necessário, adicione-o ao arquivo `tokens.ts` para manter rastreabilidade.
 3. **Aplicar tokens via JS apenas uma vez** – `applyStaticTokens` roda durante a inicialização do tema e não precisa ser reexecutado.
 4. **Suporte a modo automático** – `setMaterialTheme('system' | 'light' | 'dark')` mantém a sincronização com o Storybook e com o app.
+5. **Curvaturas consistentes** – superfícies principais usam `card` (raio extra-large por padrão) e widgets compactos usam `card card--compact`; tons personalizados podem aplicar `.md-shape-*` para aproveitar `--md-sys-shape-corner-*` sem estilos inline.
 
 ## Próximos passos
 

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -387,6 +387,43 @@ html {
     color: var(--md-sys-color-on-secondary-container);
   }
 
+  /* MD3 shape utilities */
+  .md-shape-small {
+    border-radius: var(--md-sys-shape-corner-small);
+  }
+
+  .md-shape-medium {
+    border-radius: var(--md-sys-shape-corner-medium);
+  }
+
+  .md-shape-large {
+    border-radius: var(--md-sys-shape-corner-large);
+  }
+
+  .md-shape-extra-large {
+    border-radius: var(--md-sys-shape-corner-extra-large);
+  }
+
+  .md-shape-double-extra-large {
+    border-radius: var(--md-sys-shape-corner-double-extra-large);
+  }
+
+  .md-shape-triple-extra-large {
+    border-radius: var(--md-sys-shape-corner-triple-extra-large);
+  }
+
+  .md-shape-quadruple-extra-large {
+    border-radius: var(--md-sys-shape-corner-quadruple-extra-large);
+  }
+
+  .md-shape-quintuple-extra-large {
+    border-radius: var(--md-sys-shape-corner-quintuple-extra-large);
+  }
+
+  .md-shape-full {
+    border-radius: var(--md-sys-shape-corner-full);
+  }
+
   .md-typescale-display-large {
     font-family: var(--md-sys-typescale-font);
     font-size: var(--md-sys-typescale-display-large-size);
@@ -1534,6 +1571,10 @@ html {
       background-color 180ms ease;
     overflow: hidden;
     backdrop-filter: saturate(120%);
+  }
+
+  .card--compact {
+    border-radius: var(--md-sys-shape-corner-large, var(--md-sys-border-radius-large));
   }
 
   .card--interactive {

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -1,6 +1,6 @@
 ﻿<template>
   <section class="page-section page-section--roomy">
-    <header class="card p-6 md:p-8" :style="{ borderRadius: 'var(--md-sys-border-radius-large)' }">
+    <header class="card p-6 md:p-8">
       <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <div
           class="max-w-2xl"
@@ -16,10 +16,7 @@
           </p>
         </div>
         <div class="grid gap-3 sm:grid-cols-2 md:w-64 md:grid-cols-1">
-          <div
-            class="surface-tonal p-4 shadow-elevation-1"
-            :style="{ borderRadius: 'var(--md-sys-border-radius-large)' }"
-          >
+          <div class="surface-tonal md-shape-large p-4 shadow-elevation-1">
             <p
               class="text-label-medium uppercase tracking-[0.2em] text-[var(--md-sys-color-on-surface-variant)]"
             >
@@ -30,8 +27,7 @@
             </p>
           </div>
           <div
-            class="card border-none bg-[var(--md-sys-color-surface-container-high)] p-4"
-            :style="{ borderRadius: 'var(--md-sys-border-radius-large)' }"
+            class="card card--compact border-none bg-[var(--md-sys-color-surface-container-high)] p-4"
           >
             <p
               class="text-label-medium uppercase tracking-[0.2em] text-[var(--md-sys-color-on-surface-variant)]"

--- a/src/pages/ValidationReport.vue
+++ b/src/pages/ValidationReport.vue
@@ -17,10 +17,7 @@
             </p>
           </div>
           <div class="grid gap-3 sm:grid-cols-2">
-            <div
-              class="md-surface-container md-elevation-1 rounded-3xl p-4"
-              :style="{ borderRadius: 'var(--md-sys-border-radius-large)' }"
-            >
+            <div class="md-surface-container md-elevation-1 md-shape-large p-4">
               <p class="md-typescale-label-small tracking-[0.18em] text-on-surface-variant">
                 Disciplinas avaliadas
               </p>
@@ -29,7 +26,7 @@
               </p>
             </div>
             <div
-              class="md-surface-container-high md-elevation-1 rounded-3xl border border-transparent p-4"
+              class="md-surface-container-high md-elevation-1 md-shape-large border border-transparent p-4"
             >
               <p class="md-typescale-label-small tracking-[0.18em] text-on-surface-variant">
                 Lições com apontamentos
@@ -41,10 +38,7 @@
           </div>
         </div>
         <dl class="mt-6 grid gap-4 sm:grid-cols-3">
-          <div
-            class="md-surface-container md-elevation-1 rounded-3xl p-4"
-            :style="{ borderRadius: 'var(--md-sys-border-radius-large)' }"
-          >
+          <div class="md-surface-container md-elevation-1 md-shape-large p-4">
             <dt class="md-typescale-label-small tracking-[0.18em] text-on-surface-variant">
               Lições avaliadas
             </dt>
@@ -52,10 +46,7 @@
               {{ report.totals.lessons }}
             </dd>
           </div>
-          <div
-            class="md-surface-container md-elevation-1 rounded-3xl p-4"
-            :style="{ borderRadius: 'var(--md-sys-border-radius-large)' }"
-          >
+          <div class="md-surface-container md-elevation-1 md-shape-large p-4">
             <dt class="md-typescale-label-small tracking-[0.18em] text-on-surface-variant">
               Problemas
             </dt>
@@ -63,10 +54,7 @@
               {{ report.totals.problems }}
             </dd>
           </div>
-          <div
-            class="md-surface-container md-elevation-1 rounded-3xl p-4"
-            :style="{ borderRadius: 'var(--md-sys-border-radius-large)' }"
-          >
+          <div class="md-surface-container md-elevation-1 md-shape-large p-4">
             <dt class="md-typescale-label-small tracking-[0.18em] text-on-surface-variant">
               Avisos
             </dt>
@@ -102,7 +90,7 @@
               <tr
                 v-for="course in sortedCourses"
                 :key="course.id"
-                class="rounded-3xl bg-[var(--md-sys-color-surface-container-high)] md-typescale-body-medium text-on-surface"
+                class="md-shape-extra-large bg-[var(--md-sys-color-surface-container-high)] md-typescale-body-medium text-on-surface"
               >
                 <td class="rounded-l-3xl px-4 py-3 font-semibold uppercase tracking-[0.12em]">
                   {{ course.id }}
@@ -158,7 +146,7 @@
                   <tr
                     v-for="summary in category.rows"
                     :key="summary.course"
-                    class="rounded-3xl bg-[var(--md-sys-color-surface-container-high)] md-typescale-body-medium text-on-surface"
+                    class="md-shape-extra-large bg-[var(--md-sys-color-surface-container-high)] md-typescale-body-medium text-on-surface"
                   >
                     <td class="rounded-l-3xl px-4 py-3 font-semibold uppercase tracking-[0.12em]">
                       {{ summary.course }}
@@ -182,7 +170,7 @@
         </div>
         <div
           v-else
-          class="mt-6 rounded-3xl bg-[var(--md-sys-color-surface-container-high)] p-6 text-center"
+          class="mt-6 md-shape-extra-large bg-[var(--md-sys-color-surface-container-high)] p-6 text-center"
         >
           <p class="md-typescale-title-medium font-semibold text-on-surface">
             Nenhum material registrado
@@ -208,7 +196,7 @@
           <article
             v-for="course in coursesWithIssues"
             :key="course.id"
-            class="md-surface-container md-elevation-1 rounded-3xl p-5"
+            class="md-surface-container md-elevation-1 md-shape-extra-large p-5"
           >
             <header class="flex flex-wrap items-center gap-3">
               <span class="chip font-semibold uppercase tracking-[0.12em]">{{ course.id }}</span>
@@ -262,7 +250,7 @@
         </div>
         <div
           v-else
-          class="mt-6 rounded-3xl bg-[var(--md-sys-color-surface-container-high)] p-6 text-center"
+          class="mt-6 md-shape-extra-large bg-[var(--md-sys-color-surface-container-high)] p-6 text-center"
         >
           <p class="md-typescale-title-medium font-semibold text-on-surface">
             Nenhuma pendência encontrada


### PR DESCRIPTION
## Summary
- add reusable `.md-shape-*` utilities and a `card--compact` variant mapped to Material Design shape tokens
- refactor Home and Validation Report pages to use the new utilities/variant instead of inline border radius styles, ensuring compact widgets keep the large radius
- document the official card curvature usage for surfaces and widgets in the design system guidelines

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d96433a004832cb3feca4199726dc3