### PR TITLE
Align FAB styling with Material 3 tokens

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,6 @@
         <template #leading>
           <ArrowUp class="md-icon" aria-hidden="true" />
         </template>
-        <span class="sr-only">Voltar ao topo</span>
       </Md3Button>
     </transition>
   </div>

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -1602,8 +1602,13 @@ html {
     min-width: 3.5rem;
     min-height: 3.5rem;
     padding: 0;
+    --md3-button-container: var(--md-sys-color-primary-container);
+    --md3-button-color: var(--md-sys-color-on-primary-container);
+    --md3-button-outline-color: var(--md-sys-color-primary-container);
+    --md3-button-shadow: var(--shadow-elevation-2);
+    --md3-button-state-layer: var(--md-sys-state-layer-on-primary-container);
     border-radius: var(--md-sys-border-radius-4xl);
-    box-shadow: var(--shadow-elevation-2);
+    box-shadow: var(--md3-button-shadow);
     transition:
       transform 180ms ease,
       box-shadow 180ms ease;
@@ -1622,6 +1627,12 @@ html {
   .md3-fab .md-icon {
     width: var(--md-sys-icon-size-medium);
     height: var(--md-sys-icon-size-medium);
+  }
+
+  .md3-fab .md3-button__icon--leading,
+  .md3-fab .md3-button__icon--trailing {
+    margin-inline-start: 0;
+    margin-inline-end: 0;
   }
 
   @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- align the floating action button tokens with the Material 3 primary container palette
- remove the redundant sr-only label so Md3Button treats the FAB as icon-only and centers the icon
- zero out icon margins in the FAB to avoid offset when no visible label is present

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9bbdd0678832cb4556b9a545a071d