### PR TITLE
Adjust card surface mix and border contrast

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -1553,14 +1553,14 @@ html {
     position: relative;
     background: color-mix(
       in srgb,
-      var(--md-sys-color-surface-container-highest, var(--md-sys-color-surface)) 94%,
-      var(--md-sys-color-surface) 6%
+      var(--md-sys-color-surface-container, var(--md-sys-color-surface)) 65%,
+      var(--md-sys-color-surface, #ffffff) 35%
     );
     color: var(--md-sys-color-on-surface);
     border: 1px solid
       color-mix(
         in srgb,
-        var(--md-sys-color-outline-variant, var(--md-sys-color-outline)) 55%,
+        var(--md-sys-color-outline-variant, var(--md-sys-color-outline)) 70%,
         transparent
       );
     border-radius: var(--md-sys-shape-corner-extra-large, 1.5rem);


### PR DESCRIPTION
## Summary
- lighten the card surface background by using the surface-container token mix for better harmony with page backgrounds
- increase the outline-variant mix on card borders to maintain AA contrast, especially in dark mode

## Testing
- npm run lint *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d994bc74c0832cafa849f781434830