### PR TITLE
Improve pill accessibility states

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -2013,6 +2013,14 @@ html {
     transition: all 130ms ease;
   }
 
+  .pill-item:focus-visible {
+    outline: 3px solid color-mix(in srgb, var(--md-sys-color-primary) 60%, transparent 40%);
+    outline-offset: 2px;
+    box-shadow:
+      0 0 0 3px color-mix(in srgb, var(--md-sys-color-primary) 24%, transparent 76%),
+      var(--shadow-elevation-1);
+  }
+
   .pill-item:hover {
     background-color: var(--md-sys-state-layer-on-surface);
     color: var(--md-sys-color-on-surface);

--- a/src/pages/CourseHome.vue
+++ b/src/pages/CourseHome.vue
@@ -5,6 +5,7 @@
         <button
           class="pill-item"
           :class="{ 'pill-item--active': contentFilter === 'all' }"
+          :aria-pressed="contentFilter === 'all'"
           type="button"
           @click="updateSection('all')"
         >
@@ -13,6 +14,7 @@
         <button
           class="pill-item"
           :class="{ 'pill-item--active': contentFilter === 'lesson' }"
+          :aria-pressed="contentFilter === 'lesson'"
           type="button"
           @click="updateSection('lesson')"
         >
@@ -21,6 +23,7 @@
         <button
           class="pill-item"
           :class="{ 'pill-item--active': contentFilter === 'exercise' }"
+          :aria-pressed="contentFilter === 'exercise'"
           type="button"
           @click="updateSection('exercise')"
         >
@@ -31,6 +34,7 @@
         <button
           class="pill-item"
           :class="{ 'pill-item--active': viewMode === 'grid' }"
+          :aria-pressed="viewMode === 'grid'"
           type="button"
           @click="viewMode = 'grid'"
         >
@@ -40,6 +44,7 @@
         <button
           class="pill-item"
           :class="{ 'pill-item--active': viewMode === 'list' }"
+          :aria-pressed="viewMode === 'list'"
           type="button"
           @click="viewMode = 'list'"
         >


### PR DESCRIPTION
## Summary
- set aria-pressed on CourseHome filter and view mode pills to reflect active state
- add Material Design 3 inspired focus-visible outline and shadow to pill buttons for keyboard users

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d96879735c832cbc509c4763c25465