### PR TITLE
Automate governance prep and publish shared calendar

### DIFF
--- a/docs/governance/faculty-review-sessions.ics
+++ b/docs/governance/faculty-review-sessions.ics
@@ -1,0 +1,52 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Edu Governance//Faculty Review Sessions//PT
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+BEGIN:VTIMEZONE
+TZID:America/Fortaleza
+X-LIC-LOCATION:America/Fortaleza
+BEGIN:STANDARD
+TZOFFSETFROM:-0300
+TZOFFSETTO:-0300
+TZNAME:BRT
+DTSTART:19700101T000000
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:faculty-review-20240325T100000-ALGI@edu
+DTSTAMP:20250121T120000Z
+DTSTART;TZID=America/Fortaleza:20240325T100000
+DTEND;TZID=America/Fortaleza:20240325T110000
+SUMMARY:Revisão Docentes - Semana 1 (ALGI)
+DESCRIPTION:Saneamento das aulas 01-08 e definição de componentes MD3 essenciais (TruthTable, Flowchart, Simulador). Entregáveis: lista de blocos a migrar, backlog de exercícios revisados e ata com responsáveis.
+LOCATION:Reunião online (Google Meet ou Microsoft Teams)
+END:VEVENT
+BEGIN:VEVENT
+UID:faculty-review-20240401T100000-DDM@edu
+DTSTAMP:20250121T120000Z
+DTSTART;TZID=America/Fortaleza:20240401T100000
+DTEND;TZID=America/Fortaleza:20240401T110000
+SUMMARY:Revisão Docentes - Semana 2 (DDM)
+DESCRIPTION:Reorganização por sprints, atualização de referências (Compose, SwiftUI, Flutter) e definição de novos componentes (Painel de Arquitetura, Checklist de Loja). Entregáveis: cronograma de atualização, componentes priorizados e fontes oficiais.
+LOCATION:Reunião online (Google Meet ou Microsoft Teams)
+END:VEVENT
+BEGIN:VEVENT
+UID:faculty-review-20240408T100000-LPOO@edu
+DTSTAMP:20250121T120000Z
+DTSTART;TZID=America/Fortaleza:20240408T100000
+DTEND;TZID=America/Fortaleza:20240408T110000
+SUMMARY:Revisão Docentes - Semana 3 (LPOO)
+DESCRIPTION:Alinhamento de casos práticos e componentes UML interativos (Class Designer, Interaction Diagram). Entregáveis: especificações dos componentes e plano de exercícios práticos com GitHub Classroom.
+LOCATION:Reunião online (Google Meet ou Microsoft Teams)
+END:VEVENT
+BEGIN:VEVENT
+UID:faculty-review-20240415T100000-TDJD-TGS@edu
+DTSTAMP:20250121T120000Z
+DTSTART;TZID=America/Fortaleza:20240415T100000
+DTEND;TZID=America/Fortaleza:20240415T110000
+SUMMARY:Revisão Docentes - Semana 4 (TDJD & TGS)
+DESCRIPTION:Atualização tecnológica (Unity 6, Godot 4, estudos de caso ESG) e componentes sistêmicos (Pipeline Canvas, System Mapper). Entregáveis: plano de revisão de conteúdo, lista de assets e matriz de competências atualizada.
+LOCATION:Reunião online (Google Meet ou Microsoft Teams)
+END:VEVENT
+END:VCALENDAR

--- a/docs/governance/faculty-review-sessions.md
+++ b/docs/governance/faculty-review-sessions.md
@@ -35,6 +35,8 @@ O objetivo destas sessões é revisar, corrigir e preparar os materiais atuais a
 | Semana 3 | **LPOO**           | Alinhamento de casos práticos e componentes UML interativos (Class Designer, Interaction Diagram)                                                             | Especificação dos novos componentes, plano de exercícios práticos com GitHub Classroom |
 | Semana 4 | **TDJD** & **TGS** | Atualização tecnológica (Unity 6, Godot 4, estudos de caso ESG) e componentes sistêmicos (Pipeline Canvas, System Mapper)                                     | Plano de revisão de conteúdo, lista de assets, matriz de competências atualizada       |
 
+> A agenda compartilhada está disponível no arquivo [docs/governance/faculty-review-sessions.ics](./faculty-review-sessions.ics). Importe-o no Google Calendar ou Microsoft Teams para enviar convites recorrentes de 60 minutos em fuso **America/Fortaleza**.
+
 ## 4. Critérios de conclusão por sessão
 
 - Todas as lições revisadas possuem metadados completos (`summary`, `competencies`, `outcomes`, `metadata.updatedAt`).
@@ -53,8 +55,10 @@ O objetivo destas sessões é revisar, corrigir e preparar os materiais atuais a
 
 ## 6. Checklist operacional para cada encontro
 
-- [ ] Atualizar relatório `reports/content-validation-report.json` antes da reunião.
-- [ ] Preparar resumo dos blocos legados e pendências em `reports/governance-alert.md`.
+- [ ] Atualizar relatório `reports/content-validation-report.json` antes da reunião.  
+      _Execute `npm run validate:content` para gerar o arquivo automaticamente._
+- [ ] Preparar resumo dos blocos legados e pendências em `reports/governance-alert.md`.  
+      _Execute `npm run report:governance` para gerar o alerta consolidado (o comando já executa a validação antes do resumo)._
 - [ ] Confirmar presença dos participantes obrigatórios com 24h de antecedência.
 - [ ] Registrar decisões na ata compartilhada em até 24h após a sessão.
 - [ ] Atualizar status dos itens no backlog (`docs/material-redesign-plan.md` e issues associadas).
@@ -69,3 +73,54 @@ O objetivo destas sessões é revisar, corrigir e preparar os materiais atuais a
 ---
 
 > **Responsáveis:** squad de governança (design system + pedagogia) em parceria com lideranças de curso. Atualizações devem ser registradas neste documento a cada rodada de revisão.
+
+## 8. Agenda compartilhada e convites
+
+- Arquivo `.ics`: [docs/governance/faculty-review-sessions.ics](./faculty-review-sessions.ics)
+- Horário padrão: **10h00 – 11h00 (America/Fortaleza)** com reunião online (Google Meet ou Microsoft Teams).
+- Participantes sugeridos para o convite: docentes responsáveis, especialistas pedagógicos, squad de governança e apoio técnico indicado no início do documento.
+
+### Checklist rápido para importar
+
+1. Google Calendar: `Configurações` → `Importar e exportar` → `Importar` → selecionar o arquivo `.ics` e o calendário compartilhado da squad.
+2. Microsoft Teams: `Calendar` → `Add new calendar` → `Upload from file` → escolher o `.ics` e marcar a opção para compartilhar com o canal da disciplina.
+3. Após o import, adicione links das chamadas (Meet/Teams) diretamente na série recorrente e confirme a visibilidade dos convidados.
+
+## 9. Registro das sessões e indicadores
+
+Atualize os quadros abaixo logo após cada encontro, consolidando ata, pendências resolvidas e próximos passos. Utilize o relatório `reports/governance-alert.md` como base para os indicadores.
+
+### 9.1 Indicadores semanais
+
+| Semana                | Data       | Cobertura de revisão | Metadados completos | Componentes validados | Pendências críticas resolvidas | Observações                |
+| --------------------- | ---------- | -------------------- | ------------------- | --------------------- | ------------------------------ | -------------------------- |
+| Semana 1 (ALGI)       | 25/03/2024 | _Preencher_          | _Preencher_         | _Preencher_           | _Preencher_                    | _Notas e links relevantes_ |
+| Semana 2 (DDM)        | 01/04/2024 | _Preencher_          | _Preencher_         | _Preencher_           | _Preencher_                    | _Notas e links relevantes_ |
+| Semana 3 (LPOO)       | 08/04/2024 | _Preencher_          | _Preencher_         | _Preencher_           | _Preencher_                    | _Notas e links relevantes_ |
+| Semana 4 (TDJD & TGS) | 15/04/2024 | _Preencher_          | _Preencher_         | _Preencher_           | _Preencher_                    | _Notas e links relevantes_ |
+
+### 9.2 Ata sintética por sessão
+
+#### Semana 1 – ALGI (25/03/2024)
+
+- **Ata:** _Preencher com o link/registro oficial._
+- **Pendências resolvidas:** _Listar entregas confirmadas._
+- **Próximos passos:** _Definir responsáveis e prazos._
+
+#### Semana 2 – DDM (01/04/2024)
+
+- **Ata:** _Preencher com o link/registro oficial._
+- **Pendências resolvidas:** _Listar entregas confirmadas._
+- **Próximos passos:** _Definir responsáveis e prazos._
+
+#### Semana 3 – LPOO (08/04/2024)
+
+- **Ata:** _Preencher com o link/registro oficial._
+- **Pendências resolvidas:** _Listar entregas confirmadas._
+- **Próximos passos:** _Definir responsáveis e prazos._
+
+#### Semana 4 – TDJD & TGS (15/04/2024)
+
+- **Ata:** _Preencher com o link/registro oficial._
+- **Pendências resolvidas:** _Listar entregas confirmadas._
+- **Próximos passos:** _Definir responsáveis e prazos._

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "validate:report": "node scripts/validate-content.mjs --report",
     "report:observability": "node scripts/report-content-metrics.mjs",
     "report:observability:check": "node scripts/report-content-metrics.mjs --check",
-    "report:governance": "node scripts/generate-governance-alert.mjs",
+    "report:governance": "npm run validate:content && node scripts/generate-governance-alert.mjs",
     "report:governance:history": "node scripts/report-governance-history.mjs",
     "report:courses": "node scripts/report-course-summary.mjs",
     "teacher:service": "node scripts/teacher-automation-server.mjs",
@@ -67,7 +67,7 @@
   },
   "lint-staged": {
     "**/*.{vue,ts,tsx,js,jsx,cjs,mjs,json,md,css,scss}": "prettier --write",
-    "src/content/**/*.{json,vue}": "npm run validate:content --"
+    "src/content/**/*.{json,vue}": "npm run validate:content -- --no-report"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"

--- a/reports/content-validation-report.json
+++ b/reports/content-validation-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-27T23:50:41.356Z",
+  "generatedAt": "2025-09-29T00:13:25.492Z",
   "status": "passed",
   "totals": {
     "courses": 5,

--- a/reports/governance-alert.json
+++ b/reports/governance-alert.json
@@ -1,17 +1,17 @@
 {
-  "generatedAt": "2025-09-26T23:47:02.143Z",
+  "generatedAt": "2025-09-29T00:13:25.724Z",
   "hasValidationReport": true,
   "hasObservabilityReport": true,
-  "validationStatus": "passed-with-warnings",
+  "validationStatus": "passed",
   "validationTotals": {
     "problems": 0,
-    "warnings": 4,
-    "lessonsWithIssues": 4
+    "warnings": 0,
+    "lessonsWithIssues": 0
   },
   "observabilityTotals": {
-    "legacyBlocks": 28,
-    "legacyLessons": 27,
-    "md3Blocks": 520,
+    "legacyBlocks": 0,
+    "legacyLessons": 0,
+    "md3Blocks": 623,
     "lessonsTotal": 92,
     "courses": 5,
     "exercisesWithoutMetadata": 0,
@@ -20,64 +20,24 @@
   "metadataIssues": [],
   "courses": [
     {
-      "id": "tgs",
+      "id": "algi",
       "problems": 0,
-      "warnings": 2,
-      "lessonsWithIssues": 2,
-      "legacyBlocks": 8,
-      "legacyLessons": 8,
-      "legacyLessonIds": [
-        "lesson-06",
-        "lesson-07",
-        "lesson-10",
-        "lesson-11",
-        "lesson-12",
-        "lesson-13",
-        "lesson-14",
-        "lesson-15"
-      ],
+      "warnings": 0,
+      "lessonsWithIssues": 0,
+      "legacyBlocks": 0,
+      "legacyLessons": 0,
+      "legacyLessonIds": [],
       "exercisesWithoutMetadata": 0,
       "supplementsWithoutMetadata": 0
     },
     {
       "id": "ddm",
       "problems": 0,
-      "warnings": 1,
-      "lessonsWithIssues": 1,
-      "legacyBlocks": 8,
-      "legacyLessons": 8,
-      "legacyLessonIds": [
-        "lesson-03",
-        "lesson-06",
-        "lesson-07",
-        "lesson-08",
-        "lesson-09",
-        "lesson-10",
-        "lesson-13",
-        "lesson-14"
-      ],
-      "exercisesWithoutMetadata": 0,
-      "supplementsWithoutMetadata": 0
-    },
-    {
-      "id": "tdjd",
-      "problems": 0,
-      "warnings": 1,
-      "lessonsWithIssues": 1,
-      "legacyBlocks": 5,
-      "legacyLessons": 5,
-      "legacyLessonIds": ["lesson-02", "lesson-10", "lesson-11", "lesson-12", "lesson-13"],
-      "exercisesWithoutMetadata": 0,
-      "supplementsWithoutMetadata": 0
-    },
-    {
-      "id": "algi",
-      "problems": 0,
       "warnings": 0,
       "lessonsWithIssues": 0,
-      "legacyBlocks": 6,
-      "legacyLessons": 5,
-      "legacyLessonIds": ["lesson-04", "lesson-14", "lesson-15", "lesson-29", "lesson-39"],
+      "legacyBlocks": 0,
+      "legacyLessons": 0,
+      "legacyLessonIds": [],
       "exercisesWithoutMetadata": 0,
       "supplementsWithoutMetadata": 0
     },
@@ -86,24 +46,46 @@
       "problems": 0,
       "warnings": 0,
       "lessonsWithIssues": 0,
-      "legacyBlocks": 1,
-      "legacyLessons": 1,
-      "legacyLessonIds": ["lesson-01"],
+      "legacyBlocks": 0,
+      "legacyLessons": 0,
+      "legacyLessonIds": [],
+      "exercisesWithoutMetadata": 0,
+      "supplementsWithoutMetadata": 0
+    },
+    {
+      "id": "tdjd",
+      "problems": 0,
+      "warnings": 0,
+      "lessonsWithIssues": 0,
+      "legacyBlocks": 0,
+      "legacyLessons": 0,
+      "legacyLessonIds": [],
+      "exercisesWithoutMetadata": 0,
+      "supplementsWithoutMetadata": 0
+    },
+    {
+      "id": "tgs",
+      "problems": 0,
+      "warnings": 0,
+      "lessonsWithIssues": 0,
+      "legacyBlocks": 0,
+      "legacyLessons": 0,
+      "legacyLessonIds": [],
       "exercisesWithoutMetadata": 0,
       "supplementsWithoutMetadata": 0
     }
   ],
   "flags": {
     "hasProblems": false,
-    "hasWarnings": true,
-    "totalLegacyBlocks": 28,
-    "shouldOpenIssue": true
+    "hasWarnings": false,
+    "totalLegacyBlocks": 0,
+    "shouldOpenIssue": false
   },
   "trend": {
     "validationProblems": 0,
-    "validationWarnings": 0,
-    "legacyBlocks": 0,
-    "legacyLessons": 0,
+    "validationWarnings": -4,
+    "legacyBlocks": -28,
+    "legacyLessons": -27,
     "exercisesWithoutMetadata": 0,
     "supplementsWithoutMetadata": 0
   }

--- a/reports/governance-alert.md
+++ b/reports/governance-alert.md
@@ -1,37 +1,31 @@
 # Alerta de governança de conteúdo
 
-_Gerado em 2025-09-26 23:47:02.143 UTC_
+_Gerado em 2025-09-29 00:13:25.724 UTC_
 
 ## Diagnóstico rápido
 
-- **Status da validação**: ⚠️ aprovado com avisos com 0 problema(s) e 4 aviso(s).
-- **Blocos legados**: 28 em 27 lição(ões) (total de 92 lições mapeadas).
+- **Status da validação**: ✅ aprovado com 0 problema(s) e 0 aviso(s).
+- **Blocos legados**: 0 em 0 lição(ões) (total de 92 lições mapeadas).
 - **Metadados obrigatórios**: 0 exercícios e 0 suplementos pendentes.
 
 ### Evolução em relação à última execução
 
 - Problemas de validação: — (sem alteração)
-- Avisos de validação: — (sem alteração)
-- Blocos legados: — (sem alteração)
-- Lições com blocos legados: — (sem alteração)
+- Avisos de validação: ▼ -4
+- Blocos legados: ▼ -28
+- Lições com blocos legados: ▼ -27
 - Exercícios sem metadados: — (sem alteração)
 - Suplementos sem metadados: — (sem alteração)
 
 ## Cursos com apontamentos
 
-| Curso | Problemas | Avisos | Blocos legados | Lições afetadas                                                                        | Exercícios s/ metadados | Suplementos s/ metadados |
-| ----- | --------- | ------ | -------------- | -------------------------------------------------------------------------------------- | ----------------------- | ------------------------ |
-| tgs   | 0         | 2      | 8              | lesson-06, lesson-07, lesson-10, lesson-11, lesson-12, lesson-13, lesson-14, lesson-15 | 0                       | 0                        |
-| ddm   | 0         | 1      | 8              | lesson-03, lesson-06, lesson-07, lesson-08, lesson-09, lesson-10, lesson-13, lesson-14 | 0                       | 0                        |
-| tdjd  | 0         | 1      | 5              | lesson-02, lesson-10, lesson-11, lesson-12, lesson-13                                  | 0                       | 0                        |
-| algi  | 0         | 0      | 6              | lesson-04, lesson-14, lesson-15, lesson-29, lesson-39                                  | 0                       | 0                        |
-| lpoo  | 0         | 0      | 1              | lesson-01                                                                              | 0                       | 0                        |
-
-### Tipos mais frequentes
-
-**Avisos**
-
-- legacy-block: 4
+| Curso | Problemas | Avisos | Blocos legados | Lições afetadas | Exercícios s/ metadados | Suplementos s/ metadados |
+| ----- | --------- | ------ | -------------- | --------------- | ----------------------- | ------------------------ |
+| algi  | 0         | 0      | 0              | —               | 0                       | 0                        |
+| ddm   | 0         | 0      | 0              | —               | 0                       | 0                        |
+| lpoo  | 0         | 0      | 0              | —               | 0                       | 0                        |
+| tdjd  | 0         | 0      | 0              | —               | 0                       | 0                        |
+| tgs   | 0         | 0      | 0              | —               | 0                       | 0                        |
 
 ### Próximas ações sugeridas
 

--- a/reports/governance-history.json
+++ b/reports/governance-history.json
@@ -37,5 +37,18 @@
       "exercisesWithoutMetadata": 0,
       "supplementsWithoutMetadata": 0
     }
+  },
+  {
+    "generatedAt": "2025-09-29T00:13:25.724Z",
+    "validation": {
+      "problems": 0,
+      "warnings": 0
+    },
+    "observability": {
+      "legacyBlocks": 0,
+      "legacyLessons": 0,
+      "exercisesWithoutMetadata": 0,
+      "supplementsWithoutMetadata": 0
+    }
   }
 ]

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -1599,6 +1599,10 @@ main().catch((error) => {
 });
 
 function resolveReportPath(args) {
+  if (args.includes('--no-report')) {
+    return null;
+  }
+
   const equalsArg = args.find((arg) => arg.startsWith('--report='));
   if (equalsArg) {
     const candidate = equalsArg.slice('--report='.length).trim();
@@ -1607,7 +1611,7 @@ function resolveReportPath(args) {
 
   const flagIndex = args.indexOf('--report');
   if (flagIndex === -1) {
-    return null;
+    return toAbsoluteReportPath(DEFAULT_REPORT_PATH);
   }
 
   const nextArg = args[flagIndex + 1];


### PR DESCRIPTION
## Summary
- add a shared ICS calendar and expand the faculty review sessions guide with guidance for imports, meeting notes, and indicator tracking
- make content validation write its default report (with an opt-out for lint-staged) and run it automatically before the governance alert is generated
- refresh the governance validation and alert reports using the new automated flow

## Testing
- npm run report:governance

------
https://chatgpt.com/codex/tasks/task_e_68d9ce426d5c832c88f980e9a74e74c0