### PR TITLE
Ensure callout videos have accessible names

### DIFF
--- a/src/components/lesson/Callout.vue
+++ b/src/components/lesson/Callout.vue
@@ -45,7 +45,8 @@
             <div class="callout__video-frame">
               <iframe
                 :src="block.src"
-                title="Video player"
+                :title="resolveVideoAccessibleName(block, index)"
+                :aria-label="resolveVideoAccessibleName(block, index)"
                 loading="lazy"
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                 allowfullscreen
@@ -168,6 +169,16 @@ function isPlainText(language?: string) {
   }
   const normalized = language.toLowerCase();
   return normalized === 'plaintext' || normalized === 'pseudocode' || normalized === 'text';
+}
+
+function resolveVideoAccessibleName(block: RichVideo, index: number): string {
+  const trimmedTitle = typeof block.title === 'string' ? block.title.trim() : '';
+
+  if (trimmedTitle.length > 0) {
+    return trimmedTitle;
+  }
+
+  return `Vídeo do callout ${index + 1}`;
 }
 </script>
 


### PR DESCRIPTION
## Summary
- make callout video iframe titles reactive to the block title and provide a translated fallback
- reuse the same accessible name for both the iframe title and aria-label to keep them synchronized

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d96bc3d934832cb4509338c7bcd8fc