### PR TITLE
Update CodeBlock toolbar icons to use MD icon sizing

### DIFF
--- a/src/components/lesson/CodeBlock.vue
+++ b/src/components/lesson/CodeBlock.vue
@@ -16,8 +16,10 @@
           @click="copyCode"
         >
           <template #leading>
-            <Check v-if="copied" :size="18" aria-hidden="true" />
-            <Copy v-else :size="18" aria-hidden="true" />
+            <span class="md-icon md-icon--md" aria-hidden="true">
+              <Check v-if="copied" />
+              <Copy v-else />
+            </span>
           </template>
         </Md3Button>
       </div>


### PR DESCRIPTION
## Summary
- wrap CodeBlock toolbar icons with the md-icon classes so sizing comes from global tokens
- remove explicit size attributes from the Check and Copy icons while preserving the Md3Button behavior

## Testing
- npm run build-storybook -- --quiet

------
https://chatgpt.com/codex/tasks/task_e_68d990fb1b98832cb579308fed31c319