### PR TITLE
Align lesson chart outlines with Material outline palette

### DIFF
--- a/src/components/lesson/LessonChart.vue
+++ b/src/components/lesson/LessonChart.vue
@@ -167,6 +167,11 @@ function formatNumber(value: number): string {
   flex-direction: column;
   gap: var(--md-sys-spacing-4);
   box-shadow: var(--shadow-elevation-1);
+  --lesson-chart-ring: color-mix(
+    in srgb,
+    var(--md-sys-color-outline-variant) 60%,
+    var(--md-sys-color-surface)
+  );
 }
 
 .lesson-chart__header {
@@ -200,7 +205,7 @@ function formatNumber(value: number): string {
   width: 200px;
   height: 200px;
   border-radius: 50%;
-  box-shadow: inset 0 0 0 8px rgba(0, 0, 0, 0.05);
+  box-shadow: inset 0 0 0 8px var(--lesson-chart-ring);
 }
 
 .lesson-chart__pie-total {
@@ -275,7 +280,7 @@ function formatNumber(value: number): string {
   width: 1rem;
   height: 1rem;
   border-radius: 0.25rem;
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+  box-shadow: inset 0 0 0 1px var(--lesson-chart-ring);
 }
 
 .lesson-chart__legend-text {


### PR DESCRIPTION
## Summary
- derive a lesson chart ring color from the Material outline variant mixed with the surface tone
- reuse the shared ring color for the pie chart rim and legend swatches to harmonize the component styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d99e4a6f50832c95e645276a39d656