### PR TITLE
Atualiza meta theme-color dinamicamente

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="theme-color" content="#0B0F19" />
+    <meta name="theme-color" content="" id="app-theme-color" />
     <!-- Inter font to match ALG1 look -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/theme/material-theme.ts
+++ b/src/theme/material-theme.ts
@@ -119,6 +119,7 @@ function applyScheme(mode: ThemeMode) {
   const scheme: Scheme = mode === 'dark' ? materialTheme.schemes.dark : materialTheme.schemes.light;
   const palette = scheme.toJSON() as Record<string, number | string>;
   const rootStyle = document.documentElement.style;
+  const themeColorMeta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
 
   COLOR_ROLE_TOKENS.forEach((token) => {
     const value = palette[token];
@@ -129,6 +130,13 @@ function applyScheme(mode: ThemeMode) {
 
   const primary = toHex(palette.primary);
   const onSurface = toHex(palette.onSurface);
+  const background = toHex(palette.background);
+  const surface = toHex(palette.surface);
+
+  if (themeColorMeta) {
+    const themeColor = mode === 'dark' ? surface : background;
+    themeColorMeta.content = themeColor;
+  }
 
   rootStyle.setProperty(
     '--md-sys-state-layer-primary',


### PR DESCRIPTION
## Summary
- remove o valor estático do meta theme-color para permitir atualização dinâmica
- sincroniza o meta theme-color com as cores de background/surface do esquema ativo

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d99a6ac7f8832c949ed58e74458af4