### PR TITLE
Add MD3 didactics components and migrate ALGI lessons 16-18

### DIFF
--- a/docs/didactics/class-designer.md
+++ b/docs/didactics/class-designer.md
@@ -1,0 +1,81 @@
+# ClassDesigner (MD3)
+
+O `ClassDesigner` traduz diagramas de classes UML para a linguagem visual do Material Design 3, permitindo que aulas de orientação a objetos apresentem relacionamentos, atributos e responsabilidades em formato totalmente declarativo.
+
+## API declarativa
+
+```ts
+interface UmlMember {
+  id: string;
+  signature: string; // exemplo: "+ nome: String"
+  visibility?: 'public' | 'private' | 'protected' | 'package';
+  note?: string;
+}
+
+interface UmlClass {
+  id: string;
+  name: string;
+  stereotype?: string; // <<interface>>, <<service>>
+  summary?: string;
+  type?: 'class' | 'interface' | 'enum';
+  attributes?: UmlMember[];
+  methods?: UmlMember[];
+  responsibilities?: string[];
+  notes?: string[];
+}
+
+interface UmlRelationship {
+  id: string;
+  from: string;
+  to: string;
+  type:
+    | 'association'
+    | 'aggregation'
+    | 'composition'
+    | 'inheritance'
+    | 'realization'
+    | 'dependency';
+  description?: string;
+  fromMultiplicity?: string;
+  toMultiplicity?: string;
+}
+
+interface UmlLegendItem {
+  id: string;
+  label: string;
+  description?: string;
+  kind?: UmlRelationship['type'] | UmlClass['type'];
+}
+
+interface ClassDesignerProps {
+  title?: string;
+  summary?: string;
+  classes: UmlClass[];
+  relationships?: UmlRelationship[];
+  legend?: UmlLegendItem[];
+}
+```
+
+- `classes` aceita atributos e métodos separados para manter a semântica dos diagramas UML. O componente converte a visibilidade em ícones padrão (`+`, `-`, `#`, `~`) automaticamente.
+- `relationships` são renderizados como cartões textuais com multiplicidades e descrições legíveis por leitores de tela, substituindo setas complexas.
+- `legend` permite registrar convenções de estereótipos ou tipos de relacionamento utilizados na aula.
+
+## Fundamentos de design
+
+- **Card MD3 acessível**: cada classe é um `article` com cabeçalho, lista de atributos/métodos e responsabilidades. Os estados de foco usam `box-shadow` MD3 e mantêm contraste AA. 【F:src/components/lesson/ClassDesigner.vue†L1-L170】
+- **Tipografia declarada**: os títulos usam `text-title-medium`, enquanto assinaturas aplicam `text-body-medium` com fonte monoespaçada opcional em membros. 【F:src/components/lesson/ClassDesigner.vue†L46-L130】
+- **Relacionamentos textuais**: apresentados em uma lista com `role="list"`, contendo etiqueta do tipo (`Herança`, `Composição`, etc.), multiplicidades e descrição resumida. 【F:src/components/lesson/ClassDesigner.vue†L132-L170】
+
+## Testes
+
+A suíte `ClassDesigner.test.ts` cobre:
+
+1. Renderização de classes com atributos e métodos completos.
+2. Conversão automática de visibilidade para símbolos UML.
+3. Exibição de relacionamentos com multiplicidades e legenda opcional. 【F:src/components/lesson/**tests**/ClassDesigner.test.ts†L1-L81】
+
+## Próximos passos
+
+1. Publicar stories no Storybook demonstrando diagramas típicos (modelo entidade-relacionamento, camadas de serviço, padrões de projeto).
+2. Criar presets para exercícios de LPOO (ex.: composição vs agregação) usando o `blockRegistry` (`type: "classDesigner"`). 【F:src/components/lesson/blockRegistry.ts†L1-L360】
+3. Conectar o componente às rubricas de avaliação de modelagem UML previstas em `docs/material-redesign-plan.md`.

--- a/docs/didactics/pipeline-canvas.md
+++ b/docs/didactics/pipeline-canvas.md
@@ -1,0 +1,79 @@
+# PipelineCanvas (MD3)
+
+O `PipelineCanvas` organiza jornadas de produção — como o pipeline de desenvolvimento de jogos — em estágios claros, com entregas, riscos e responsáveis documentados no padrão MD3.
+
+## API declarativa
+
+```ts
+interface PipelineActivity {
+  id: string;
+  label: string;
+  description?: string;
+  role?: string; // responsável principal
+}
+
+interface PipelineDeliverable {
+  id: string;
+  label: string;
+  description?: string;
+  evidence?: string; // link ou instrução de comprovação
+}
+
+interface PipelineRisk {
+  id: string;
+  label: string;
+  severity?: 'low' | 'medium' | 'high';
+  mitigation?: string;
+}
+
+interface PipelineStage {
+  id: string;
+  title: string;
+  summary?: string;
+  status?: 'not-started' | 'in-progress' | 'blocked' | 'done';
+  owners?: string[];
+  durationHours?: number;
+  activities?: PipelineActivity[];
+  deliverables?: PipelineDeliverable[];
+  risks?: PipelineRisk[];
+  checkpoints?: string[]; // micro marcos internos
+}
+
+interface PipelineMilestone {
+  id: string;
+  title: string;
+  description?: string;
+  due?: string; // ISO date
+}
+
+interface PipelineCanvasProps {
+  title?: string;
+  summary?: string;
+  stages: PipelineStage[];
+  milestones?: PipelineMilestone[];
+}
+```
+
+- `status` controla a badge do estágio (Ex.: "Em andamento"), alinhada às cores tonais MD3.
+- `owners` lista pessoas responsáveis; quando múltiplas, são apresentados como chips secundários.
+- `deliverables` e `activities` aparecem como listas textuais; `evidence` gera uma descrição auxiliar.
+
+## Fundamentos de design
+
+- **Grid responsivo**: estágios são renderizados em `grid` com minmax de 18rem, adaptando-se para uma coluna em telas pequenas. 【F:src/components/lesson/PipelineCanvas.vue†L18-L132】
+- **Badges de status**: cores tonais para `blocked` (erro), `in-progress` (primário), `done` (terciário) e `not-started` (outline) reforçam acompanhamento visual. 【F:src/components/lesson/PipelineCanvas.vue†L64-L104】
+- **Milestones acessíveis**: listados separadamente com `aria-label` claro, exibindo datas legíveis (`due`). 【F:src/components/lesson/PipelineCanvas.vue†L134-L178】
+
+## Testes
+
+A suíte `PipelineCanvas.test.ts` valida:
+
+1. Renderização dos estágios com atividades e entregáveis completos.
+2. Seleção correta da badge de status.
+3. Exibição dos marcos com data formatada e descrição opcional. 【F:src/components/lesson/**tests**/PipelineCanvas.test.ts†L1-L82】
+
+## Próximos passos
+
+1. Adicionar suporte a indicadores quantitativos (burn-down, capacidade) e integrar com dashboards de progresso.
+2. Produzir presets para TDJD (pipeline de jogo) e DDM (sprints de publicação nas lojas) no Storybook.
+3. Avaliar integrações com arrastar-e-soltar para priorização rápida, mantendo fallback textual para acessibilidade.

--- a/docs/didactics/system-mapper.md
+++ b/docs/didactics/system-mapper.md
@@ -1,0 +1,70 @@
+# SystemMapper (MD3)
+
+O `SystemMapper` representa mapas de causalidade e loops de feedback utilizados em Teoria Geral de Sistemas, reutilizando a base visual do `Md3Flowchart` com foco em narrativa textual acessível.
+
+## API declarativa
+
+```ts
+interface SystemFactor {
+  id: string;
+  name: string;
+  summary?: string;
+  kind?: 'stock' | 'flow' | 'driver' | 'outcome' | 'constraint';
+  indicators?: string[]; // métricas observáveis
+}
+
+interface SystemLoopStep {
+  id: string;
+  from: string;
+  to: string;
+  effect?: 'reinforces' | 'balances';
+  description?: string;
+}
+
+interface SystemLoop {
+  id: string;
+  name: string;
+  polarity: 'reinforcing' | 'balancing';
+  summary?: string;
+  steps: SystemLoopStep[];
+  insights?: string[];
+}
+
+interface SystemInsight {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+interface SystemMapperProps {
+  title?: string;
+  summary?: string;
+  factors: SystemFactor[];
+  loops: SystemLoop[];
+  insights?: SystemInsight[];
+}
+```
+
+- `factors` descrevem estoques, fluxos e variáveis externas. O componente aplica um selo tonal por tipo (`stock`, `flow`, etc.).
+- `loops` registram o sentido da alça (`reinforcing`/`balancing`) e cada ligação textual descreve o efeito esperado (`aumenta`, `reduz`).
+- `insights` permitem destacar aprendizados ou ações recomendadas derivadas do mapa sistêmico.
+
+## Fundamentos de design
+
+- **Stacks tonais**: fatores são cartões MD3 com selo `data-kind`, adaptando cor para cada tipo de variável. 【F:src/components/lesson/SystemMapper.vue†L16-L118】
+- **Loops narrativos**: cada loop é um `article` com identificador `R` ou `B`, além da lista de passos (`role="list"`). Os efeitos positivos/negativos utilizam `data-effect` para aplicar cores consistentes. 【F:src/components/lesson/SystemMapper.vue†L120-L188】
+- **Insights acionáveis**: renderizados como `callout` MD3 com ícone informativo, reforçando próximos passos ou riscos monitorados. 【F:src/components/lesson/SystemMapper.vue†L190-L232】
+
+## Testes
+
+A suíte `SystemMapper.test.ts` contempla:
+
+1. Renderização das variáveis com selo de tipo.
+2. Descrição completa dos loops com polaridade e etapas.
+3. Exibição opcional dos insights finais. 【F:src/components/lesson/**tests**/SystemMapper.test.ts†L1-L86】
+
+## Próximos passos
+
+1. Investigar integração com simulações simples (slider → efeito) preservando fallback textual.
+2. Criar presets para estudos de caso (ex.: cadeia de suprimentos, políticas públicas de saúde).
+3. Conectar o componente ao pipeline de validação para apontar loops incompletos automaticamente.

--- a/docs/material-redesign-plan.md
+++ b/docs/material-redesign-plan.md
@@ -53,6 +53,7 @@
 - Reescrever conteúdos em formato declarativo (`.md`/`MDC` ou JSON normalizado) com componentes semânticos (`<md-section>`, `<md-stepper>`).
 - Criar novos componentes: "Tabela Verdade", "Fluxograma" e "Simulador de Execução" revisados, incluindo acessibilidade e animações MD.
 - Implementar trilhas de exercícios com gradação de dificuldade e feedback automático.
+- Migrar as aulas 16-18 para o schema `md3.lesson.v1`, cobrindo condicionais avançadas e introdução a laços, com índices atualizados. 【F:src/content/courses/algi/lessons/lesson-16.json†L1-L210】【F:src/content/courses/algi/lessons/lesson-17.json†L1-L212】【F:src/content/courses/algi/lessons/lesson-18.json†L1-L210】【F:src/content/courses/algi/lessons.json†L165-L210】
 
 ### 5.2 Desenvolvimento para Dispositivos Móveis (DDM)
 
@@ -65,17 +66,20 @@
 - As aulas 01-08 foram migradas para o schema `md3.lesson.v1`, reorganizando objetivos, planos de voo e novos blocos MD3 (fluxogramas, tabelas de visibilidade e diagramas de blocos). 【F:src/content/courses/lpoo/lessons/lesson-01.json†L1-L214】【F:src/content/courses/lpoo/lessons/lesson-02.json†L1-L203】【F:src/content/courses/lpoo/lessons/lesson-03.json†L1-L214】【F:src/content/courses/lpoo/lessons/lesson-04.json†L1-L227】【F:src/content/courses/lpoo/lessons/lesson-05.json†L1-L210】【F:src/content/courses/lpoo/lessons/lesson-06.json†L1-L208】【F:src/content/courses/lpoo/lessons/lesson-07.json†L1-L242】【F:src/content/courses/lpoo/lessons/lesson-08.json†L1-L211】
 - O índice `lessons.json` agora aponta para os arquivos JSON, traz resumo, tags, duração e `formatVersion`, permitindo que os relatórios de governança identifiquem o status real das aulas. 【F:src/content/courses/lpoo/lessons.json†L1-L64】
 - Próximos passos: preparar um componente "ClassDesigner" a partir do `Md3BlockDiagram` para ilustrar relações UML, migrar exercícios (`modelagem-uml.json`, `refatoracao.json`) para o novo schema e registrar rubricas alinhadas às competências de orientação a objetos.
+- ✅ `ClassDesigner` especificado e implementado com documentação MD3, habilitando diagramas de classes reusáveis nas próximas aulas. 【F:docs/didactics/class-designer.md†L1-L63】【F:src/components/lesson/ClassDesigner.vue†L1-L344】【F:src/components/lesson/**tests**/ClassDesigner.test.ts†L1-L81】
 
 ### 5.4 Tecnologia e Desenvolvimento para Jogos Digitais (TDJD)
 
 - Estruturar jornadas: Ideação → Prototipagem → Produção → Publicação → Pós-lançamento.
 - Desenvolver componentes visuais: "Pipeline Canvas", "Matriz de Mecânicas" e "Quadro de Assets".
+- ✅ `PipelineCanvas` publicado com estágios, entregáveis e marcos tonais, pronto para jornadas de produção de jogos. 【F:docs/didactics/pipeline-canvas.md†L1-L66】【F:src/components/lesson/PipelineCanvas.vue†L1-L324】【F:src/components/lesson/**tests**/PipelineCanvas.test.ts†L1-L82】
 - Integrar checklists técnicos (builds multiplataforma) e referências a motores modernos (Unity 6, Unreal 5, Godot 4).
 
 ### 5.5 Teoria Geral de Sistemas (TGS)
 
 - Reorganizar aulas para enfatizar pensamento sistêmico aplicado (mapas de causalidade, diagramas de loops, modelagem de estoques e fluxos).
 - Criar componente "System Mapper" para diagramas dinâmicos e "Radar de Competências" para avaliação formativa.
+- ✅ `SystemMapper` construído para loops de feedback com legenda MD3, desbloqueando as migrações de TGS. 【F:docs/didactics/system-mapper.md†L1-L63】【F:src/components/lesson/SystemMapper.vue†L1-L357】【F:src/components/lesson/**tests**/SystemMapper.test.ts†L1-L86】
 - Atualizar materiais com estudos de caso atuais (transformação digital, ESG, saúde pública).
 
 ## 6. Arquitetura de Conteúdo Proposta
@@ -219,3 +223,5 @@ O documento `docs/governance/faculty-review-sessions.md` organiza a agenda, indi
 - Entrega do novo `Md3Flowchart` com API declarativa, conectores configuráveis e tokens MD3 aplicados. 【F:src/components/lesson/Md3Flowchart.vue†L1-L214】
 - Documentação inicial publicada em `docs/didactics/md3-flowchart.md`, orientando próximos componentes. 【F:docs/didactics/md3-flowchart.md†L1-L60】
 - Testes atualizados para cobrir fluxos lineares, bifurcações e loops customizados. 【F:src/components/lesson/**tests**/Md3Flowchart.test.ts†L1-L74】
+- Biblioteca expandida com `ClassDesigner`, `PipelineCanvas` e `SystemMapper`, incluindo testes automatizados e documentação pedagógica. 【F:src/components/lesson/ClassDesigner.vue†L1-L344】【F:src/components/lesson/PipelineCanvas.vue†L1-L324】【F:src/components/lesson/SystemMapper.vue†L1-L357】【F:src/components/lesson/**tests**/ClassDesigner.test.ts†L1-L81】【F:docs/didactics/pipeline-canvas.md†L1-L66】
+- Índices de aulas, exercícios e suplementos do ALGI atualizados com metadados completos após as novas entregas. 【F:src/content/courses/algi/lessons.json†L165-L210】【F:src/content/courses/algi/exercises.json†L1-L32】【F:src/content/courses/algi/supplements.json†L1-L16】

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -42,9 +42,14 @@ const SUPPORTED_BLOCK_TYPES = [
   'accordion',
   'representations',
   'truthTable',
+  'roadmap',
   'audio',
   'audioBlock',
   'md3Table',
+  'md3Flowchart',
+  'classDesigner',
+  'pipelineCanvas',
+  'systemMapper',
   'component',
   'legacySection',
 ];
@@ -59,6 +64,9 @@ const SUPPORTED_CUSTOM_COMPONENTS = [
   'MemoryDiagram',
   'OrderedList',
   'CardGrid',
+  'ClassDesigner',
+  'PipelineCanvas',
+  'SystemMapper',
 ];
 
 const ALLOWED_CALLOUT_VARIANTS = new Set([

--- a/src/components/lesson/ClassDesigner.vue
+++ b/src/components/lesson/ClassDesigner.vue
@@ -1,0 +1,679 @@
+<template>
+  <section
+    class="class-designer card md-stack"
+    role="group"
+    :aria-label="title ?? 'Diagrama de classes UML'"
+  >
+    <header v-if="title || summary" class="class-designer__header md-stack">
+      <h3
+        v-if="title"
+        class="class-designer__title text-title-medium font-semibold text-on-surface"
+      >
+        {{ title }}
+      </h3>
+      <p v-if="summary" class="class-designer__summary supporting-text">
+        {{ summary }}
+      </p>
+    </header>
+
+    <div class="class-designer__grid" role="list">
+      <article
+        v-for="umlClass in normalizedClasses"
+        :key="umlClass.id"
+        class="class-designer__class md-surface"
+        role="listitem"
+        :aria-labelledby="`${umlClass.id}-name`"
+        :aria-describedby="umlClass.descriptionId"
+        :data-type="umlClass.type ?? 'class'"
+      >
+        <header class="class-designer__class-header">
+          <div class="class-designer__class-heading md-stack">
+            <span v-if="umlClass.stereotype" class="class-designer__stereotype supporting-text">
+              «{{ umlClass.stereotype }}»
+            </span>
+            <h4
+              :id="`${umlClass.id}-name`"
+              class="class-designer__class-name text-title-small font-semibold"
+            >
+              {{ umlClass.name }}
+            </h4>
+            <span
+              v-if="umlClass.typeLabel"
+              class="class-designer__type-chip"
+              :data-type="umlClass.type ?? 'class'"
+            >
+              {{ umlClass.typeLabel }}
+            </span>
+          </div>
+          <p
+            v-if="umlClass.summary"
+            :id="umlClass.descriptionId"
+            class="class-designer__class-summary supporting-text"
+          >
+            {{ umlClass.summary }}
+          </p>
+        </header>
+
+        <section
+          v-if="umlClass.attributes.length"
+          class="class-designer__section"
+          aria-label="Atributos"
+          role="list"
+        >
+          <h5 class="class-designer__section-title text-label-large font-semibold">Atributos</h5>
+          <ul class="class-designer__members" role="list">
+            <li
+              v-for="attribute in umlClass.attributes"
+              :key="attribute.id"
+              class="class-designer__member"
+              role="listitem"
+            >
+              <span class="class-designer__member-visibility" aria-hidden="true">{{
+                attribute.symbol
+              }}</span>
+              <span class="sr-only">{{ attribute.visibilityLabel }}</span>
+              <span class="class-designer__member-signature text-body-medium">{{
+                attribute.signature
+              }}</span>
+              <p v-if="attribute.note" class="class-designer__member-note supporting-text">
+                {{ attribute.note }}
+              </p>
+            </li>
+          </ul>
+        </section>
+
+        <section
+          v-if="umlClass.methods.length"
+          class="class-designer__section"
+          aria-label="Métodos"
+          role="list"
+        >
+          <h5 class="class-designer__section-title text-label-large font-semibold">Métodos</h5>
+          <ul class="class-designer__members" role="list">
+            <li
+              v-for="method in umlClass.methods"
+              :key="method.id"
+              class="class-designer__member"
+              role="listitem"
+            >
+              <span class="class-designer__member-visibility" aria-hidden="true">{{
+                method.symbol
+              }}</span>
+              <span class="sr-only">{{ method.visibilityLabel }}</span>
+              <span class="class-designer__member-signature text-body-medium">{{
+                method.signature
+              }}</span>
+              <p v-if="method.note" class="class-designer__member-note supporting-text">
+                {{ method.note }}
+              </p>
+            </li>
+          </ul>
+        </section>
+
+        <section
+          v-if="umlClass.responsibilities.length"
+          class="class-designer__section"
+          aria-label="Responsabilidades"
+          role="list"
+        >
+          <h5 class="class-designer__section-title text-label-large font-semibold">
+            Responsabilidades
+          </h5>
+          <ul class="class-designer__responsibilities" role="list">
+            <li
+              v-for="responsibility in umlClass.responsibilities"
+              :key="responsibility"
+              class="class-designer__responsibility"
+              role="listitem"
+            >
+              {{ responsibility }}
+            </li>
+          </ul>
+        </section>
+
+        <section
+          v-if="umlClass.notes.length"
+          class="class-designer__section"
+          aria-label="Notas"
+          role="list"
+        >
+          <h5 class="class-designer__section-title text-label-large font-semibold">Notas</h5>
+          <ul class="class-designer__notes" role="list">
+            <li
+              v-for="note in umlClass.notes"
+              :key="note"
+              class="class-designer__note supporting-text"
+              role="listitem"
+            >
+              {{ note }}
+            </li>
+          </ul>
+        </section>
+      </article>
+    </div>
+
+    <section
+      v-if="relationshipsWithLabels.length"
+      class="class-designer__relationships md-stack"
+      aria-label="Relacionamentos"
+      role="list"
+    >
+      <article
+        v-for="relationship in relationshipsWithLabels"
+        :key="relationship.id"
+        class="class-designer__relationship"
+        role="listitem"
+        :data-type="relationship.type"
+      >
+        <header class="class-designer__relationship-header">
+          <span class="class-designer__relationship-type text-label-large font-semibold">{{
+            relationship.typeLabel
+          }}</span>
+          <p class="class-designer__relationship-link text-body-medium">
+            {{ relationship.fromLabel }} {{ relationship.connector }} {{ relationship.toLabel }}
+          </p>
+        </header>
+        <p
+          v-if="relationship.description"
+          class="class-designer__relationship-description supporting-text"
+        >
+          {{ relationship.description }}
+        </p>
+      </article>
+    </section>
+
+    <section
+      v-if="legendWithDescriptions.length"
+      class="class-designer__legend md-stack"
+      aria-label="Legenda"
+      role="list"
+    >
+      <article
+        v-for="item in legendWithDescriptions"
+        :key="item.id"
+        class="class-designer__legend-item"
+        role="listitem"
+      >
+        <span class="class-designer__legend-swatch" :data-kind="item.kind ?? 'class'"></span>
+        <div class="class-designer__legend-copy md-stack">
+          <p class="text-label-large font-semibold">{{ item.label }}</p>
+          <p v-if="item.description" class="supporting-text">{{ item.description }}</p>
+        </div>
+      </article>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+type UmlVisibility = 'public' | 'private' | 'protected' | 'package';
+
+type UmlMember = {
+  id: string;
+  signature: string;
+  visibility?: UmlVisibility;
+  note?: string;
+};
+
+type UmlClass = {
+  id: string;
+  name: string;
+  stereotype?: string;
+  summary?: string;
+  type?: 'class' | 'interface' | 'enum';
+  attributes?: UmlMember[];
+  methods?: UmlMember[];
+  responsibilities?: string[];
+  notes?: string[];
+};
+
+type UmlRelationship = {
+  id: string;
+  from: string;
+  to: string;
+  type:
+    | 'association'
+    | 'aggregation'
+    | 'composition'
+    | 'inheritance'
+    | 'realization'
+    | 'dependency';
+  description?: string;
+  fromMultiplicity?: string;
+  toMultiplicity?: string;
+};
+
+type UmlLegendItem = {
+  id: string;
+  label: string;
+  description?: string;
+  kind?: UmlRelationship['type'] | UmlClass['type'];
+};
+
+interface ClassDesignerProps {
+  title?: string;
+  summary?: string;
+  classes: UmlClass[];
+  relationships?: UmlRelationship[];
+  legend?: UmlLegendItem[];
+}
+
+const props = withDefaults(defineProps<ClassDesignerProps>(), {
+  classes: () => [],
+  relationships: () => [],
+  legend: () => [],
+  title: undefined,
+  summary: undefined,
+});
+
+const visibilitySymbolMap: Record<UmlVisibility, string> = {
+  public: '+',
+  private: '-',
+  protected: '#',
+  package: '~',
+};
+
+const visibilityLabelMap: Record<UmlVisibility, string> = {
+  public: 'Visibilidade pública',
+  private: 'Visibilidade privada',
+  protected: 'Visibilidade protegida',
+  package: 'Visibilidade de pacote',
+};
+
+const typeLabelMap: Record<NonNullable<UmlClass['type']>, string> = {
+  class: 'Classe',
+  interface: 'Interface',
+  enum: 'Enumeração',
+};
+
+type NormalizedMember = {
+  id: string;
+  signature: string;
+  note?: string;
+  symbol: string;
+  visibilityLabel: string;
+};
+
+type NormalizedClass = {
+  id: string;
+  name: string;
+  summary?: string;
+  stereotype?: string;
+  type?: UmlClass['type'];
+  typeLabel?: string;
+  attributes: NormalizedMember[];
+  methods: NormalizedMember[];
+  responsibilities: string[];
+  notes: string[];
+  descriptionId?: string;
+};
+
+const normalizedClasses = computed<NormalizedClass[]>(() =>
+  props.classes
+    .map((umlClass) => {
+      const attributes = normalizeMembers(umlClass.attributes);
+      const methods = normalizeMembers(umlClass.methods);
+      const responsibilities = normalizeStrings(umlClass.responsibilities);
+      const notes = normalizeStrings(umlClass.notes);
+      const summary = cleanString(umlClass.summary);
+      const descriptionId =
+        summary || responsibilities.length || notes.length
+          ? `${umlClass.id}-description`
+          : undefined;
+      const type = umlClass.type ?? 'class';
+      return {
+        id: umlClass.id,
+        name: umlClass.name,
+        stereotype: cleanString(umlClass.stereotype),
+        summary: summary || undefined,
+        type: umlClass.type,
+        typeLabel: umlClass.type ? typeLabelMap[umlClass.type] : undefined,
+        attributes,
+        methods,
+        responsibilities,
+        notes,
+        descriptionId,
+      } satisfies NormalizedClass;
+    })
+    .filter((umlClass) => umlClass.id && umlClass.name)
+);
+
+type RelationshipLabel = {
+  id: string;
+  type: UmlRelationship['type'];
+  typeLabel: string;
+  fromLabel: string;
+  toLabel: string;
+  connector: string;
+  description?: string;
+};
+
+const relationshipLabelMap: Record<UmlRelationship['type'], string> = {
+  association: 'Associação',
+  aggregation: 'Agregação',
+  composition: 'Composição',
+  inheritance: 'Herança',
+  realization: 'Realização',
+  dependency: 'Dependência',
+};
+
+const relationshipsWithLabels = computed<RelationshipLabel[]>(() =>
+  props.relationships
+    .map((relationship) => {
+      const fromMultiplicity = cleanString(relationship.fromMultiplicity);
+      const toMultiplicity = cleanString(relationship.toMultiplicity);
+      return {
+        id: relationship.id,
+        type: relationship.type,
+        typeLabel: relationshipLabelMap[relationship.type],
+        fromLabel: `${relationship.from}${fromMultiplicity ? ` [${fromMultiplicity}]` : ''}`,
+        toLabel: `${relationship.to}${toMultiplicity ? ` [${toMultiplicity}]` : ''}`,
+        connector: connectorForType(relationship.type),
+        description: cleanString(relationship.description),
+      } satisfies RelationshipLabel;
+    })
+    .filter(
+      (relationship) =>
+        relationship.id && relationship.typeLabel && relationship.fromLabel && relationship.toLabel
+    )
+);
+
+const legendWithDescriptions = computed(() =>
+  props.legend
+    .map((item) => ({
+      id: item.id,
+      label: item.label,
+      description: cleanString(item.description) || undefined,
+      kind: item.kind,
+    }))
+    .filter((item) => item.id && item.label)
+);
+
+function normalizeMembers(members: UmlMember[] | undefined): NormalizedMember[] {
+  if (!Array.isArray(members)) {
+    return [];
+  }
+  return members
+    .map((member, index) => {
+      const visibility = member.visibility ?? 'public';
+      const signature = cleanString(member.signature);
+      return {
+        id: member.id ?? `${visibility}-${index}`,
+        signature,
+        note: cleanString(member.note) || undefined,
+        symbol: visibilitySymbolMap[visibility],
+        visibilityLabel: visibilityLabelMap[visibility],
+      } satisfies NormalizedMember;
+    })
+    .filter((member) => Boolean(member.id) && Boolean(member.signature));
+}
+
+function normalizeStrings(values: string[] | undefined): string[] {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  return values
+    .map((value) => cleanString(value))
+    .filter((value): value is string => Boolean(value));
+}
+
+function cleanString(value: string | undefined | null): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function connectorForType(type: UmlRelationship['type']): string {
+  switch (type) {
+    case 'inheritance':
+    case 'realization':
+      return '⇨';
+    case 'aggregation':
+      return '◊→';
+    case 'composition':
+      return '◆→';
+    case 'dependency':
+      return '⇒';
+    default:
+      return '→';
+  }
+}
+</script>
+
+<style scoped>
+.class-designer {
+  padding: var(--md-sys-spacing-6);
+  border-radius: var(--md-sys-border-radius-3xl);
+  background: color-mix(in srgb, var(--md-sys-color-surface-container-high) 85%, transparent);
+  border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 65%, transparent);
+  gap: var(--md-sys-spacing-6);
+}
+
+.class-designer__header {
+  gap: var(--md-sys-spacing-2);
+}
+
+.class-designer__title {
+  margin: 0;
+}
+
+.class-designer__summary {
+  margin: 0;
+}
+
+.class-designer__grid {
+  display: grid;
+  gap: var(--md-sys-spacing-5);
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+}
+
+.class-designer__class {
+  display: grid;
+  gap: var(--md-sys-spacing-4);
+  padding: var(--md-sys-spacing-5);
+  border-radius: var(--md-sys-border-radius-2xl);
+  border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 55%, transparent);
+  background: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
+  box-shadow: var(--shadow-elevation-1);
+  transition: box-shadow 160ms ease;
+}
+
+.class-designer__class:hover,
+.class-designer__class:focus-within {
+  box-shadow: var(--shadow-elevation-2);
+}
+
+.class-designer__class-header {
+  display: grid;
+  gap: var(--md-sys-spacing-3);
+}
+
+.class-designer__class-heading {
+  gap: var(--md-sys-spacing-1);
+}
+
+.class-designer__stereotype {
+  margin: 0;
+  color: color-mix(in srgb, var(--md-sys-color-primary) 65%, var(--md-sys-color-on-surface) 35%);
+}
+
+.class-designer__class-name {
+  margin: 0;
+}
+
+.class-designer__type-chip {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 0.125rem 0.75rem;
+  border-radius: 999px;
+  font-size: var(--md-sys-typescale-label-small-size);
+  font-weight: 600;
+  letter-spacing: var(--md-sys-typescale-label-small-tracking);
+  background: color-mix(in srgb, var(--md-sys-color-secondary-container) 75%, transparent);
+  color: var(--md-sys-color-on-secondary-container);
+}
+
+.class-designer__class-summary {
+  margin: 0;
+}
+
+.class-designer__section {
+  display: grid;
+  gap: var(--md-sys-spacing-2);
+}
+
+.class-designer__section-title {
+  margin: 0;
+}
+
+.class-designer__members {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--md-sys-spacing-2);
+}
+
+.class-designer__member {
+  display: grid;
+  gap: 0.125rem;
+  align-items: start;
+}
+
+.class-designer__member-visibility {
+  font-family: var(--font-family-monospace);
+  font-size: var(--md-sys-typescale-label-large-size);
+  color: color-mix(in srgb, var(--md-sys-color-primary) 65%, var(--md-sys-color-on-surface) 35%);
+}
+
+.class-designer__member-signature {
+  font-family: var(--font-family-monospace);
+}
+
+.class-designer__member-note {
+  margin: 0;
+}
+
+.class-designer__responsibilities,
+.class-designer__notes {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--md-sys-spacing-1);
+}
+
+.class-designer__responsibility,
+.class-designer__note {
+  padding: var(--md-sys-spacing-2) var(--md-sys-spacing-3);
+  border-radius: var(--md-sys-border-radius-large);
+  background: color-mix(in srgb, var(--md-sys-color-primary-container) 30%, transparent);
+  color: var(--md-sys-color-on-primary-container);
+}
+
+.class-designer__notes .class-designer__note {
+  background: color-mix(in srgb, var(--md-sys-color-secondary-container) 30%, transparent);
+  color: var(--md-sys-color-on-secondary-container);
+}
+
+.class-designer__relationships {
+  gap: var(--md-sys-spacing-3);
+}
+
+.class-designer__relationship {
+  border-radius: var(--md-sys-border-radius-2xl);
+  border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 55%, transparent);
+  background: var(--md-sys-color-surface);
+  padding: var(--md-sys-spacing-4);
+  display: grid;
+  gap: var(--md-sys-spacing-2);
+}
+
+.class-designer__relationship[data-type='inheritance'],
+.class-designer__relationship[data-type='realization'] {
+  border-color: color-mix(in srgb, var(--md-sys-color-primary) 45%, transparent);
+}
+
+.class-designer__relationship[data-type='composition'] {
+  border-color: color-mix(in srgb, var(--md-sys-color-tertiary) 45%, transparent);
+}
+
+.class-designer__relationship[data-type='aggregation'] {
+  border-color: color-mix(in srgb, var(--md-sys-color-secondary) 45%, transparent);
+}
+
+.class-designer__relationship-header {
+  display: grid;
+  gap: var(--md-sys-spacing-1);
+}
+
+.class-designer__relationship-type {
+  margin: 0;
+}
+
+.class-designer__relationship-link {
+  margin: 0;
+  font-family: var(--font-family-monospace);
+}
+
+.class-designer__relationship-description {
+  margin: 0;
+}
+
+.class-designer__legend {
+  gap: var(--md-sys-spacing-2);
+}
+
+.class-designer__legend-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--md-sys-spacing-3);
+  align-items: start;
+}
+
+.class-designer__legend-swatch {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--md-sys-color-outline) 40%, transparent);
+  border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 60%, transparent);
+}
+
+.class-designer__legend-swatch[data-kind='interface'] {
+  background: color-mix(in srgb, var(--md-sys-color-tertiary-container) 65%, transparent);
+  border-color: color-mix(in srgb, var(--md-sys-color-tertiary) 45%, transparent);
+}
+
+.class-designer__legend-swatch[data-kind='enum'] {
+  background: color-mix(in srgb, var(--md-sys-color-secondary-container) 65%, transparent);
+  border-color: color-mix(in srgb, var(--md-sys-color-secondary) 45%, transparent);
+}
+
+.class-designer__legend-swatch[data-kind='composition'] {
+  background: color-mix(in srgb, var(--md-sys-color-tertiary) 35%, transparent);
+}
+
+.class-designer__legend-swatch[data-kind='aggregation'] {
+  background: color-mix(in srgb, var(--md-sys-color-secondary) 35%, transparent);
+}
+
+.class-designer__legend-swatch[data-kind='inheritance'],
+.class-designer__legend-swatch[data-kind='realization'] {
+  background: color-mix(in srgb, var(--md-sys-color-primary) 35%, transparent);
+}
+
+.class-designer__legend-copy {
+  gap: 0.125rem;
+}
+
+@media (max-width: 640px) {
+  .class-designer {
+    padding: var(--md-sys-spacing-4);
+  }
+
+  .class-designer__class {
+    padding: var(--md-sys-spacing-4);
+  }
+}
+</style>

--- a/src/components/lesson/PipelineCanvas.vue
+++ b/src/components/lesson/PipelineCanvas.vue
@@ -1,0 +1,656 @@
+<template>
+  <section
+    class="pipeline-canvas card md-stack"
+    role="group"
+    :aria-label="title ?? 'Pipeline de produção'"
+  >
+    <header v-if="title || summary" class="pipeline-canvas__header md-stack">
+      <h3
+        v-if="title"
+        class="pipeline-canvas__title text-title-medium font-semibold text-on-surface"
+      >
+        {{ title }}
+      </h3>
+      <p v-if="summary" class="pipeline-canvas__summary supporting-text">
+        {{ summary }}
+      </p>
+    </header>
+
+    <div class="pipeline-canvas__stages" role="list">
+      <article
+        v-for="stage in normalizedStages"
+        :key="stage.id"
+        class="pipeline-canvas__stage md-surface"
+        role="listitem"
+        :aria-labelledby="`${stage.id}-title`"
+        :data-status="stage.status"
+      >
+        <header class="pipeline-canvas__stage-header">
+          <div class="pipeline-canvas__stage-heading">
+            <h4
+              :id="`${stage.id}-title`"
+              class="pipeline-canvas__stage-title text-title-small font-semibold"
+            >
+              {{ stage.title }}
+            </h4>
+            <span v-if="stage.status" class="pipeline-canvas__status" :data-status="stage.status">
+              {{ stage.statusLabel }}
+            </span>
+          </div>
+          <p v-if="stage.summary" class="pipeline-canvas__stage-summary supporting-text">
+            {{ stage.summary }}
+          </p>
+          <div
+            v-if="stage.owners.length || stage.durationHours"
+            class="pipeline-canvas__stage-meta supporting-text"
+          >
+            <span v-if="stage.durationHours" class="pipeline-canvas__duration">
+              {{ stage.durationLabel }}
+            </span>
+            <ul v-if="stage.owners.length" class="pipeline-canvas__owners" role="list">
+              <li
+                v-for="owner in stage.owners"
+                :key="owner"
+                class="pipeline-canvas__owner"
+                role="listitem"
+              >
+                {{ owner }}
+              </li>
+            </ul>
+          </div>
+        </header>
+
+        <section
+          v-if="stage.activities.length"
+          class="pipeline-canvas__section"
+          aria-label="Atividades"
+          role="list"
+        >
+          <h5 class="pipeline-canvas__section-title text-label-large font-semibold">
+            Atividades chave
+          </h5>
+          <ul class="pipeline-canvas__items" role="list">
+            <li
+              v-for="activity in stage.activities"
+              :key="activity.id"
+              class="pipeline-canvas__item"
+              role="listitem"
+            >
+              <p class="pipeline-canvas__item-label text-body-medium">{{ activity.label }}</p>
+              <p
+                v-if="activity.description"
+                class="pipeline-canvas__item-description supporting-text"
+              >
+                {{ activity.description }}
+              </p>
+              <p v-if="activity.role" class="pipeline-canvas__item-role supporting-text">
+                Responsável: {{ activity.role }}
+              </p>
+            </li>
+          </ul>
+        </section>
+
+        <section
+          v-if="stage.deliverables.length"
+          class="pipeline-canvas__section"
+          aria-label="Entregáveis"
+          role="list"
+        >
+          <h5 class="pipeline-canvas__section-title text-label-large font-semibold">Entregáveis</h5>
+          <ul class="pipeline-canvas__items" role="list">
+            <li
+              v-for="deliverable in stage.deliverables"
+              :key="deliverable.id"
+              class="pipeline-canvas__item"
+              role="listitem"
+            >
+              <p class="pipeline-canvas__item-label text-body-medium">{{ deliverable.label }}</p>
+              <p
+                v-if="deliverable.description"
+                class="pipeline-canvas__item-description supporting-text"
+              >
+                {{ deliverable.description }}
+              </p>
+              <p v-if="deliverable.evidence" class="pipeline-canvas__item-role supporting-text">
+                Evidência: {{ deliverable.evidence }}
+              </p>
+            </li>
+          </ul>
+        </section>
+
+        <section
+          v-if="stage.risks.length"
+          class="pipeline-canvas__section"
+          aria-label="Riscos"
+          role="list"
+        >
+          <h5 class="pipeline-canvas__section-title text-label-large font-semibold">
+            Riscos monitorados
+          </h5>
+          <ul class="pipeline-canvas__items" role="list">
+            <li
+              v-for="risk in stage.risks"
+              :key="risk.id"
+              class="pipeline-canvas__item"
+              role="listitem"
+            >
+              <p class="pipeline-canvas__item-label text-body-medium">
+                {{ risk.label }}
+                <span
+                  v-if="risk.severityLabel"
+                  class="pipeline-canvas__risk"
+                  :data-severity="risk.severity"
+                >
+                  {{ risk.severityLabel }}
+                </span>
+              </p>
+              <p v-if="risk.mitigation" class="pipeline-canvas__item-description supporting-text">
+                Mitigação: {{ risk.mitigation }}
+              </p>
+            </li>
+          </ul>
+        </section>
+
+        <section
+          v-if="stage.checkpoints.length"
+          class="pipeline-canvas__section"
+          aria-label="Checkpoints"
+          role="list"
+        >
+          <h5 class="pipeline-canvas__section-title text-label-large font-semibold">Checkpoints</h5>
+          <ul class="pipeline-canvas__chips" role="list">
+            <li
+              v-for="checkpoint in stage.checkpoints"
+              :key="checkpoint"
+              class="pipeline-canvas__chip"
+              role="listitem"
+            >
+              {{ checkpoint }}
+            </li>
+          </ul>
+        </section>
+      </article>
+    </div>
+
+    <section
+      v-if="normalizedMilestones.length"
+      class="pipeline-canvas__milestones md-stack"
+      aria-label="Marcos"
+      role="list"
+    >
+      <article
+        v-for="milestone in normalizedMilestones"
+        :key="milestone.id"
+        class="pipeline-canvas__milestone"
+        role="listitem"
+      >
+        <header class="pipeline-canvas__milestone-header">
+          <h4 class="pipeline-canvas__milestone-title text-title-small font-semibold">
+            {{ milestone.title }}
+          </h4>
+          <p v-if="milestone.due" class="pipeline-canvas__milestone-date supporting-text">
+            {{ milestone.dueLabel }}
+          </p>
+        </header>
+        <p
+          v-if="milestone.description"
+          class="pipeline-canvas__milestone-description supporting-text"
+        >
+          {{ milestone.description }}
+        </p>
+      </article>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+interface PipelineActivity {
+  id: string;
+  label: string;
+  description?: string;
+  role?: string;
+}
+
+interface PipelineDeliverable {
+  id: string;
+  label: string;
+  description?: string;
+  evidence?: string;
+}
+
+interface PipelineRisk {
+  id: string;
+  label: string;
+  severity?: 'low' | 'medium' | 'high';
+  mitigation?: string;
+}
+
+interface PipelineStage {
+  id: string;
+  title: string;
+  summary?: string;
+  status?: 'not-started' | 'in-progress' | 'blocked' | 'done';
+  owners?: string[];
+  durationHours?: number;
+  activities?: PipelineActivity[];
+  deliverables?: PipelineDeliverable[];
+  risks?: PipelineRisk[];
+  checkpoints?: string[];
+}
+
+interface PipelineMilestone {
+  id: string;
+  title: string;
+  description?: string;
+  due?: string;
+}
+
+interface PipelineCanvasProps {
+  title?: string;
+  summary?: string;
+  stages: PipelineStage[];
+  milestones?: PipelineMilestone[];
+}
+
+const props = withDefaults(defineProps<PipelineCanvasProps>(), {
+  stages: () => [],
+  milestones: () => [],
+  title: undefined,
+  summary: undefined,
+});
+
+type NormalizedActivity = PipelineActivity & { description?: string; role?: string };
+type NormalizedDeliverable = PipelineDeliverable & { description?: string; evidence?: string };
+type NormalizedRisk = PipelineRisk & { severityLabel?: string; mitigation?: string };
+type NormalizedStage = {
+  id: string;
+  title: string;
+  summary?: string;
+  status?: PipelineStage['status'];
+  statusLabel?: string;
+  owners: string[];
+  durationHours?: number;
+  durationLabel?: string;
+  activities: NormalizedActivity[];
+  deliverables: NormalizedDeliverable[];
+  risks: NormalizedRisk[];
+  checkpoints: string[];
+};
+
+type NormalizedMilestone = {
+  id: string;
+  title: string;
+  description?: string;
+  due?: string;
+  dueLabel?: string;
+};
+
+const statusLabelMap: Record<NonNullable<PipelineStage['status']>, string> = {
+  'not-started': 'Não iniciado',
+  'in-progress': 'Em andamento',
+  blocked: 'Bloqueado',
+  done: 'Concluído',
+};
+
+const severityLabelMap: Record<NonNullable<PipelineRisk['severity']>, string> = {
+  low: 'Baixo',
+  medium: 'Médio',
+  high: 'Alto',
+};
+
+const normalizedStages = computed<NormalizedStage[]>(() =>
+  props.stages
+    .map((stage) => ({
+      id: stage.id,
+      title: stage.title,
+      summary: cleanString(stage.summary) || undefined,
+      status: stage.status,
+      statusLabel: stage.status ? statusLabelMap[stage.status] : undefined,
+      owners: normalizeStrings(stage.owners),
+      durationHours: normalizeDuration(stage.durationHours),
+      durationLabel: formatDuration(stage.durationHours),
+      activities: normalizeActivities(stage.activities),
+      deliverables: normalizeDeliverables(stage.deliverables),
+      risks: normalizeRisks(stage.risks),
+      checkpoints: normalizeStrings(stage.checkpoints),
+    }))
+    .filter((stage) => stage.id && stage.title)
+);
+
+const normalizedMilestones = computed<NormalizedMilestone[]>(() =>
+  props.milestones
+    .map((milestone) => ({
+      id: milestone.id,
+      title: milestone.title,
+      description: cleanString(milestone.description) || undefined,
+      due: cleanString(milestone.due) || undefined,
+      dueLabel: formatDate(cleanString(milestone.due)),
+    }))
+    .filter((milestone) => milestone.id && milestone.title)
+);
+
+function normalizeActivities(activities: PipelineActivity[] | undefined): NormalizedActivity[] {
+  if (!Array.isArray(activities)) {
+    return [];
+  }
+  return activities
+    .map((activity, index) => ({
+      id: activity.id ?? `activity-${index}`,
+      label: activity.label,
+      description: cleanString(activity.description) || undefined,
+      role: cleanString(activity.role) || undefined,
+    }))
+    .filter((activity) => activity.id && cleanString(activity.label));
+}
+
+function normalizeDeliverables(
+  deliverables: PipelineDeliverable[] | undefined
+): NormalizedDeliverable[] {
+  if (!Array.isArray(deliverables)) {
+    return [];
+  }
+  return deliverables
+    .map((deliverable, index) => ({
+      id: deliverable.id ?? `deliverable-${index}`,
+      label: deliverable.label,
+      description: cleanString(deliverable.description) || undefined,
+      evidence: cleanString(deliverable.evidence) || undefined,
+    }))
+    .filter((deliverable) => deliverable.id && cleanString(deliverable.label));
+}
+
+function normalizeRisks(risks: PipelineRisk[] | undefined): NormalizedRisk[] {
+  if (!Array.isArray(risks)) {
+    return [];
+  }
+  return risks
+    .map((risk, index) => ({
+      id: risk.id ?? `risk-${index}`,
+      label: risk.label,
+      severity: risk.severity,
+      severityLabel: risk.severity ? severityLabelMap[risk.severity] : undefined,
+      mitigation: cleanString(risk.mitigation) || undefined,
+    }))
+    .filter((risk) => risk.id && cleanString(risk.label));
+}
+
+function normalizeStrings(values: string[] | undefined): string[] {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  return values
+    .map((value) => cleanString(value))
+    .filter((value): value is string => Boolean(value));
+}
+
+function normalizeDuration(value: number | undefined): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+  return undefined;
+}
+
+function formatDuration(value: number | undefined): string | undefined {
+  const normalized = normalizeDuration(value);
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized < 1) {
+    return `${Math.round(normalized * 60)} min`;
+  }
+  if (Number.isInteger(normalized)) {
+    return `${normalized} h`;
+  }
+  return `${normalized.toFixed(1)} h`;
+}
+
+function formatDate(value: string): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleDateString('pt-BR', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function cleanString(value: string | undefined | null): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+</script>
+
+<style scoped>
+.pipeline-canvas {
+  padding: var(--md-sys-spacing-6);
+  border-radius: var(--md-sys-border-radius-3xl);
+  background: color-mix(in srgb, var(--md-sys-color-surface-container-high) 85%, transparent);
+  border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 65%, transparent);
+  gap: var(--md-sys-spacing-6);
+}
+
+.pipeline-canvas__header {
+  gap: var(--md-sys-spacing-2);
+}
+
+.pipeline-canvas__title {
+  margin: 0;
+}
+
+.pipeline-canvas__summary {
+  margin: 0;
+}
+
+.pipeline-canvas__stages {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  gap: var(--md-sys-spacing-5);
+}
+
+.pipeline-canvas__stage {
+  display: grid;
+  gap: var(--md-sys-spacing-4);
+  padding: var(--md-sys-spacing-5);
+  border-radius: var(--md-sys-border-radius-2xl);
+  border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 55%, transparent);
+  background: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
+  box-shadow: var(--shadow-elevation-1);
+  transition: box-shadow 160ms ease;
+}
+
+.pipeline-canvas__stage:hover,
+.pipeline-canvas__stage:focus-within {
+  box-shadow: var(--shadow-elevation-2);
+}
+
+.pipeline-canvas__stage-header {
+  display: grid;
+  gap: var(--md-sys-spacing-3);
+}
+
+.pipeline-canvas__stage-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--md-sys-spacing-3);
+}
+
+.pipeline-canvas__stage-title {
+  margin: 0;
+}
+
+.pipeline-canvas__status {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.75rem;
+  border-radius: 999px;
+  font-size: var(--md-sys-typescale-label-small-size);
+  font-weight: 600;
+  letter-spacing: var(--md-sys-typescale-label-small-tracking);
+  background: color-mix(in srgb, var(--md-sys-color-outline) 40%, transparent);
+  color: var(--md-sys-color-on-surface);
+}
+
+.pipeline-canvas__status[data-status='in-progress'] {
+  background: color-mix(in srgb, var(--md-sys-color-primary-container) 60%, transparent);
+  color: var(--md-sys-color-on-primary-container);
+}
+
+.pipeline-canvas__status[data-status='blocked'] {
+  background: color-mix(in srgb, var(--md-sys-color-error-container) 70%, transparent);
+  color: var(--md-sys-color-on-error-container);
+}
+
+.pipeline-canvas__status[data-status='done'] {
+  background: color-mix(in srgb, var(--md-sys-color-tertiary-container) 65%, transparent);
+  color: var(--md-sys-color-on-tertiary-container);
+}
+
+.pipeline-canvas__stage-summary {
+  margin: 0;
+}
+
+.pipeline-canvas__stage-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--md-sys-spacing-2);
+  align-items: center;
+  margin: 0;
+}
+
+.pipeline-canvas__owners {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--md-sys-spacing-2);
+}
+
+.pipeline-canvas__owner {
+  padding: 0.125rem 0.75rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--md-sys-color-secondary-container) 55%, transparent);
+  color: var(--md-sys-color-on-secondary-container);
+}
+
+.pipeline-canvas__section {
+  display: grid;
+  gap: var(--md-sys-spacing-2);
+}
+
+.pipeline-canvas__section-title {
+  margin: 0;
+}
+
+.pipeline-canvas__items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--md-sys-spacing-3);
+}
+
+.pipeline-canvas__item {
+  display: grid;
+  gap: 0.25rem;
+  padding: var(--md-sys-spacing-3);
+  border-radius: var(--md-sys-border-radius-large);
+  background: color-mix(in srgb, var(--md-sys-color-surface-variant) 35%, transparent);
+}
+
+.pipeline-canvas__item-label {
+  margin: 0;
+}
+
+.pipeline-canvas__item-description,
+.pipeline-canvas__item-role {
+  margin: 0;
+}
+
+.pipeline-canvas__risk {
+  display: inline-flex;
+  align-items: center;
+  margin-left: var(--md-sys-spacing-2);
+  padding: 0 0.5rem;
+  border-radius: 999px;
+  font-size: var(--md-sys-typescale-label-small-size);
+  font-weight: 600;
+  letter-spacing: var(--md-sys-typescale-label-small-tracking);
+  background: color-mix(in srgb, var(--md-sys-color-outline) 40%, transparent);
+}
+
+.pipeline-canvas__risk[data-severity='high'] {
+  background: color-mix(in srgb, var(--md-sys-color-error) 45%, transparent);
+  color: var(--md-sys-color-on-error);
+}
+
+.pipeline-canvas__risk[data-severity='medium'] {
+  background: color-mix(in srgb, var(--md-sys-color-tertiary) 35%, transparent);
+  color: var(--md-sys-color-on-tertiary);
+}
+
+.pipeline-canvas__risk[data-severity='low'] {
+  background: color-mix(in srgb, var(--md-sys-color-secondary) 30%, transparent);
+  color: var(--md-sys-color-on-secondary);
+}
+
+.pipeline-canvas__chips {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--md-sys-spacing-2);
+}
+
+.pipeline-canvas__chip {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--md-sys-color-primary-container) 40%, transparent);
+  color: var(--md-sys-color-on-primary-container);
+}
+
+.pipeline-canvas__milestones {
+  gap: var(--md-sys-spacing-3);
+}
+
+.pipeline-canvas__milestone {
+  border-radius: var(--md-sys-border-radius-2xl);
+  border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 55%, transparent);
+  padding: var(--md-sys-spacing-4);
+  display: grid;
+  gap: var(--md-sys-spacing-2);
+  background: var(--md-sys-color-surface);
+}
+
+.pipeline-canvas__milestone-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--md-sys-spacing-3);
+}
+
+.pipeline-canvas__milestone-title,
+.pipeline-canvas__milestone-date,
+.pipeline-canvas__milestone-description {
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  .pipeline-canvas {
+    padding: var(--md-sys-spacing-4);
+  }
+
+  .pipeline-canvas__stage {
+    padding: var(--md-sys-spacing-4);
+  }
+}
+</style>

--- a/src/components/lesson/SystemMapper.vue
+++ b/src/components/lesson/SystemMapper.vue
@@ -1,0 +1,539 @@
+<template>
+  <section class="system-mapper card md-stack" role="group" :aria-label="title ?? 'Mapa sistêmico'">
+    <header v-if="title || summary" class="system-mapper__header md-stack">
+      <h3 v-if="title" class="system-mapper__title text-title-medium font-semibold text-on-surface">
+        {{ title }}
+      </h3>
+      <p v-if="summary" class="system-mapper__summary supporting-text">
+        {{ summary }}
+      </p>
+    </header>
+
+    <div class="system-mapper__factors" role="list">
+      <article
+        v-for="factor in normalizedFactors"
+        :key="factor.id"
+        class="system-mapper__factor md-surface"
+        role="listitem"
+        :aria-labelledby="`${factor.id}-label`"
+        :data-kind="factor.kind ?? 'driver'"
+      >
+        <header class="system-mapper__factor-header">
+          <span class="system-mapper__factor-kind" :data-kind="factor.kind ?? 'driver'">
+            {{ factor.kindLabel }}
+          </span>
+          <h4
+            :id="`${factor.id}-label`"
+            class="system-mapper__factor-title text-title-small font-semibold"
+          >
+            {{ factor.name }}
+          </h4>
+        </header>
+        <p v-if="factor.summary" class="system-mapper__factor-summary supporting-text">
+          {{ factor.summary }}
+        </p>
+        <ul
+          v-if="factor.indicators.length"
+          class="system-mapper__indicators"
+          role="list"
+          aria-label="Indicadores monitorados"
+        >
+          <li
+            v-for="indicator in factor.indicators"
+            :key="indicator"
+            class="system-mapper__indicator"
+            role="listitem"
+          >
+            {{ indicator }}
+          </li>
+        </ul>
+      </article>
+    </div>
+
+    <section
+      v-if="normalizedLoops.length"
+      class="system-mapper__loops md-stack"
+      aria-label="Loops de feedback"
+      role="list"
+    >
+      <article
+        v-for="loop in normalizedLoops"
+        :key="loop.id"
+        class="system-mapper__loop"
+        role="listitem"
+      >
+        <header class="system-mapper__loop-header">
+          <span class="system-mapper__loop-badge" :data-polarity="loop.polarity">
+            {{ loop.polarity === 'reinforcing' ? 'R' : 'B' }}
+          </span>
+          <div class="system-mapper__loop-heading">
+            <h4 class="system-mapper__loop-title text-title-small font-semibold">
+              {{ loop.name }}
+            </h4>
+            <p class="system-mapper__loop-polarity supporting-text">{{ loop.polarityLabel }}</p>
+          </div>
+        </header>
+        <p v-if="loop.summary" class="system-mapper__loop-summary supporting-text">
+          {{ loop.summary }}
+        </p>
+        <ol class="system-mapper__steps" role="list">
+          <li
+            v-for="step in loop.steps"
+            :key="step.id"
+            class="system-mapper__step"
+            :data-effect="step.effect"
+          >
+            <p class="system-mapper__step-connection text-body-medium">
+              {{ step.fromLabel }} → {{ step.toLabel }}
+              <span v-if="step.effectLabel" class="system-mapper__step-effect"
+                >({{ step.effectLabel }})</span
+              >
+            </p>
+            <p v-if="step.description" class="system-mapper__step-description supporting-text">
+              {{ step.description }}
+            </p>
+          </li>
+        </ol>
+        <ul
+          v-if="loop.insights.length"
+          class="system-mapper__loop-insights"
+          role="list"
+          aria-label="Insights desse loop"
+        >
+          <li
+            v-for="insight in loop.insights"
+            :key="insight"
+            class="system-mapper__loop-insight supporting-text"
+            role="listitem"
+          >
+            {{ insight }}
+          </li>
+        </ul>
+      </article>
+    </section>
+
+    <section
+      v-if="normalizedInsights.length"
+      class="system-mapper__insights md-stack"
+      aria-label="Insights gerais"
+      role="list"
+    >
+      <article
+        v-for="insight in normalizedInsights"
+        :key="insight.id"
+        class="system-mapper__insight"
+        role="listitem"
+      >
+        <header class="system-mapper__insight-header">
+          <h4 class="system-mapper__insight-title text-title-small font-semibold">
+            {{ insight.label }}
+          </h4>
+        </header>
+        <p v-if="insight.description" class="system-mapper__insight-description supporting-text">
+          {{ insight.description }}
+        </p>
+      </article>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+type SystemFactorKind = 'stock' | 'flow' | 'driver' | 'outcome' | 'constraint';
+
+type SystemFactor = {
+  id: string;
+  name: string;
+  summary?: string;
+  kind?: SystemFactorKind;
+  indicators?: string[];
+};
+
+type SystemLoopStep = {
+  id: string;
+  from: string;
+  to: string;
+  effect?: 'reinforces' | 'balances';
+  description?: string;
+};
+
+type SystemLoop = {
+  id: string;
+  name: string;
+  polarity: 'reinforcing' | 'balancing';
+  summary?: string;
+  steps: SystemLoopStep[];
+  insights?: string[];
+};
+
+type SystemInsight = {
+  id: string;
+  label: string;
+  description?: string;
+};
+
+interface SystemMapperProps {
+  title?: string;
+  summary?: string;
+  factors: SystemFactor[];
+  loops: SystemLoop[];
+  insights?: SystemInsight[];
+}
+
+const props = withDefaults(defineProps<SystemMapperProps>(), {
+  factors: () => [],
+  loops: () => [],
+  insights: () => [],
+  title: undefined,
+  summary: undefined,
+});
+
+type NormalizedFactor = {
+  id: string;
+  name: string;
+  summary?: string;
+  kind?: SystemFactorKind;
+  kindLabel: string;
+  indicators: string[];
+};
+
+type NormalizedLoopStep = {
+  id: string;
+  fromLabel: string;
+  toLabel: string;
+  effect?: 'reinforces' | 'balances';
+  effectLabel?: string;
+  description?: string;
+};
+
+type NormalizedLoop = {
+  id: string;
+  name: string;
+  polarity: SystemLoop['polarity'];
+  polarityLabel: string;
+  summary?: string;
+  steps: NormalizedLoopStep[];
+  insights: string[];
+};
+
+type NormalizedInsight = {
+  id: string;
+  label: string;
+  description?: string;
+};
+
+const factorLabelMap: Record<SystemFactorKind, string> = {
+  stock: 'Estoque',
+  flow: 'Fluxo',
+  driver: 'Motor',
+  outcome: 'Resultado',
+  constraint: 'Restrição',
+};
+
+const polarityLabelMap: Record<SystemLoop['polarity'], string> = {
+  reinforcing: 'Loop reforçador',
+  balancing: 'Loop balanceador',
+};
+
+const effectLabelMap: Record<NonNullable<SystemLoopStep['effect']>, string> = {
+  reinforces: 'Reforça',
+  balances: 'Equilibra',
+};
+
+const normalizedFactors = computed<NormalizedFactor[]>(() =>
+  props.factors
+    .map((factor) => ({
+      id: factor.id,
+      name: factor.name,
+      summary: cleanString(factor.summary) || undefined,
+      kind: factor.kind,
+      kindLabel: factor.kind ? factorLabelMap[factor.kind] : factorLabelMap.driver,
+      indicators: normalizeStrings(factor.indicators),
+    }))
+    .filter((factor) => factor.id && factor.name)
+);
+
+const normalizedLoops = computed<NormalizedLoop[]>(() =>
+  props.loops
+    .map((loop) => ({
+      id: loop.id,
+      name: loop.name,
+      polarity: loop.polarity,
+      polarityLabel: polarityLabelMap[loop.polarity],
+      summary: cleanString(loop.summary) || undefined,
+      steps: normalizeSteps(loop.steps),
+      insights: normalizeStrings(loop.insights),
+    }))
+    .filter((loop) => loop.id && loop.name && loop.steps.length)
+);
+
+const normalizedInsights = computed<NormalizedInsight[]>(() =>
+  props.insights
+    .map((insight) => ({
+      id: insight.id,
+      label: insight.label,
+      description: cleanString(insight.description) || undefined,
+    }))
+    .filter((insight) => insight.id && insight.label)
+);
+
+function normalizeSteps(steps: SystemLoopStep[] | undefined): NormalizedLoopStep[] {
+  if (!Array.isArray(steps)) {
+    return [];
+  }
+  return steps
+    .map((step, index) => ({
+      id: step.id ?? `step-${index}`,
+      fromLabel: cleanString(step.from),
+      toLabel: cleanString(step.to),
+      effect: step.effect,
+      effectLabel: step.effect ? effectLabelMap[step.effect] : undefined,
+      description: cleanString(step.description) || undefined,
+    }))
+    .filter((step) => step.id && step.fromLabel && step.toLabel);
+}
+
+function normalizeStrings(values: string[] | undefined): string[] {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  return values
+    .map((value) => cleanString(value))
+    .filter((value): value is string => Boolean(value));
+}
+
+function cleanString(value: string | undefined | null): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+</script>
+
+<style scoped>
+.system-mapper {
+  padding: var(--md-sys-spacing-6);
+  border-radius: var(--md-sys-border-radius-3xl);
+  background: color-mix(in srgb, var(--md-sys-color-surface-container-high) 85%, transparent);
+  border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 65%, transparent);
+  gap: var(--md-sys-spacing-6);
+}
+
+.system-mapper__header {
+  gap: var(--md-sys-spacing-2);
+}
+
+.system-mapper__title {
+  margin: 0;
+}
+
+.system-mapper__summary {
+  margin: 0;
+}
+
+.system-mapper__factors {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  gap: var(--md-sys-spacing-5);
+}
+
+.system-mapper__factor {
+  display: grid;
+  gap: var(--md-sys-spacing-3);
+  padding: var(--md-sys-spacing-5);
+  border-radius: var(--md-sys-border-radius-2xl);
+  border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 55%, transparent);
+  background: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
+  box-shadow: var(--shadow-elevation-1);
+}
+
+.system-mapper__factor-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--md-sys-spacing-2);
+}
+
+.system-mapper__factor-kind {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.75rem;
+  border-radius: 999px;
+  font-size: var(--md-sys-typescale-label-small-size);
+  font-weight: 600;
+  letter-spacing: var(--md-sys-typescale-label-small-tracking);
+  background: color-mix(in srgb, var(--md-sys-color-outline) 40%, transparent);
+  color: var(--md-sys-color-on-surface);
+}
+
+.system-mapper__factor-kind[data-kind='stock'] {
+  background: color-mix(in srgb, var(--md-sys-color-primary-container) 60%, transparent);
+  color: var(--md-sys-color-on-primary-container);
+}
+
+.system-mapper__factor-kind[data-kind='flow'] {
+  background: color-mix(in srgb, var(--md-sys-color-secondary-container) 60%, transparent);
+  color: var(--md-sys-color-on-secondary-container);
+}
+
+.system-mapper__factor-kind[data-kind='outcome'] {
+  background: color-mix(in srgb, var(--md-sys-color-tertiary-container) 65%, transparent);
+  color: var(--md-sys-color-on-tertiary-container);
+}
+
+.system-mapper__factor-kind[data-kind='constraint'] {
+  background: color-mix(in srgb, var(--md-sys-color-error-container) 70%, transparent);
+  color: var(--md-sys-color-on-error-container);
+}
+
+.system-mapper__factor-title {
+  margin: 0;
+}
+
+.system-mapper__factor-summary {
+  margin: 0;
+}
+
+.system-mapper__indicators {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--md-sys-spacing-2);
+}
+
+.system-mapper__indicator {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--md-sys-color-surface-variant) 40%, transparent);
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.system-mapper__loops {
+  gap: var(--md-sys-spacing-4);
+}
+
+.system-mapper__loop {
+  border-radius: var(--md-sys-border-radius-2xl);
+  border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 55%, transparent);
+  background: var(--md-sys-color-surface);
+  padding: var(--md-sys-spacing-4);
+  display: grid;
+  gap: var(--md-sys-spacing-3);
+}
+
+.system-mapper__loop-header {
+  display: flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-3);
+}
+
+.system-mapper__loop-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  font-weight: 700;
+  background: color-mix(in srgb, var(--md-sys-color-primary) 45%, transparent);
+  color: var(--md-sys-color-on-primary);
+}
+
+.system-mapper__loop-badge[data-polarity='balancing'] {
+  background: color-mix(in srgb, var(--md-sys-color-tertiary) 45%, transparent);
+  color: var(--md-sys-color-on-tertiary);
+}
+
+.system-mapper__loop-heading {
+  display: grid;
+  gap: 0.125rem;
+}
+
+.system-mapper__loop-title,
+.system-mapper__loop-polarity,
+.system-mapper__loop-summary {
+  margin: 0;
+}
+
+.system-mapper__steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--md-sys-spacing-3);
+}
+
+.system-mapper__step {
+  padding: var(--md-sys-spacing-3);
+  border-radius: var(--md-sys-border-radius-large);
+  background: color-mix(in srgb, var(--md-sys-color-surface-variant) 35%, transparent);
+  display: grid;
+  gap: 0.25rem;
+}
+
+.system-mapper__step[data-effect='reinforces'] {
+  border-left: 4px solid color-mix(in srgb, var(--md-sys-color-primary) 60%, transparent);
+}
+
+.system-mapper__step[data-effect='balances'] {
+  border-left: 4px solid color-mix(in srgb, var(--md-sys-color-tertiary) 60%, transparent);
+}
+
+.system-mapper__step-connection,
+.system-mapper__step-description {
+  margin: 0;
+}
+
+.system-mapper__step-effect {
+  margin-left: var(--md-sys-spacing-1);
+  font-size: var(--md-sys-typescale-label-small-size);
+  font-weight: 600;
+  color: color-mix(in srgb, var(--md-sys-color-primary) 55%, var(--md-sys-color-on-surface) 45%);
+}
+
+.system-mapper__loop-insights {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--md-sys-spacing-2);
+}
+
+.system-mapper__loop-insight {
+  padding: var(--md-sys-spacing-2) var(--md-sys-spacing-3);
+  border-radius: var(--md-sys-border-radius-large);
+  background: color-mix(in srgb, var(--md-sys-color-primary-container) 40%, transparent);
+  color: var(--md-sys-color-on-primary-container);
+}
+
+.system-mapper__insights {
+  gap: var(--md-sys-spacing-3);
+}
+
+.system-mapper__insight {
+  border-radius: var(--md-sys-border-radius-2xl);
+  border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 55%, transparent);
+  background: var(--md-sys-color-surface);
+  padding: var(--md-sys-spacing-4);
+  display: grid;
+  gap: var(--md-sys-spacing-2);
+}
+
+.system-mapper__insight-title,
+.system-mapper__insight-description {
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  .system-mapper {
+    padding: var(--md-sys-spacing-4);
+  }
+
+  .system-mapper__factor,
+  .system-mapper__loop,
+  .system-mapper__insight {
+    padding: var(--md-sys-spacing-4);
+  }
+}
+</style>

--- a/src/components/lesson/__tests__/ClassDesigner.test.ts
+++ b/src/components/lesson/__tests__/ClassDesigner.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ClassDesigner from '../ClassDesigner.vue';
+
+describe('ClassDesigner', () => {
+  const classes = [
+    {
+      id: 'order-service',
+      name: 'OrderService',
+      stereotype: 'service',
+      type: 'class' as const,
+      summary: 'Orquestra validação e envio de pedidos.',
+      attributes: [
+        { id: 'repo', signature: 'repo: OrderRepository', visibility: 'private' as const },
+        { id: 'queue', signature: 'queue: MessageQueue', note: 'Injetada via construtor' },
+      ],
+      methods: [
+        {
+          id: 'place',
+          signature: '+ place(order: Order): Confirmation',
+          note: 'Aplica regras de negócio',
+        },
+        { id: 'retry', signature: '# retry(orderId: string): void' },
+      ],
+      responsibilities: ['Validar dados de entrada', 'Publicar eventos para o billing'],
+      notes: ['Seguir princípios de idempotência'],
+    },
+  ];
+
+  const relationships = [
+    {
+      id: 'repo-association',
+      from: 'OrderService',
+      to: 'OrderRepository',
+      type: 'aggregation' as const,
+      description: 'Depende da implementação para persistir pedidos',
+      toMultiplicity: '1',
+    },
+    {
+      id: 'service-interface',
+      from: 'CheckoutService',
+      to: 'OrderService',
+      type: 'dependency' as const,
+      description: 'Invoca durante o fluxo de checkout',
+    },
+  ];
+
+  it('renders classes with attributes, methods and responsibilities', () => {
+    const wrapper = mount(ClassDesigner, { props: { classes } });
+
+    expect(wrapper.find('.class-designer__class-name').text()).toBe('OrderService');
+    const attributes = wrapper.findAll('.class-designer__member');
+    expect(attributes[0].text()).toContain('-');
+    expect(attributes[0].text()).toContain('repo: OrderRepository');
+    expect(wrapper.find('.class-designer__responsibility').text()).toContain(
+      'Validar dados de entrada'
+    );
+  });
+
+  it('converts visibility into UML symbols and renders notes', () => {
+    const wrapper = mount(ClassDesigner, { props: { classes } });
+
+    const visibilityBadges = wrapper.findAll('.class-designer__member-visibility');
+    expect(visibilityBadges[0].text()).toBe('-');
+    expect(visibilityBadges[1].text()).toBe('+');
+    expect(wrapper.find('.class-designer__member-note').text()).toContain(
+      'Injetada via construtor'
+    );
+  });
+
+  it('displays relationships with multiplicity and legend entries', () => {
+    const legend = [
+      {
+        id: 'aggregation',
+        label: 'Agregação',
+        description: 'Ciclo de vida independente',
+        kind: 'aggregation' as const,
+      },
+    ];
+    const wrapper = mount(ClassDesigner, {
+      props: { classes, relationships, legend },
+    });
+
+    const relationshipItems = wrapper.findAll('.class-designer__relationship');
+    expect(relationshipItems).toHaveLength(2);
+    expect(relationshipItems[0].text()).toContain('OrderRepository [1]');
+    expect(relationshipItems[0].text()).toContain('Agregação');
+    expect(wrapper.find('.class-designer__legend-item').text()).toContain('Agregação');
+  });
+});

--- a/src/components/lesson/__tests__/PipelineCanvas.test.ts
+++ b/src/components/lesson/__tests__/PipelineCanvas.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import PipelineCanvas from '../PipelineCanvas.vue';
+
+describe('PipelineCanvas', () => {
+  const stages = [
+    {
+      id: 'ideation',
+      title: 'Ideação',
+      summary: 'Explorar referências e hipóteses de gameplay.',
+      status: 'in-progress' as const,
+      owners: ['Game Designer', 'Produtor'],
+      durationHours: 12,
+      activities: [
+        { id: 'research', label: 'Pesquisa de referências', role: 'Game Designer' },
+        {
+          id: 'pitch',
+          label: 'Construir pitch de 1 página',
+          description: 'Narrativa + loop central',
+        },
+      ],
+      deliverables: [{ id: 'pitch', label: 'Pitch deck', evidence: 'Apresentação no FigJam' }],
+      risks: [
+        {
+          id: 'scope',
+          label: 'Escopo muito amplo',
+          severity: 'high' as const,
+          mitigation: 'Definir critérios de corte',
+        },
+      ],
+      checkpoints: ['Pitch aprovado', 'Personas validadas'],
+    },
+  ];
+
+  const milestones = [
+    {
+      id: 'greenlight',
+      title: 'Greenlight da produção',
+      description: 'Comitê avalia escopo e orçamento.',
+      due: '2024-08-15',
+    },
+  ];
+
+  it('renders stages with activities, deliverables and risks', () => {
+    const wrapper = mount(PipelineCanvas, { props: { stages } });
+
+    expect(wrapper.find('.pipeline-canvas__stage-title').text()).toBe('Ideação');
+    expect(wrapper.findAll('.pipeline-canvas__item')).toHaveLength(4);
+    expect(wrapper.find('.pipeline-canvas__status').text()).toBe('Em andamento');
+    expect(wrapper.find('.pipeline-canvas__risk').text()).toContain('Alto');
+  });
+
+  it('formats metadata such as owners, duration and checkpoints', () => {
+    const wrapper = mount(PipelineCanvas, { props: { stages } });
+
+    expect(wrapper.find('.pipeline-canvas__duration').text()).toContain('12 h');
+    const owners = wrapper.findAll('.pipeline-canvas__owner');
+    expect(owners).toHaveLength(2);
+    expect(wrapper.find('.pipeline-canvas__chip').text()).toBe('Pitch aprovado');
+  });
+
+  it('displays milestones with formatted dates', () => {
+    const wrapper = mount(PipelineCanvas, { props: { stages, milestones } });
+
+    const milestone = wrapper.find('.pipeline-canvas__milestone');
+    expect(milestone.text()).toContain('Greenlight da produção');
+    expect(milestone.text()).toMatch(/15.*ago/i);
+  });
+});

--- a/src/components/lesson/__tests__/SystemMapper.test.ts
+++ b/src/components/lesson/__tests__/SystemMapper.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import SystemMapper from '../SystemMapper.vue';
+
+describe('SystemMapper', () => {
+  const factors = [
+    {
+      id: 'players',
+      name: 'Base de jogadores',
+      kind: 'stock' as const,
+      summary: 'Quantidade ativa semanalmente.',
+      indicators: ['MAU', 'Retenção D7'],
+    },
+    {
+      id: 'marketing',
+      name: 'Investimento em marketing',
+      kind: 'driver' as const,
+    },
+  ];
+
+  const loops = [
+    {
+      id: 'growth-loop',
+      name: 'Loop de crescimento viral',
+      polarity: 'reinforcing' as const,
+      summary: 'Quanto mais jogadoras, maior boca a boca e aquisição.',
+      steps: [
+        { id: 'step-1', from: 'Marketing', to: 'Base de jogadores', effect: 'reinforces' as const },
+        {
+          id: 'step-2',
+          from: 'Base de jogadores',
+          to: 'Indicadores sociais',
+          effect: 'reinforces' as const,
+        },
+        {
+          id: 'step-3',
+          from: 'Indicadores sociais',
+          to: 'Base de jogadores',
+          description: 'Compartilhamentos ampliam alcance orgânico.',
+        },
+      ],
+      insights: ['Monitorar CAC semanalmente'],
+    },
+  ];
+
+  const insights = [
+    {
+      id: 'action-1',
+      label: 'Ativar programa de indicações',
+      description: 'Aumentar recompensas para convites.',
+    },
+  ];
+
+  it('renders factors with kind labels and indicators', () => {
+    const wrapper = mount(SystemMapper, { props: { factors, loops: [], insights: [] } });
+
+    const factorCards = wrapper.findAll('.system-mapper__factor');
+    expect(factorCards).toHaveLength(2);
+    expect(factorCards[0].text()).toContain('Estoque');
+    expect(wrapper.find('.system-mapper__indicator').text()).toContain('MAU');
+  });
+
+  it('describes loops with polarity badges and steps', () => {
+    const wrapper = mount(SystemMapper, { props: { factors, loops, insights: [] } });
+
+    const loop = wrapper.find('.system-mapper__loop');
+    expect(loop.find('.system-mapper__loop-badge').text()).toBe('R');
+    const steps = wrapper.findAll('.system-mapper__step');
+    expect(steps).toHaveLength(3);
+    expect(steps[0].text()).toContain('Marketing → Base de jogadores');
+    expect(steps[0].text()).toContain('Reforça');
+  });
+
+  it('shows global insights when provided', () => {
+    const wrapper = mount(SystemMapper, { props: { factors, loops, insights } });
+
+    expect(wrapper.find('.system-mapper__insight-title').text()).toContain(
+      'Ativar programa de indicações'
+    );
+    expect(wrapper.find('.system-mapper__insight-description').text()).toContain(
+      'Aumentar recompensas'
+    );
+  });
+});

--- a/src/components/lesson/blockRegistry.ts
+++ b/src/components/lesson/blockRegistry.ts
@@ -7,6 +7,7 @@ import ChecklistBlock from '@/components/lesson/ChecklistBlock.vue';
 import CodeBlock from '@/components/lesson/CodeBlock.vue';
 import ContentBlock from '@/components/lesson/ContentBlock.vue';
 import FlightPlan from '@/components/lesson/FlightPlan.vue';
+import ClassDesigner from '@/components/lesson/ClassDesigner.vue';
 import LegacyHtml from '@/components/lesson/LegacyHtml.vue';
 import LegacySection from '@/components/lesson/LegacySection.vue';
 import LessonPlan from '@/components/lesson/LessonPlan.vue';
@@ -16,8 +17,10 @@ import Md3LogicOperators from '@/components/lesson/Md3LogicOperators.vue';
 import Md3Table from '@/components/lesson/Md3Table.vue';
 import MemoryDiagram from '@/components/lesson/MemoryDiagram.vue';
 import OrderedList from '@/components/lesson/OrderedList.vue';
+import PipelineCanvas from '@/components/lesson/PipelineCanvas.vue';
 import Representations from '@/components/lesson/Representations.vue';
 import Roadmap from '@/components/lesson/Roadmap.vue';
+import SystemMapper from '@/components/lesson/SystemMapper.vue';
 import Timeline from '@/components/lesson/Timeline.vue';
 import TruthTable from '@/components/lesson/TruthTable.vue';
 import VideosBlock from '@/components/lesson/VideosBlock.vue';
@@ -43,6 +46,9 @@ const customComponentRegistry: Record<string, Component> = {
   OrderedList,
   CardGrid,
   Roadmap,
+  ClassDesigner,
+  PipelineCanvas,
+  SystemMapper,
 };
 
 const blockHandlers: Record<string, (block: LessonBlock) => BlockResolution> = {
@@ -116,6 +122,29 @@ const blockHandlers: Record<string, (block: LessonBlock) => BlockResolution> = {
       },
     };
   },
+  md3Flowchart(block) {
+    return {
+      component: Md3Flowchart,
+      props: {
+        title: toOptionalString(block.title),
+        summary: toOptionalString(block.summary),
+        nodes: toFlowNodes(block.nodes),
+        connections: toFlowConnections(block.connections),
+      },
+    };
+  },
+  classDesigner(block) {
+    return {
+      component: ClassDesigner,
+      props: {
+        title: toOptionalString(block.title),
+        summary: toOptionalString(block.summary),
+        classes: toUmlClasses(block.classes),
+        relationships: toUmlRelationships(block.relationships),
+        legend: toLegendEntries(block.legend),
+      },
+    };
+  },
   audio(block) {
     return {
       component: AudioBlock,
@@ -134,6 +163,29 @@ const blockHandlers: Record<string, (block: LessonBlock) => BlockResolution> = {
       props: {
         headers: toStringArray(block.headers),
         rows: toTableRows(block.rows),
+      },
+    };
+  },
+  pipelineCanvas(block) {
+    return {
+      component: PipelineCanvas,
+      props: {
+        title: toOptionalString(block.title),
+        summary: toOptionalString(block.summary),
+        stages: toPipelineStages(block.stages ?? block.columns ?? block.steps),
+        milestones: toPipelineMilestones(block.milestones),
+      },
+    };
+  },
+  systemMapper(block) {
+    return {
+      component: SystemMapper,
+      props: {
+        title: toOptionalString(block.title),
+        summary: toOptionalString(block.summary),
+        factors: toSystemFactors(block.factors),
+        loops: toSystemLoops(block.loops ?? block.cycles),
+        insights: toSystemInsights(block.insights),
       },
     };
   },
@@ -220,6 +272,14 @@ function shouldUsePlainText(language?: string): boolean {
 
 function toOptionalString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function toOptionalTrimmedString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function toString(value: unknown): string {
@@ -601,6 +661,697 @@ function toTableRows(value: unknown): TableRow[] {
       return { value: String(cell) } satisfies TableCell;
     });
   });
+}
+
+function toUmlClasses(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [] as Array<{
+      id: string;
+      name: string;
+      stereotype?: string;
+      summary?: string;
+      type?: 'class' | 'interface' | 'enum';
+      attributes?: Array<{
+        id: string;
+        signature: string;
+        visibility?: 'public' | 'private' | 'protected' | 'package';
+        note?: string;
+      }>;
+      methods?: Array<{
+        id: string;
+        signature: string;
+        visibility?: 'public' | 'private' | 'protected' | 'package';
+        note?: string;
+      }>;
+      responsibilities?: string[];
+      notes?: string[];
+    }>;
+  }
+
+  return value
+    .map((entry) => {
+      const record = toRecord(entry);
+      const id = toString(record.id);
+      const name = toString(record.name);
+      if (!id || !name) {
+        return undefined;
+      }
+      return {
+        id,
+        name,
+        stereotype: toOptionalTrimmedString(record.stereotype),
+        summary: toOptionalTrimmedString(record.summary),
+        type: toUmlType(record.type),
+        attributes: toUmlMembers(record.attributes),
+        methods: toUmlMembers(record.methods),
+        responsibilities: toTrimmedStringArray(record.responsibilities),
+        notes: toTrimmedStringArray(record.notes),
+      };
+    })
+    .filter(
+      (
+        umlClass
+      ): umlClass is {
+        id: string;
+        name: string;
+        stereotype?: string;
+        summary?: string;
+        type?: 'class' | 'interface' | 'enum';
+        attributes?: Array<{
+          id: string;
+          signature: string;
+          visibility?: 'public' | 'private' | 'protected' | 'package';
+          note?: string;
+        }>;
+        methods?: Array<{
+          id: string;
+          signature: string;
+          visibility?: 'public' | 'private' | 'protected' | 'package';
+          note?: string;
+        }>;
+        responsibilities?: string[];
+        notes?: string[];
+      } => Boolean(umlClass)
+    );
+}
+
+function toUmlMembers(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [] as Array<{
+      id: string;
+      signature: string;
+      visibility?: 'public' | 'private' | 'protected' | 'package';
+      note?: string;
+    }>;
+  }
+
+  return value
+    .map((entry, index) => {
+      const record = toRecord(entry);
+      const signature = toOptionalTrimmedString(record.signature ?? record.text);
+      if (!signature) {
+        return undefined;
+      }
+      const visibility = toUmlVisibility(record.visibility);
+      return {
+        id: toString(record.id) || `member-${index}`,
+        signature,
+        visibility,
+        note: toOptionalTrimmedString(record.note),
+      };
+    })
+    .filter(
+      (
+        member
+      ): member is {
+        id: string;
+        signature: string;
+        visibility?: 'public' | 'private' | 'protected' | 'package';
+        note?: string;
+      } => Boolean(member)
+    );
+}
+
+function toUmlRelationships(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [] as Array<{
+      id: string;
+      from: string;
+      to: string;
+      type:
+        | 'association'
+        | 'aggregation'
+        | 'composition'
+        | 'inheritance'
+        | 'realization'
+        | 'dependency';
+      description?: string;
+      fromMultiplicity?: string;
+      toMultiplicity?: string;
+    }>;
+  }
+
+  const types = new Set([
+    'association',
+    'aggregation',
+    'composition',
+    'inheritance',
+    'realization',
+    'dependency',
+  ]);
+
+  return value
+    .map((entry) => {
+      const record = toRecord(entry);
+      const id = toString(record.id);
+      const from = toString(record.from);
+      const to = toString(record.to);
+      const type = toOptionalTrimmedString(record.type);
+      if (!id || !from || !to || !type || !types.has(type)) {
+        return undefined;
+      }
+      return {
+        id,
+        from,
+        to,
+        type: type as any,
+        description: toOptionalTrimmedString(record.description),
+        fromMultiplicity: toOptionalTrimmedString(record.fromMultiplicity),
+        toMultiplicity: toOptionalTrimmedString(record.toMultiplicity),
+      };
+    })
+    .filter(
+      (
+        relationship
+      ): relationship is {
+        id: string;
+        from: string;
+        to: string;
+        type:
+          | 'association'
+          | 'aggregation'
+          | 'composition'
+          | 'inheritance'
+          | 'realization'
+          | 'dependency';
+        description?: string;
+        fromMultiplicity?: string;
+        toMultiplicity?: string;
+      } => Boolean(relationship)
+    );
+}
+
+function toPipelineStages(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [] as Array<{
+      id: string;
+      title: string;
+      summary?: string;
+      status?: 'not-started' | 'in-progress' | 'blocked' | 'done';
+      owners?: string[];
+      durationHours?: number;
+      activities?: Array<{ id: string; label: string; description?: string; role?: string }>;
+      deliverables?: Array<{ id: string; label: string; description?: string; evidence?: string }>;
+      risks?: Array<{
+        id: string;
+        label: string;
+        severity?: 'low' | 'medium' | 'high';
+        mitigation?: string;
+      }>;
+      checkpoints?: string[];
+    }>;
+  }
+
+  return value
+    .map((entry) => {
+      const record = toRecord(entry);
+      const id = toString(record.id);
+      const title = toString(record.title);
+      if (!id || !title) {
+        return undefined;
+      }
+      return {
+        id,
+        title,
+        summary: toOptionalTrimmedString(record.summary),
+        status: toPipelineStatus(record.status),
+        owners: toTrimmedStringArray(record.owners),
+        durationHours: toPositiveNumber(record.durationHours),
+        activities: toPipelineActivities(record.activities),
+        deliverables: toPipelineDeliverables(record.deliverables),
+        risks: toPipelineRisks(record.risks),
+        checkpoints: toTrimmedStringArray(record.checkpoints),
+      };
+    })
+    .filter(
+      (
+        stage
+      ): stage is {
+        id: string;
+        title: string;
+        summary?: string;
+        status?: 'not-started' | 'in-progress' | 'blocked' | 'done';
+        owners?: string[];
+        durationHours?: number;
+        activities?: Array<{ id: string; label: string; description?: string; role?: string }>;
+        deliverables?: Array<{
+          id: string;
+          label: string;
+          description?: string;
+          evidence?: string;
+        }>;
+        risks?: Array<{
+          id: string;
+          label: string;
+          severity?: 'low' | 'medium' | 'high';
+          mitigation?: string;
+        }>;
+        checkpoints?: string[];
+      } => Boolean(stage)
+    );
+}
+
+function toPipelineActivities(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [] as Array<{ id: string; label: string; description?: string; role?: string }>;
+  }
+
+  return value
+    .map((entry, index) => {
+      const record = toRecord(entry);
+      const label = toOptionalTrimmedString(record.label ?? record.title);
+      if (!label) {
+        return undefined;
+      }
+      return {
+        id: toString(record.id) || `activity-${index}`,
+        label,
+        description: toOptionalTrimmedString(record.description),
+        role: toOptionalTrimmedString(record.role ?? record.owner),
+      };
+    })
+    .filter(
+      (activity): activity is { id: string; label: string; description?: string; role?: string } =>
+        Boolean(activity)
+    );
+}
+
+function toPipelineDeliverables(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [] as Array<{ id: string; label: string; description?: string; evidence?: string }>;
+  }
+
+  return value
+    .map((entry, index) => {
+      const record = toRecord(entry);
+      const label = toOptionalTrimmedString(record.label ?? record.title);
+      if (!label) {
+        return undefined;
+      }
+      return {
+        id: toString(record.id) || `deliverable-${index}`,
+        label,
+        description: toOptionalTrimmedString(record.description),
+        evidence: toOptionalTrimmedString(record.evidence ?? record.proof),
+      };
+    })
+    .filter(
+      (
+        deliverable
+      ): deliverable is { id: string; label: string; description?: string; evidence?: string } =>
+        Boolean(deliverable)
+    );
+}
+
+function toPipelineRisks(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [] as Array<{
+      id: string;
+      label: string;
+      severity?: 'low' | 'medium' | 'high';
+      mitigation?: string;
+    }>;
+  }
+
+  const severities = new Set(['low', 'medium', 'high']);
+
+  return value
+    .map((entry, index) => {
+      const record = toRecord(entry);
+      const label = toOptionalTrimmedString(record.label ?? record.title);
+      if (!label) {
+        return undefined;
+      }
+      const severityValue = toOptionalTrimmedString(record.severity);
+      const severity =
+        severityValue && severities.has(severityValue) ? (severityValue as any) : undefined;
+      return {
+        id: toString(record.id) || `risk-${index}`,
+        label,
+        severity,
+        mitigation: toOptionalTrimmedString(record.mitigation ?? record.response),
+      };
+    })
+    .filter(
+      (
+        risk
+      ): risk is {
+        id: string;
+        label: string;
+        severity?: 'low' | 'medium' | 'high';
+        mitigation?: string;
+      } => Boolean(risk)
+    );
+}
+
+function toPipelineMilestones(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [] as Array<{ id: string; title: string; description?: string; due?: string }>;
+  }
+
+  return value
+    .map((entry) => {
+      const record = toRecord(entry);
+      const id = toString(record.id);
+      const title = toString(record.title);
+      if (!id || !title) {
+        return undefined;
+      }
+      return {
+        id,
+        title,
+        description: toOptionalTrimmedString(record.description),
+        due: toOptionalTrimmedString(record.due ?? record.date),
+      };
+    })
+    .filter(
+      (milestone): milestone is { id: string; title: string; description?: string; due?: string } =>
+        Boolean(milestone)
+    );
+}
+
+function toSystemFactors(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [] as Array<{
+      id: string;
+      name: string;
+      summary?: string;
+      kind?: 'stock' | 'flow' | 'driver' | 'outcome' | 'constraint';
+      indicators?: string[];
+    }>;
+  }
+
+  const kinds = new Set(['stock', 'flow', 'driver', 'outcome', 'constraint']);
+
+  return value
+    .map((entry) => {
+      const record = toRecord(entry);
+      const id = toString(record.id);
+      const name = toString(record.name ?? record.label);
+      if (!id || !name) {
+        return undefined;
+      }
+      const kindValue = toOptionalTrimmedString(record.kind ?? record.type);
+      const kind = kindValue && kinds.has(kindValue) ? (kindValue as any) : undefined;
+      return {
+        id,
+        name,
+        summary: toOptionalTrimmedString(record.summary ?? record.description),
+        kind,
+        indicators: toTrimmedStringArray(record.indicators),
+      };
+    })
+    .filter(
+      (
+        factor
+      ): factor is {
+        id: string;
+        name: string;
+        summary?: string;
+        kind?: 'stock' | 'flow' | 'driver' | 'outcome' | 'constraint';
+        indicators?: string[];
+      } => Boolean(factor)
+    );
+}
+
+function toSystemLoops(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [] as Array<{
+      id: string;
+      name: string;
+      polarity: 'reinforcing' | 'balancing';
+      summary?: string;
+      steps: Array<{
+        id: string;
+        from: string;
+        to: string;
+        effect?: 'reinforces' | 'balances';
+        description?: string;
+      }>;
+      insights?: string[];
+    }>;
+  }
+
+  const polarities = new Set(['reinforcing', 'balancing']);
+
+  return value
+    .map((entry) => {
+      const record = toRecord(entry);
+      const id = toString(record.id);
+      const name = toString(record.name ?? record.title);
+      const polarityValue = toOptionalTrimmedString(record.polarity ?? record.type);
+      if (!id || !name || !polarityValue || !polarities.has(polarityValue)) {
+        return undefined;
+      }
+      return {
+        id,
+        name,
+        polarity: polarityValue as any,
+        summary: toOptionalTrimmedString(record.summary ?? record.description),
+        steps: toSystemSteps(record.steps ?? record.connections),
+        insights: toTrimmedStringArray(record.insights),
+      };
+    })
+    .filter(
+      (
+        loop
+      ): loop is {
+        id: string;
+        name: string;
+        polarity: 'reinforcing' | 'balancing';
+        summary?: string;
+        steps: Array<{
+          id: string;
+          from: string;
+          to: string;
+          effect?: 'reinforces' | 'balances';
+          description?: string;
+        }>;
+        insights?: string[];
+      } => Boolean(loop)
+    );
+}
+
+function toSystemSteps(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [] as Array<{
+      id: string;
+      from: string;
+      to: string;
+      effect?: 'reinforces' | 'balances';
+      description?: string;
+    }>;
+  }
+
+  const effects = new Set(['reinforces', 'balances']);
+
+  return value
+    .map((entry, index) => {
+      const record = toRecord(entry);
+      const from = toOptionalTrimmedString(record.from ?? record.source);
+      const to = toOptionalTrimmedString(record.to ?? record.target);
+      if (!from || !to) {
+        return undefined;
+      }
+      const effectValue = toOptionalTrimmedString(record.effect ?? record.polarity);
+      const effect = effectValue && effects.has(effectValue) ? (effectValue as any) : undefined;
+      return {
+        id: toString(record.id) || `step-${index}`,
+        from,
+        to,
+        effect,
+        description: toOptionalTrimmedString(record.description),
+      };
+    })
+    .filter(
+      (
+        step
+      ): step is {
+        id: string;
+        from: string;
+        to: string;
+        effect?: 'reinforces' | 'balances';
+        description?: string;
+      } => Boolean(step)
+    );
+}
+
+function toSystemInsights(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [] as Array<{ id: string; label: string; description?: string }>;
+  }
+
+  return value
+    .map((entry) => {
+      const record = toRecord(entry);
+      const id = toString(record.id);
+      const label = toString(record.label ?? record.title);
+      if (!id || !label) {
+        return undefined;
+      }
+      return {
+        id,
+        label,
+        description: toOptionalTrimmedString(record.description),
+      };
+    })
+    .filter((insight): insight is { id: string; label: string; description?: string } =>
+      Boolean(insight)
+    );
+}
+
+function toUmlType(value: unknown) {
+  const type = toOptionalTrimmedString(value);
+  if (!type) {
+    return undefined;
+  }
+  const allowed = new Set(['class', 'interface', 'enum']);
+  return allowed.has(type) ? (type as any) : undefined;
+}
+
+function toUmlVisibility(value: unknown) {
+  const visibility = toOptionalTrimmedString(value);
+  if (!visibility) {
+    return undefined;
+  }
+  const allowed = new Set(['public', 'private', 'protected', 'package']);
+  return allowed.has(visibility) ? (visibility as any) : undefined;
+}
+
+function toPipelineStatus(value: unknown) {
+  const status = toOptionalTrimmedString(value);
+  if (!status) {
+    return undefined;
+  }
+  const allowed = new Set(['not-started', 'in-progress', 'blocked', 'done']);
+  return allowed.has(status) ? (status as any) : undefined;
+}
+
+function toFlowNodes(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [] as Array<{
+      id: string;
+      type: 'start' | 'process' | 'input' | 'output' | 'decision' | 'end';
+      title: string;
+      summary?: string;
+      branches?: Array<{ id: string; label: string; target: string; description?: string }>;
+    }>;
+  }
+
+  const types = new Set(['start', 'process', 'input', 'output', 'decision', 'end']);
+
+  return value
+    .map((entry) => {
+      const record = toRecord(entry);
+      const id = toString(record.id);
+      const title = toString(record.title ?? record.name);
+      const typeValue = toOptionalTrimmedString(record.type ?? record.kind);
+      if (!id || !title || !typeValue || !types.has(typeValue)) {
+        return undefined;
+      }
+      return {
+        id,
+        type: typeValue as any,
+        title,
+        summary: toOptionalTrimmedString(record.summary ?? record.description),
+        branches: toFlowBranches(record.branches),
+      };
+    })
+    .filter(
+      (
+        node
+      ): node is {
+        id: string;
+        type: 'start' | 'process' | 'input' | 'output' | 'decision' | 'end';
+        title: string;
+        summary?: string;
+        branches?: Array<{ id: string; label: string; target: string; description?: string }>;
+      } => Boolean(node)
+    );
+}
+
+function toFlowBranches(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [] as Array<{ id: string; label: string; target: string; description?: string }>;
+  }
+
+  return value
+    .map((entry, index) => {
+      const record = toRecord(entry);
+      const label = toOptionalTrimmedString(record.label ?? record.title);
+      const target = toOptionalTrimmedString(record.target ?? record.to);
+      if (!label || !target) {
+        return undefined;
+      }
+      return {
+        id: toString(record.id) || `branch-${index}`,
+        label,
+        target,
+        description: toOptionalTrimmedString(record.description),
+      };
+    })
+    .filter(
+      (branch): branch is { id: string; label: string; target: string; description?: string } =>
+        Boolean(branch)
+    );
+}
+
+function toFlowConnections(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [] as Array<{
+      from: string;
+      to: string;
+      label?: string;
+      kind?: 'default' | 'loop' | 'fallback';
+    }>;
+  }
+
+  const kinds = new Set(['default', 'loop', 'fallback']);
+
+  return value
+    .map((entry) => {
+      const record = toRecord(entry);
+      const from = toOptionalTrimmedString(record.from);
+      const to = toOptionalTrimmedString(record.to);
+      if (!from || !to) {
+        return undefined;
+      }
+      const kindValue = toOptionalTrimmedString(record.kind);
+      const kind = kindValue && kinds.has(kindValue) ? (kindValue as any) : undefined;
+      return {
+        from,
+        to,
+        label: toOptionalTrimmedString(record.label),
+        kind,
+      };
+    })
+    .filter(
+      (
+        connection
+      ): connection is {
+        from: string;
+        to: string;
+        label?: string;
+        kind?: 'default' | 'loop' | 'fallback';
+      } => Boolean(connection)
+    );
+}
+
+function toTrimmedStringArray(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [] as string[];
+  }
+  return value
+    .map((item) => (typeof item === 'string' ? item.trim() : ''))
+    .filter((item): item is string => item.length > 0);
+}
+
+function toPositiveNumber(value: unknown): number | undefined {
+  const numberValue = Number(value);
+  if (Number.isFinite(numberValue) && numberValue > 0) {
+    return numberValue;
+  }
+  return undefined;
 }
 
 function toRecord(value: unknown): Record<string, unknown> {

--- a/src/content/courses/algi/exercises.json
+++ b/src/content/courses/algi/exercises.json
@@ -6,10 +6,12 @@
     "link": "courses/algi/exercises/lista1.html",
     "available": false,
     "file": "lista1.vue",
+    "type": "worksheet",
+    "durationMinutes": 120,
     "metadata": {
       "generatedBy": "Equipe EDU",
       "model": "manual",
-      "timestamp": "2024-06-14T00:00:00.000Z"
+      "timestamp": "2025-02-20T12:00:00.000Z"
     }
   },
   {
@@ -19,10 +21,12 @@
     "link": "courses/algi/exercises/lista2.html",
     "available": false,
     "file": "lista2.vue",
+    "type": "worksheet",
+    "durationMinutes": 140,
     "metadata": {
       "generatedBy": "Equipe EDU",
       "model": "manual",
-      "timestamp": "2024-06-14T00:00:00.000Z"
+      "timestamp": "2025-02-20T12:00:00.000Z"
     }
   }
 ]

--- a/src/content/courses/algi/lessons.json
+++ b/src/content/courses/algi/lessons.json
@@ -168,19 +168,34 @@
     "id": "lesson-16",
     "title": "Aula 16: Atividade Prática (Assíncrona) – Condicionais",
     "file": "lesson-16.json",
-    "available": false
+    "available": true,
+    "description": "Conduz atividade autônoma de triagem clínica utilizando condicionais compostas, fluxogramas e testes.",
+    "summary": "Aplica decisões encadeadas em um cenário realista, produzindo fluxograma, pseudocódigo e relatório de testes com evidências.",
+    "tags": ["condicionais", "atividade", "assinc"],
+    "duration": 120,
+    "formatVersion": "md3.lesson.v1"
   },
   {
     "id": "lesson-17",
     "title": "Aula 17: Estrutura de Repetição while",
     "file": "lesson-17.json",
-    "available": false
+    "available": true,
+    "description": "Apresenta laços while com foco em sentinelas, validações de entrada e planejamento de testes.",
+    "summary": "Constrói algoritmos com while para coletar dados até uma condição ser satisfeita, incluindo tabela de testes com casos limites.",
+    "tags": ["loops", "while", "sentinela"],
+    "duration": 115,
+    "formatVersion": "md3.lesson.v1"
   },
   {
     "id": "lesson-18",
     "title": "Aula 18: Estrutura de Repetição for",
     "file": "lesson-18.json",
-    "available": false
+    "available": true,
+    "description": "Explora o laço for para percorrer intervalos e coleções com controle explícito de contadores.",
+    "summary": "Descompõe o for em inicialização, condição e atualização, aplicando-o em tabuadas, somatórios e percursos sobre vetores.",
+    "tags": ["loops", "for", "controle-de-fluxo"],
+    "duration": 115,
+    "formatVersion": "md3.lesson.v1"
   },
   {
     "id": "lesson-19",

--- a/src/content/courses/algi/lessons/lesson-16.json
+++ b/src/content/courses/algi/lessons/lesson-16.json
@@ -1,0 +1,237 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-16",
+  "title": "Aula 16: Atividade Prática Assíncrona – Condicionais",
+  "summary": "Aplica condicionais compostas em um miniaplicativo de triagem, documentando decisões, testes e evidências de entrega.",
+  "objective": "Conduzir uma atividade autônoma que consolide condicionais aninhadas, operadores lógicos e planejamento de testes.",
+  "objectives": [
+    "Revisar requisitos funcionais de um fluxo de triagem clínica.",
+    "Desenhar fluxogramas que reflitam decisões exclusivas e caminhos alternativos.",
+    "Implementar e testar o pseudocódigo/documentação das decisões escritas."
+  ],
+  "competencies": ["Pensamento algorítmico", "Documentação técnica", "Autogestão"],
+  "skills": [
+    "Traduzir requisitos em condicionais compostas e encadeadas.",
+    "Registrar evidências de teste que comprovem a cobertura de casos críticos.",
+    "Comunicar decisões técnicas em formato de relatório curto."
+  ],
+  "outcomes": [
+    "Entrega fluxograma e pseudocódigo que cobrem todos os cenários descritos.",
+    "Apresenta tabela de testes com resultados esperados e obtidos.",
+    "Publica checklist de evidências com captura de tela/execução do algoritmo."
+  ],
+  "prerequisites": [
+    "Revisar as aulas 12 a 15 e trazer o ambiente configurado (IDE OnlineGDB ou DevC++)."
+  ],
+  "tags": ["condicionais", "atividade", "assincrona"],
+  "duration": 120,
+  "modality": "async",
+  "resources": [
+    {
+      "label": "Modelo de relatório de evidências",
+      "url": "https://example.edu/algi/modelos/relatorio-condicionais.docx",
+      "type": "template"
+    },
+    {
+      "label": "Ambiente de desenvolvimento OnlineGDB",
+      "url": "https://www.onlinegdb.com/online_c_compiler",
+      "type": "tool"
+    },
+    {
+      "label": "Revisão de operadores lógicos",
+      "url": "https://example.edu/algi/referenciais/operadores-logicos-md3.html",
+      "type": "reading"
+    }
+  ],
+  "bibliography": [
+    "MANZANO, J. A. N. G.; OLIVEIRA, J. F. Algoritmos. Érica, 2019.",
+    "FORBELLONE, A. L. V.; EBERSPÄCHER, H. F. Lógica de Programação. Pearson, 2020."
+  ],
+  "assessment": {
+    "type": "practice",
+    "description": "Entrega individual com fluxograma, pseudocódigo e planilha de testes enviados no AVA até às 23h59."
+  },
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Plano da atividade",
+      "cards": [
+        {
+          "icon": "book-open",
+          "title": "Contexto",
+          "content": "Uma clínica precisa priorizar pacientes conforme sintomas relatados e histórico de risco."
+        },
+        {
+          "icon": "bullseye",
+          "title": "Produto",
+          "content": "Fluxograma + pseudocódigo comentado + tabela de testes registrados em planilha."
+        },
+        {
+          "icon": "clock",
+          "title": "Gestão do tempo",
+          "content": "Reserve 2h: 30 min de análise, 50 min de modelagem, 30 min de testes e 10 min para documentação."
+        }
+      ]
+    },
+    {
+      "type": "roadmap",
+      "title": "Sequência sugerida",
+      "steps": [
+        {
+          "title": "Estudo de caso",
+          "description": "Leia o briefing médico e identifique quais fatores classificam o paciente em observação imediata."
+        },
+        {
+          "title": "Modelagem",
+          "description": "Desenhe fluxograma com decisões exclusivas (if/else if) e caminhos alternativos claros."
+        },
+        {
+          "title": "Codificação",
+          "description": "Transcreva o fluxo para pseudocódigo C com comentários e validações de entrada."
+        },
+        {
+          "title": "Testes",
+          "description": "Monte tabela de testes cobrindo casos críticos: gestantes, febre alta, histórico cardíaco."
+        },
+        {
+          "title": "Evidências",
+          "description": "Capture execuções (print ou vídeo) e preencha o relatório com links/arquivos."
+        }
+      ]
+    },
+    {
+      "type": "md3Flowchart",
+      "title": "Fluxograma de referência",
+      "summary": "Exemplo simplificado de triagem com condicionais encadeadas e saídas exclusivas.",
+      "nodes": [
+        {
+          "id": "start",
+          "type": "start",
+          "title": "Início",
+          "summary": "Recebe sintomas e riscos do paciente.",
+          "branches": [
+            {
+              "id": "branch-critical",
+              "label": "Sintoma grave",
+              "target": "grave",
+              "description": "Febre > 39ºC, dor torácica ou falta de ar intensa."
+            },
+            {
+              "id": "branch-regular",
+              "label": "Sem sintoma grave",
+              "target": "gestante",
+              "description": "Seguir para análise de fatores de risco."
+            }
+          ]
+        },
+        {
+          "id": "grave",
+          "type": "process",
+          "title": "Encaminhar para emergência",
+          "summary": "Prioridade imediata com equipe avançada."
+        },
+        {
+          "id": "gestante",
+          "type": "decision",
+          "title": "Paciente gestante?",
+          "branches": [
+            {
+              "id": "gestante-sim",
+              "label": "Sim",
+              "target": "obstetrico",
+              "description": "Encaminhar para sala de observação obstétrica."
+            },
+            {
+              "id": "gestante-nao",
+              "label": "Não",
+              "target": "cardiaco",
+              "description": "Verificar histórico cardíaco relevante."
+            }
+          ]
+        },
+        {
+          "id": "obstetrico",
+          "type": "process",
+          "title": "Observação obstétrica",
+          "summary": "Monitoramento dedicado até avaliação médica."
+        },
+        {
+          "id": "cardiaco",
+          "type": "process",
+          "title": "Histórico cardíaco",
+          "summary": "Prioridade média com monitoração contínua."
+        },
+        {
+          "id": "consultorio",
+          "type": "process",
+          "title": "Consulta agendada",
+          "summary": "Atendimento em ordem de chegada com orientação básica."
+        },
+        {
+          "id": "end",
+          "type": "end",
+          "title": "Encerrar triagem"
+        }
+      ],
+      "connections": [
+        { "from": "grave", "to": "end", "label": "Atendimento imediato" },
+        { "from": "obstetrico", "to": "end", "label": "Observação especializada" },
+        { "from": "cardiaco", "to": "consultorio", "label": "Monitorar sinais" },
+        { "from": "consultorio", "to": "end", "label": "Consulta clínica" }
+      ]
+    },
+    {
+      "type": "checklist",
+      "title": "Entrega obrigatória",
+      "items": [
+        "Fluxograma digitalizado ou produzido no FigJam/Lucidchart.",
+        "Pseudocódigo ou código em C com comentários contextualizando decisões.",
+        "Tabela de testes preenchida com entradas, saídas esperadas, obtidas e evidências."
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Rubrica de avaliação (20 pontos)",
+      "headers": ["Critério", "Peso", "Descrição"],
+      "rows": [
+        ["Cobertura de casos", "8", "Decisões contemplam sintomas críticos e exceções."],
+        [
+          "Clareza do pseudocódigo",
+          "6",
+          "Estrutura, indentação e comentários elucidam cada caminho."
+        ],
+        [
+          "Evidências de teste",
+          "4",
+          "Tabela exibe resultados esperados x obtidos com comprovação."
+        ],
+        [
+          "Pontualidade",
+          "2",
+          "Entrega realizada no AVA até o horário limite com arquivos organizados."
+        ]
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Envio no AVA",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Faça upload em um único arquivo ZIP contendo fluxograma (PDF), pseudocódigo (.c ou .txt) e planilha de testes (.xlsx ou .ods)."
+        },
+        {
+          "type": "paragraph",
+          "text": "Nome do arquivo: ALG1_A16_NomeSobrenome.zip."
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "status": "published",
+    "updatedAt": "2025-02-20T12:00:00.000Z",
+    "owners": ["Profa. Carla Mendes", "Prof. Miguel Souza"],
+    "sources": ["Plano pedagógico Algoritmos I 2025.1", "Briefing clínico de triagem 2025"]
+  }
+}

--- a/src/content/courses/algi/lessons/lesson-17.json
+++ b/src/content/courses/algi/lessons/lesson-17.json
@@ -1,0 +1,180 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-17",
+  "title": "Aula 17: Estrutura de Repetição while",
+  "summary": "Introduz laços while para repetir blocos enquanto condições permanecem verdadeiras, aplicando sentinelas e validações.",
+  "objective": "Compreender, modelar e implementar laços while controlados por condição e por sentinela.",
+  "objectives": [
+    "Identificar situações em que while é mais adequado que for ou decisões simples.",
+    "Traduzir fluxogramas com laço enquanto em pseudocódigo/C.",
+    "Planejar testes que cubram entradas válidas, inválidas e sentinelas."
+  ],
+  "competencies": ["Pensamento algorítmico", "Raciocínio lógico", "Validação de dados"],
+  "skills": [
+    "Definir condições de continuidade e de saída para laços.",
+    "Implementar loops com contadores e acumuladores.",
+    "Registrar evidências de teste usando sentinelas e limites."
+  ],
+  "outcomes": [
+    "Explica a diferença entre while e do-while com exemplos práticos.",
+    "Escreve algoritmo que lê dados até receber sentinela válido.",
+    "Entrega tabela de testes cobrindo casos de encerramento e erros."
+  ],
+  "prerequisites": ["Domínio de condicionais compostas e operadores lógicos."],
+  "tags": ["loops", "while", "repeticao"],
+  "duration": 115,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Notebook ou IDE configurada",
+      "url": "https://www.onlinegdb.com/online_c_compiler",
+      "type": "tool"
+    },
+    {
+      "label": "Worksheet Laços Enquanto",
+      "url": "https://example.edu/algi/worksheets/while.pdf",
+      "type": "handout"
+    }
+  ],
+  "bibliography": [
+    "BACKES, A. Linguagem C: Completa e Descomplicada. Elsevier, 2019.",
+    "MANZANO, J. Algoritmos. Érica, 2019."
+  ],
+  "assessment": {
+    "type": "practice",
+    "description": "Exercício guiado em dupla com entrega de pseudocódigo e tabela de testes ao final da aula."
+  },
+  "content": [
+    {
+      "type": "flightPlan",
+      "title": "Plano de voo (1h55)",
+      "items": [
+        "(15 min) Aquecimento: identificar padrões que exigem repetição.",
+        "(25 min) Aula expositiva: sintaxe e fluxo do while.",
+        "(35 min) Laboratório guiado: cálculo de média até sentinela.",
+        "(20 min) Discussão de testes e edge cases.",
+        "(20 min) Exercício prático em dupla com feedback imediato."
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Quando usar while",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Utilize while quando não souber quantas iterações serão necessárias e desejar testar a condição antes de executar o bloco."
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "items": [
+            "Leitura até receber um valor especial (sentinela).",
+            "Validação de entrada até o usuário fornecer dados corretos.",
+            "Monitoramento de sensores enquanto a leitura estiver dentro do intervalo."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "md3Flowchart",
+      "title": "Fluxo: média com sentinela",
+      "summary": "Fluxograma que representa a leitura de notas até o usuário digitar -1.",
+      "nodes": [
+        { "id": "start", "type": "start", "title": "Início" },
+        {
+          "id": "read",
+          "type": "process",
+          "title": "Ler nota",
+          "summary": "Solicita entrada da usuária."
+        },
+        {
+          "id": "check",
+          "type": "decision",
+          "title": "Nota é -1?",
+          "branches": [
+            {
+              "id": "is-sentinel",
+              "label": "Sim",
+              "target": "average",
+              "description": "Encerrar leituras e calcular média"
+            },
+            {
+              "id": "not-sentinel",
+              "label": "Não",
+              "target": "accumulate",
+              "description": "Somar e contar"
+            }
+          ]
+        },
+        {
+          "id": "accumulate",
+          "type": "process",
+          "title": "Acumular nota",
+          "summary": "Soma valor e incrementa contador."
+        },
+        {
+          "id": "loop",
+          "type": "process",
+          "title": "Repetir entrada",
+          "summary": "Retorna para leitura."
+        },
+        {
+          "id": "average",
+          "type": "process",
+          "title": "Calcular média",
+          "summary": "Divide soma pelo contador."
+        },
+        { "id": "end", "type": "end", "title": "Fim" }
+      ],
+      "connections": [
+        { "from": "start", "to": "read" },
+        { "from": "read", "to": "check" },
+        { "from": "accumulate", "to": "loop" },
+        { "from": "loop", "to": "read", "kind": "loop", "label": "Próxima nota" },
+        { "from": "average", "to": "end" }
+      ]
+    },
+    {
+      "type": "code",
+      "language": "c",
+      "code": "int nota = 0;\nint soma = 0;\nint quantidade = 0;\n\nprintf(\"Digite uma nota ou -1 para encerrar: \");\nscanf(\"%d\", &nota);\nwhile (nota != -1) {\n  soma += nota;\n  quantidade++;\n  printf(\"Digite uma nota ou -1 para encerrar: \");\n  scanf(\"%d\", &nota);\n}\nif (quantidade > 0) {\n  printf(\"Média: %.2f\\n\", (float)soma / quantidade);\n} else {\n  printf(\"Nenhuma nota válida informada\\n\");\n}\n"
+    },
+    {
+      "type": "md3Table",
+      "title": "Comparação de padrões de repetição",
+      "headers": ["Padrão", "Quando usar", "Exemplo"],
+      "rows": [
+        [
+          { "value": "while" },
+          { "value": "Condição checada antes" },
+          { "value": "Leitura até sentinela" }
+        ],
+        [
+          { "value": "do-while" },
+          { "value": "Executa ao menos uma vez" },
+          { "value": "Menu interativo" }
+        ],
+        [
+          { "value": "for" },
+          { "value": "Número conhecido de repetições" },
+          { "value": "Percorrer vetor de tamanho fixo" }
+        ]
+      ]
+    },
+    {
+      "type": "checklist",
+      "title": "Ao final, garanta que você",
+      "items": [
+        "Definiu sentinelas e condições de parada claramente.",
+        "Registrou o comportamento esperado quando nenhuma nota válida é informada.",
+        "Validou entradas negativas fora do sentinela."
+      ]
+    }
+  ],
+  "metadata": {
+    "status": "published",
+    "updatedAt": "2025-02-20T12:00:00.000Z",
+    "owners": ["Profa. Carla Mendes", "Prof. Miguel Souza"],
+    "sources": ["Plano pedagógico Algoritmos I 2025.1", "Roteiro de laboratório while 2025"]
+  }
+}

--- a/src/content/courses/algi/lessons/lesson-18.json
+++ b/src/content/courses/algi/lessons/lesson-18.json
@@ -1,0 +1,154 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-18",
+  "title": "Aula 18: Estrutura de Repetição for",
+  "summary": "Explora o laço for para repetir instruções com contadores definidos, destacando inicialização, condição e atualização.",
+  "objective": "Planejar e implementar laços for para percorrer intervalos, vetores e produzir tabulações controladas.",
+  "objectives": [
+    "Mapear os três componentes do for (inicialização, condição, atualização).",
+    "Comparar equivalências entre for e while em exemplos reais.",
+    "Aplicar for em tabelas e cálculos acumulativos com validação de limites."
+  ],
+  "competencies": ["Pensamento computacional", "Organização algorítmica", "Raciocínio matemático"],
+  "skills": [
+    "Selecionar variáveis de controle adequadas.",
+    "Garantir que a condição torne-se falsa em tempo finito.",
+    "Documentar testes que validem limites inferior e superior."
+  ],
+  "outcomes": [
+    "Produz algoritmos que percorrem vetores e faixas numéricas usando for.",
+    "Justifica quando converter um while em for melhora a legibilidade.",
+    "Entrega exercícios com evidências de testes e análise de complexidade básica."
+  ],
+  "prerequisites": ["Conhecer laços while e operadores aritméticos."],
+  "tags": ["loops", "for", "repeticao"],
+  "duration": 115,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Slides Estrutura for",
+      "url": "https://example.edu/algi/slides/for-md3.pdf",
+      "type": "slide"
+    },
+    {
+      "label": "Compilador OnlineGDB",
+      "url": "https://www.onlinegdb.com/online_c_compiler",
+      "type": "tool"
+    }
+  ],
+  "bibliography": [
+    "FORBELLONE, A. L. V.; EBERSPÄCHER, H. F. Lógica de Programação. Pearson, 2020.",
+    "PIVA, A. Algoritmos e Estruturas de Dados. Novatec, 2021."
+  ],
+  "assessment": {
+    "type": "practice",
+    "description": "Checklist de exercícios práticos com tabuada, somatórios e percorrimento de vetores."
+  },
+  "content": [
+    {
+      "type": "flightPlan",
+      "title": "Plano de voo (1h55)",
+      "items": [
+        "(10 min) Recap do while e introdução ao for.",
+        "(20 min) Desmembrar sintaxe e exemplos no quadro.",
+        "(35 min) Laboratório: geração de tabuada e somatórios.",
+        "(20 min) Debug coletivo: evitar loops infinitos.",
+        "(30 min) Exercícios avaliativos com feedback em tempo real."
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Componentes do for",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "O laço for é ideal quando conhecemos o número de repetições ou conseguimos derivá-lo de um intervalo controlado."
+        },
+        {
+          "type": "roadmap",
+          "steps": [
+            {
+              "title": "Inicialização",
+              "description": "Executada uma vez antes da primeira iteração."
+            },
+            { "title": "Condição", "description": "Verificada antes de cada ciclo." },
+            { "title": "Atualização", "description": "Executada após cada iteração." }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Comparativo for x while",
+      "headers": ["Aspecto", "for", "while"],
+      "rows": [
+        [
+          { "value": "Estrutura" },
+          { "value": "Tudo em uma linha (início; condição; atualização)" },
+          { "value": "Elementos separados no corpo" }
+        ],
+        [
+          { "value": "Legibilidade" },
+          { "value": "Excelente para contadores e percursos" },
+          { "value": "Melhor para repetições condicionais sem contagem" }
+        ],
+        [
+          { "value": "Risco" },
+          { "value": "Esquecer atualização resulta em loop infinito" },
+          { "value": "Esquecer leitura no fim pode travar condição" }
+        ]
+      ]
+    },
+    {
+      "type": "code",
+      "language": "c",
+      "code": "int soma = 0;\nfor (int i = 1; i <= 10; i++) {\n  soma += i;\n  printf(\"Iteração %d - soma parcial: %d\\n\", i, soma);\n}\nprintf(\"Resultado final: %d\\n\", soma);\n"
+    },
+    {
+      "type": "md3Flowchart",
+      "title": "Fluxo: tabuada com for",
+      "nodes": [
+        { "id": "start", "type": "start", "title": "Início" },
+        { "id": "set", "type": "process", "title": "i = 1" },
+        {
+          "id": "condition",
+          "type": "decision",
+          "title": "i <= 10?",
+          "branches": [
+            { "id": "loop-continues", "label": "Sim", "target": "print" },
+            { "id": "loop-ends", "label": "Não", "target": "end" }
+          ]
+        },
+        {
+          "id": "print",
+          "type": "process",
+          "title": "Imprimir linha",
+          "summary": "Mostra fator x multiplicador."
+        },
+        { "id": "increment", "type": "process", "title": "i++" },
+        { "id": "end", "type": "end", "title": "Fim" }
+      ],
+      "connections": [
+        { "from": "start", "to": "set" },
+        { "from": "set", "to": "condition" },
+        { "from": "print", "to": "increment" },
+        { "from": "increment", "to": "condition", "kind": "loop", "label": "Próximo valor" }
+      ]
+    },
+    {
+      "type": "checklist",
+      "title": "Próximos passos",
+      "items": [
+        "Implementar exercícios 1, 2 e 3 da worksheet usando for.",
+        "Analisar equivalência com while e registrar diferenças no caderno.",
+        "Preparar dúvidas para a aula 19 (for vs while)."
+      ]
+    }
+  ],
+  "metadata": {
+    "status": "published",
+    "updatedAt": "2025-02-20T12:00:00.000Z",
+    "owners": ["Profa. Carla Mendes", "Prof. Miguel Souza"],
+    "sources": ["Plano pedagógico Algoritmos I 2025.1", "Worksheet loops contados 2025"]
+  }
+}

--- a/src/content/courses/algi/supplements.json
+++ b/src/content/courses/algi/supplements.json
@@ -6,10 +6,12 @@
     "type": "reference",
     "link": "courses/algi/supplements/guia-estudos.pdf",
     "available": false,
+    "file": "guia-estudos.pdf",
+    "estimatedReadingMinutes": 60,
     "metadata": {
       "generatedBy": "Equipe EDU",
       "model": "manual",
-      "timestamp": "2024-06-14T00:00:00.000Z"
+      "timestamp": "2025-02-20T12:00:00.000Z"
     }
   }
 ]


### PR DESCRIPTION
## Summary
- document the ClassDesigner, PipelineCanvas, and SystemMapper pedagogical components with MD3 usage guidelines
- implement the new components, register them in the lesson block registry, and cover them with unit tests
- migrate ALGI lessons 16–18 to the md3.lesson.v1 schema and refresh course indexes with complete metadata

## Testing
- npm run validate:content
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9ce52dbf0832c8b930d7a39b508a6