### PR TITLE
Update offline palette tokens

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -6,17 +6,24 @@
     <title>Você está offline</title>
     <style>
       :root {
-        color-scheme: dark;
-        --surface: #161b28;
-        --on-surface: #e2e7f2;
-        --outline: #2f384d;
-        --primary: #90caf9;
-        --primary-on: #082f63;
+        color-scheme: light;
+        --md-sys-color-surface: #fefbff;
+        --md-sys-color-on-surface: #1b1b1f;
+        --md-sys-color-outline: #757680;
+        --md-sys-color-primary: #0053db;
+        --md-sys-color-on-primary: #ffffff;
       }
       body {
         font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-        background: radial-gradient(circle at top, rgba(144, 202, 249, 0.12), transparent 60%), var(--surface);
-        color: var(--on-surface);
+        background-color: var(--md-sys-color-surface, #fefbff);
+        background:
+          radial-gradient(
+            circle at top,
+            color-mix(in srgb, var(--md-sys-color-primary, #0053db) 12%, transparent) 0%,
+            transparent 60%
+          ),
+          var(--md-sys-color-surface, #fefbff);
+        color: var(--md-sys-color-on-surface, #1b1b1f);
         display: grid;
         place-items: center;
         min-height: 100vh;
@@ -24,8 +31,13 @@
         padding: 24px;
       }
       .card {
-        background: rgba(22, 27, 40, 0.85);
-        border: 1px solid var(--outline);
+        background-color: var(--md-sys-color-surface, #fefbff);
+        background: color-mix(
+          in srgb,
+          var(--md-sys-color-surface, #fefbff) 92%,
+          rgba(0, 0, 0, 0.08)
+        );
+        border: 1px solid var(--md-sys-color-outline, #757680);
         border-radius: 24px;
         padding: 32px;
         max-width: 520px;
@@ -48,8 +60,8 @@
         padding: 10px 18px;
         border-radius: 999px;
         text-decoration: none;
-        background: var(--primary);
-        color: var(--primary-on);
+        background: var(--md-sys-color-primary, #0053db);
+        color: var(--md-sys-color-on-primary, #ffffff);
         font-weight: 600;
       }
     </style>


### PR DESCRIPTION
## Summary
- replace legacy offline palette variables with Material tokens and shared fallbacks
- update offline body, card, and link styles to consume the Material color tokens
- ensure graceful fallbacks for gradients and surfaces while keeping the offline page self-contained

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d99a698da0832c99119b23ec367949