### PR TITLE
Align CodeBlock MD3 border radius token

### DIFF
--- a/src/components/lesson/CodeBlock.vue
+++ b/src/components/lesson/CodeBlock.vue
@@ -155,6 +155,7 @@ watch(
   --_content-padding-block: var(--md-sys-spacing-4);
 
   background-color: var(--md-sys-color-surface-container);
+  /* Replica o raio dos cards MD3, com fallback para projetos legados */
   border-radius: var(--md-sys-shape-corner-extra-large, var(--md-sys-border-radius-xl));
   margin-block: var(--code-block-spacing, 0);
   overflow: hidden;


### PR DESCRIPTION
## Summary
- document the CodeBlock border radius token to use the MD3 extra-large shape fallback

## Testing
- npm run storybook -- --no-open

------
https://chatgpt.com/codex/tasks/task_e_68d9904952e4832c963b23a6cff01e44