### PR TITLE
Fix icon button spacing

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -1549,6 +1549,14 @@ html {
     margin-inline-start: 0.5rem;
   }
 
+  .md3-button--icon .md3-button__icon--leading {
+    margin-inline-end: 0;
+  }
+
+  .md3-button--icon .md3-button__icon--trailing {
+    margin-inline-start: 0;
+  }
+
   .card {
     position: relative;
     background: color-mix(

--- a/src/components/Md3Button.vue
+++ b/src/components/Md3Button.vue
@@ -1,12 +1,26 @@
 <template>
   <component :is="resolvedTag" v-bind="componentAttrs" :class="buttonClasses">
-    <span v-if="hasLeading" class="md3-button__icon md3-button__icon--leading">
+    <span
+      v-if="hasLeading"
+      :class="[
+        'md3-button__icon',
+        'md3-button__icon--leading',
+        { 'md3-button__icon--icon-only': iconOnly },
+      ]"
+    >
       <slot name="leading" />
     </span>
-    <span v-if="!iconOnly || hasDefaultSlot" class="md3-button__label">
+    <span v-if="!iconOnly" class="md3-button__label">
       <slot />
     </span>
-    <span v-if="hasTrailing" class="md3-button__icon md3-button__icon--trailing">
+    <span
+      v-if="hasTrailing"
+      :class="[
+        'md3-button__icon',
+        'md3-button__icon--trailing',
+        { 'md3-button__icon--icon-only': iconOnly },
+      ]"
+    >
       <slot name="trailing" />
     </span>
   </component>
@@ -54,7 +68,7 @@ const resolvedTag = computed(() => props.as ?? props.tag ?? 'button');
 const hasLeading = computed(() => Boolean(slots.leading));
 const hasTrailing = computed(() => Boolean(slots.trailing));
 const hasDefaultSlot = computed(() => Boolean(slots.default));
-const iconOnly = computed(() => props.icon);
+const iconOnly = computed(() => props.icon && !hasDefaultSlot.value);
 const isButtonTag = computed(() => resolvedTag.value === 'button');
 
 const componentAttrs = computed(() => {
@@ -84,7 +98,7 @@ const buttonClasses = computed(() => [
   'md3-button',
   `md3-button--${props.variant}`,
   {
-    'md3-button--icon': props.icon,
+    'md3-button--icon': iconOnly.value,
     'md3-button--full-width': props.fullWidth,
   },
 ]);


### PR DESCRIPTION
## Summary
- reset the icon margin offsets for MD3 icon-only buttons in the global stylesheet
- update Md3Button to expose icon-only state on icon spans and only add the icon variant class when the label is hidden

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d996777d80832ca1a38ea19a6da251