### PR TITLE
Update success and warning chip colors

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -1520,21 +1520,13 @@ html {
   }
 
   .chip--success {
-    background-color: color-mix(
-      in srgb,
-      var(--md-sys-color-primary) 18%,
-      var(--md-sys-color-surface) 82%
-    );
-    color: var(--md-sys-color-on-primary-container);
+    background-color: var(--md-sys-color-success-container);
+    color: var(--md-sys-color-on-success-container);
   }
 
   .chip--warning {
-    background-color: color-mix(
-      in srgb,
-      var(--md-sys-color-secondary) 12%,
-      var(--md-sys-color-surface) 88%
-    );
-    color: var(--md-sys-color-secondary);
+    background-color: var(--md-sys-color-warning-container);
+    color: var(--md-sys-color-on-warning-container);
   }
 
   .chip--error {
@@ -1914,6 +1906,16 @@ html[data-theme='dark'] .chip--exercise {
     var(--md-sys-color-surface) 70%
   );
   color: var(--md-sys-color-on-secondary-container);
+}
+
+html[data-theme='dark'] .chip--success {
+  background-color: var(--md-sys-color-success);
+  color: var(--md-sys-color-on-success);
+}
+
+html[data-theme='dark'] .chip--warning {
+  background-color: var(--md-sys-color-warning);
+  color: var(--md-sys-color-on-warning);
 }
 
 html[data-theme='dark'] .chip--available {


### PR DESCRIPTION
## Summary
- align success and warning chip backgrounds with the semantic success/warning container tokens
- add dark theme overrides so the success and warning chips keep proper contrast
- reviewed ValidationReport and ValidationWorkbench chip usages to confirm the semantic classes remain correct

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d99e47b704832c8c7c188239c7ae02