### PR TITLE
Align lesson surfaces with MD3 card shapes

### DIFF
--- a/src/components/lesson/Callout.vue
+++ b/src/components/lesson/Callout.vue
@@ -184,15 +184,23 @@ function resolveVideoAccessibleName(block: RichVideo, index: number): string {
 
 <style scoped>
 .callout {
-  --callout-bg: var(--md-sys-color-surface-container);
-  --callout-border: color-mix(in srgb, var(--md-sys-color-outline) 60%, transparent);
+  --callout-bg: color-mix(
+    in srgb,
+    var(--md-sys-color-surface-container, var(--md-sys-color-surface)) 65%,
+    var(--md-sys-color-surface, #ffffff) 35%
+  );
+  --callout-border: color-mix(
+    in srgb,
+    var(--md-sys-color-outline-variant, var(--md-sys-color-outline)) 70%,
+    transparent
+  );
   --callout-text: var(--md-sys-color-on-surface);
   --callout-accent: var(--md-sys-color-primary);
   display: grid;
   grid-template-columns: auto 1fr;
   gap: var(--md-sys-spacing-4);
   padding: var(--md-sys-spacing-5);
-  border-radius: var(--md-sys-border-radius-large);
+  border-radius: var(--md-sys-shape-corner-extra-large, var(--md-sys-border-radius-large));
   background: var(--callout-bg);
   border: 1px solid var(--callout-border);
   color: var(--callout-text);
@@ -268,7 +276,7 @@ function resolveVideoAccessibleName(block: RichVideo, index: number): string {
 .callout__video-frame {
   position: relative;
   padding-top: 56.25%;
-  border-radius: var(--md-sys-border-radius-large);
+  border-radius: var(--md-sys-shape-corner-large, var(--md-sys-border-radius-large));
   overflow: hidden;
   box-shadow: var(--shadow-elevation-1);
 }

--- a/src/components/lesson/Roadmap.vue
+++ b/src/components/lesson/Roadmap.vue
@@ -31,8 +31,18 @@ defineProps<{ steps: RoadmapStep[] }>();
   align-items: start;
   gap: var(--md-sys-spacing-3);
   padding: var(--md-sys-spacing-3);
-  border-radius: var(--md-sys-border-radius-large);
-  background: var(--md-sys-color-surface-container-high);
+  border-radius: var(--md-sys-shape-corner-extra-large, var(--md-sys-border-radius-large));
+  background: color-mix(
+    in srgb,
+    var(--md-sys-color-surface-container-high, var(--md-sys-color-surface)) 70%,
+    var(--md-sys-color-surface, #ffffff) 30%
+  );
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--md-sys-color-outline-variant, var(--md-sys-color-outline)) 70%,
+      transparent
+    );
   box-shadow: var(--shadow-elevation-1);
 }
 

--- a/src/components/lesson/Timeline.vue
+++ b/src/components/lesson/Timeline.vue
@@ -44,13 +44,23 @@ function sanitizeContent(value: unknown): string {
 
 <style scoped>
 .lesson-timeline {
-  background: var(--md-sys-color-surface-container);
-  border-radius: var(--md-sys-border-radius-large);
+  background: color-mix(
+    in srgb,
+    var(--md-sys-color-surface-container, var(--md-sys-color-surface)) 65%,
+    var(--md-sys-color-surface, #ffffff) 35%
+  );
+  border-radius: var(--md-sys-shape-corner-extra-large, var(--md-sys-border-radius-large));
   padding: var(--md-sys-spacing-6) var(--md-sys-spacing-7);
   display: flex;
   flex-direction: column;
   gap: var(--md-sys-spacing-5);
   box-shadow: var(--shadow-elevation-1);
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--md-sys-color-outline-variant, var(--md-sys-color-outline)) 70%,
+      transparent
+    );
 }
 
 .lesson-timeline__title {
@@ -119,7 +129,7 @@ function sanitizeContent(value: unknown): string {
   flex-direction: column;
   gap: var(--md-sys-spacing-1);
   padding: var(--md-sys-spacing-4);
-  border-radius: var(--md-sys-border-radius-large);
+  border-radius: var(--md-sys-shape-corner-large, var(--md-sys-border-radius-large));
   background: color-mix(in srgb, var(--md-sys-color-surface) 85%, transparent 15%);
   box-shadow: var(--shadow-elevation-1);
 }


### PR DESCRIPTION
## Summary
- update Callout, Timeline, and Roadmap containers to share the MD3 extra-large corner shape
- reuse the card surface background, border, and shadow tokens so these blocks match card contrast in both themes
- adjust nested elements where needed and confirm lesson stories continue to match surrounding MD3 cards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9c13cdcb8832c8528dd4ef4282bdb