### PR TITLE
Align chip and callout colors with MD tokens

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -2081,13 +2081,21 @@ html {
 }
 
 .chip--available {
-  background-color: color-mix(in srgb, #2e7d32 22%, var(--md-sys-color-surface) 78%);
-  color: #1b5e20;
+  background-color: color-mix(
+    in srgb,
+    var(--md-sys-color-success) 22%,
+    var(--md-sys-color-success-container) 78%
+  );
+  color: var(--md-sys-color-on-success-container);
 }
 
 .chip--upcoming {
-  background-color: color-mix(in srgb, #facc15 24%, var(--md-sys-color-surface) 76%);
-  color: #8a540a;
+  background-color: color-mix(
+    in srgb,
+    var(--md-sys-color-warning) 24%,
+    var(--md-sys-color-warning-container) 76%
+  );
+  color: var(--md-sys-color-on-warning-container);
 }
 
 html[data-theme='dark'] .chip--lesson {
@@ -2109,13 +2117,21 @@ html[data-theme='dark'] .chip--exercise {
 }
 
 html[data-theme='dark'] .chip--available {
-  background-color: color-mix(in srgb, #66bb6a 32%, var(--md-sys-color-surface) 68%);
-  color: #f1fbf2;
+  background-color: color-mix(
+    in srgb,
+    var(--md-sys-color-success) 32%,
+    var(--md-sys-color-on-success-container) 68%
+  );
+  color: var(--md-sys-color-on-success);
 }
 
 html[data-theme='dark'] .chip--upcoming {
-  background-color: color-mix(in srgb, #facc15 34%, var(--md-sys-color-surface) 66%);
-  color: #fff6d1;
+  background-color: color-mix(
+    in srgb,
+    var(--md-sys-color-warning) 34%,
+    var(--md-sys-color-on-warning-container) 66%
+  );
+  color: var(--md-sys-color-on-warning);
 }
 
 /* Estilos para código inline */

--- a/src/components/lesson/Callout.vue
+++ b/src/components/lesson/Callout.vue
@@ -310,10 +310,10 @@ function resolveVideoAccessibleName(block: RichVideo, index: number): string {
 }
 
 .callout--warning {
-  --callout-bg: var(--md-sys-color-warning-container, #fff3cd);
-  --callout-border: color-mix(in srgb, var(--md-sys-color-warning, #f59e0b) 40%, transparent);
-  --callout-text: var(--md-sys-color-on-warning-container, #7c5800);
-  --callout-accent: var(--md-sys-color-warning, #f59e0b);
+  --callout-bg: var(--md-sys-color-warning-container);
+  --callout-border: color-mix(in srgb, var(--md-sys-color-warning) 40%, transparent);
+  --callout-text: var(--md-sys-color-on-warning-container);
+  --callout-accent: var(--md-sys-color-warning);
 }
 
 .callout--academic {


### PR DESCRIPTION
## Summary
- harmonize available and upcoming chip colors using the success and warning token palettes in both themes
- drop fallback hex values from the warning callout so it relies solely on design tokens

## Testing
- rg '#facc15'
- rg '#2e7d32'

------
https://chatgpt.com/codex/tasks/task_e_68d99a68775c832ca0336d2393f6ac26