### PR TITLE
Align offline offline page with MD3 tokens

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -7,22 +7,10 @@
     <style>
       :root {
         color-scheme: light;
-        --md-sys-color-surface: #fefbff;
-        --md-sys-color-on-surface: #1b1b1f;
-        --md-sys-color-outline: #757680;
-        --md-sys-color-primary: #0053db;
-        --md-sys-color-on-primary: #ffffff;
       }
       body {
         font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
         background-color: var(--md-sys-color-surface, #fefbff);
-        background:
-          radial-gradient(
-            circle at top,
-            color-mix(in srgb, var(--md-sys-color-primary, #0053db) 12%, transparent) 0%,
-            transparent 60%
-          ),
-          var(--md-sys-color-surface, #fefbff);
         color: var(--md-sys-color-on-surface, #1b1b1f);
         display: grid;
         place-items: center;
@@ -32,11 +20,6 @@
       }
       .card {
         background-color: var(--md-sys-color-surface, #fefbff);
-        background: color-mix(
-          in srgb,
-          var(--md-sys-color-surface, #fefbff) 92%,
-          rgba(0, 0, 0, 0.08)
-        );
         border: 1px solid var(--md-sys-color-outline, #757680);
         border-radius: 24px;
         padding: 32px;
@@ -60,7 +43,7 @@
         padding: 10px 18px;
         border-radius: 999px;
         text-decoration: none;
-        background: var(--md-sys-color-primary, #0053db);
+        background-color: var(--md-sys-color-primary, #0053db);
         color: var(--md-sys-color-on-primary, #ffffff);
         font-weight: 600;
       }


### PR DESCRIPTION
## Summary
- remove local color variable declarations from the offline fallback page
- rely on MD3 color tokens with global fallbacks for the body, card, and retry link
- drop the unsupported gradient background so the offline page matches the palette

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d99c0c8ed4832c9976c29fddf064ff