### PR TITLE
Harmonize truth table error state styling

### DIFF
--- a/src/components/lesson/TruthTable.vue
+++ b/src/components/lesson/TruthTable.vue
@@ -467,14 +467,11 @@ export type {
 }
 
 .md3-truth-table__cell.is-false {
-  background-color: rgba(244, 67, 54, 0.16);
-  color: var(--md-sys-color-error);
+  background-color: var(--md-sys-color-error-container);
+  color: var(--md-sys-color-on-error-container);
+  border-color: var(--md-sys-color-error);
+  border-color: color-mix(in srgb, var(--md-sys-color-error) 45%, transparent);
   font-weight: 600;
-}
-
-:root[data-theme='dark'] .md3-truth-table__cell.is-false {
-  background-color: rgba(239, 83, 80, 0.24);
-  color: var(--md-sys-color-on-error);
 }
 
 .md3-truth-table__cell.is-emphasis {
@@ -526,15 +523,10 @@ export type {
 }
 
 .md3-truth-table__legend-item.is-false {
-  background-color: rgba(244, 67, 54, 0.16);
-  color: var(--md-sys-color-error);
-  border-color: rgba(244, 67, 54, 0.32);
-}
-
-:root[data-theme='dark'] .md3-truth-table__legend-item.is-false {
-  background-color: rgba(239, 83, 80, 0.24);
-  color: var(--md-sys-color-on-error);
-  border-color: rgba(239, 83, 80, 0.4);
+  background-color: var(--md-sys-color-error-container);
+  color: var(--md-sys-color-on-error-container);
+  border-color: var(--md-sys-color-error);
+  border-color: color-mix(in srgb, var(--md-sys-color-error) 45%, transparent);
 }
 
 .md3-truth-table__legend-item.is-emphasis {


### PR DESCRIPTION
## Summary
- replace hard-coded rgba colors in the truth table "false" state with Material Design token values
- remove dark-theme specific overrides so the component adapts automatically to the active palette
- align the legend border treatment with the error tone using color-mix and a token fallback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d99e49e204832cabbf88580c15f820