### PR TITLE
Define spacing token for timeline layout

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -111,6 +111,7 @@
   --md-sys-spacing-4: 1rem; /* 16px */
   --md-sys-spacing-5: 1.25rem; /* 20px */
   --md-sys-spacing-6: 1.5rem; /* 24px */
+  --md-sys-spacing-7: 1.75rem; /* 28px */
   --md-sys-spacing-8: 2rem; /* 32px */
   --md-sys-spacing-10: 2.5rem; /* 40px */
   --md-sys-spacing-12: 3rem; /* 48px */


### PR DESCRIPTION
## Summary
- add the missing Material spacing token `--md-sys-spacing-7`
- ensure the timeline component can reference the restored spacing scale

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d96acb4518832cabacfd38807f3cd5