### PR TITLE
Add responsive layout stories and expand design tokens

### DIFF
--- a/docs/design-system/tokens.md
+++ b/docs/design-system/tokens.md
@@ -1,12 +1,14 @@
 # Tokens do Design System Material 3
 
-Os tokens do tema Material You foram centralizados em `src/theme/tokens.ts` para garantir que aplicações, Storybook e scripts compartilhem a mesma fonte de verdade. A inicialização do tema (`initMaterialTheme`) injeta os tokens dinamicamente na raiz do documento e mantém aliases legados (`--shadow-elevation-*`) durante a transição.
+Os tokens do tema Material You foram centralizados em `src/theme/tokens.ts` para garantir que aplicações, Storybook e scripts compartilhem a mesma fonte de verdade. A inicialização do tema (`initMaterialTheme`) injeta os tokens dinamicamente na raiz do documento e agora publica apenas variáveis MD3 (`--md-sys-*`), eliminando os aliases legados de elevação.
 
 ## Estrutura dos tokens
 
 - **Cores** – `COLOR_ROLE_TOKENS` cobre todos os papéis gerados pelo Material Color Utilities (primários, superfícies container, tons inversos, outline etc.).
 - **Camadas de estado** – `STATE_LAYER_OPACITY` e `STRONG_STATE_LAYER_OPACITY` controlam as opacidades para hover/focus de acordo com o modo claro/escuro.
-- **Elevação** – `ELEVATION_SHADOWS` gera `--md-sys-elevation-level{1..3}` e mantém compatibilidade com `--shadow-elevation-*`.
+- **Elevação** – `ELEVATION_SHADOWS` gera `--md-sys-elevation-level{0..5}` para luz e sombra, cobrindo cards planos e componentes flutuantes sem depender de aliases.
+- **Motion** – `MOTION_TOKENS` publica durações e curvas canônicas (`--md-sys-motion-duration-*`, `--md-sys-motion-easing-*`) alinhadas às animações do Material 3.
+- **Densidade** – `DENSITY_SCALE` documenta os ajustes em dp para barras, navegação e escala de referência (`--md-sys-density-*`).
 - **Tipografia** – `TYPOGRAPHY_SCALE` define tamanhos, pesos e tracking para display/headline/title/body/label, aplicados como variáveis CSS.
 - **Espaçamento e dimensões** – `SPACING_SCALE` e `DIMENSION_SCALE` criam variáveis `--md-sys-spacing-*` e `--md-sys-icon-size-*` alinhadas às diretrizes MD3.
 - **Layout responsivo** – `BREAKPOINTS`, `LAYOUT_CONTAINERS` e `APP_BAR_HEIGHTS` publicam `--md-sys-breakpoint-*`, `--md-sys-layout-container-*` e `--md-sys-app-bar-height-*`, sincronizando grids, app bars e shells responsivos.
@@ -19,9 +21,10 @@ Os tokens do tema Material You foram centralizados em `src/theme/tokens.ts` para
 3. **Aplicar tokens via JS apenas uma vez** – `applyStaticTokens` roda durante a inicialização do tema e não precisa ser reexecutado.
 4. **Suporte a modo automático** – `setMaterialTheme('system' | 'light' | 'dark')` mantém a sincronização com o Storybook e com o app.
 5. **Curvaturas consistentes** – superfícies principais usam `card` (raio extra-large por padrão) e widgets compactos usam `card card--compact`; tons personalizados podem aplicar `.md-shape-*` para aproveitar `--md-sys-shape-corner-*` sem estilos inline.
+6. **Exportar para Figma/automação** – rode `npm run tokens:export` para gerar `reports/design-tokens.json` com o snapshot mais recente.
 
 ## Próximos passos
 
-- Expandir o mapa para tokens de motion (easing/duração) e densidade adaptativa.
-- Remover gradualmente os aliases `--shadow-elevation-*` quando os componentes estiverem migrados para `--md-sys-elevation-level*`.
-- Publicar tokens JSON exportáveis para automações externas (Figma, documentação pública).
+- Expor presets de animação no Storybook usando `MOTION_TOKENS` como fonte de verdade.
+- Auditar componentes para aproveitar `DENSITY_SCALE` em controles responsivos (rail, drawer, barras).
+- Conectar o build de tokens JSON ao pipeline de design para sincronizar Figma e automações externas.

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "simple-git-hooks": "^2.9.0",
         "storybook": "^8.4.0",
         "tailwindcss": "^3.4.0",
+        "tsx": "^4.19.1",
         "typescript": "^5.4.0",
         "vite-plugin-pwa": "^1.0.3",
         "vitest": "^3.2.4",
@@ -5964,6 +5965,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -8652,6 +8666,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -9899,6 +9923,26 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/turndown": {
       "version": "7.2.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "report:courses": "node scripts/report-course-summary.mjs",
     "teacher:service": "node scripts/teacher-automation-server.mjs",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "tokens:export": "tsx scripts/export-design-tokens.ts"
   },
   "dependencies": {
     "@material/material-color-utilities": "^0.2.7",
@@ -57,6 +58,7 @@
     "simple-git-hooks": "^2.9.0",
     "tailwindcss": "^3.4.0",
     "storybook": "^8.4.0",
+    "tsx": "^4.19.1",
     "typescript": "^5.4.0",
     "vite-plugin-pwa": "^1.0.3",
     "vitest": "^3.2.4",

--- a/reports/design-tokens.json
+++ b/reports/design-tokens.json
@@ -1,0 +1,273 @@
+{
+  "color": {
+    "roles": [
+      "primary",
+      "onPrimary",
+      "primaryContainer",
+      "onPrimaryContainer",
+      "secondary",
+      "onSecondary",
+      "secondaryContainer",
+      "onSecondaryContainer",
+      "tertiary",
+      "onTertiary",
+      "tertiaryContainer",
+      "onTertiaryContainer",
+      "error",
+      "onError",
+      "errorContainer",
+      "onErrorContainer",
+      "surface",
+      "onSurface",
+      "surfaceVariant",
+      "onSurfaceVariant",
+      "surfaceBright",
+      "surfaceDim",
+      "surfaceContainer",
+      "surfaceContainerHigh",
+      "surfaceContainerHighest",
+      "surfaceContainerLow",
+      "surfaceContainerLowest",
+      "inverseSurface",
+      "inverseOnSurface",
+      "inversePrimary",
+      "background",
+      "onBackground",
+      "outline",
+      "outlineVariant",
+      "shadow",
+      "scrim",
+      "surfaceTint"
+    ],
+    "stateLayerOpacity": {
+      "light": {
+        "primary": 0.12,
+        "onSurface": 0.12
+      },
+      "dark": {
+        "primary": 0.16,
+        "onSurface": 0.12
+      }
+    },
+    "strongStateLayerOpacity": {
+      "light": 0.2,
+      "dark": 0.24
+    }
+  },
+  "elevation": {
+    "light": {
+      "level0": "none",
+      "level1": "0px 1px 3px rgba(17, 24, 39, 0.16), 0px 2px 6px rgba(17, 24, 39, 0.12)",
+      "level2": "0px 4px 12px rgba(17, 24, 39, 0.16), 0px 2px 6px rgba(17, 24, 39, 0.12)",
+      "level3": "0px 8px 20px rgba(17, 24, 39, 0.24), 0px 4px 8px rgba(17, 24, 39, 0.16)",
+      "level4": "0px 12px 28px rgba(17, 24, 39, 0.24), 0px 8px 12px rgba(17, 24, 39, 0.2)",
+      "level5": "0px 16px 40px rgba(17, 24, 39, 0.28), 0px 12px 16px rgba(17, 24, 39, 0.2)"
+    },
+    "dark": {
+      "level0": "none",
+      "level1": "0px 1px 3px rgba(0, 0, 0, 0.55), 0px 2px 6px rgba(0, 0, 0, 0.45)",
+      "level2": "0px 4px 12px rgba(0, 0, 0, 0.48), 0px 2px 8px rgba(0, 0, 0, 0.32)",
+      "level3": "0px 10px 24px rgba(0, 0, 0, 0.55), 0px 6px 16px rgba(0, 0, 0, 0.36)",
+      "level4": "0px 16px 32px rgba(0, 0, 0, 0.6), 0px 8px 12px rgba(0, 0, 0, 0.42)",
+      "level5": "0px 20px 48px rgba(0, 0, 0, 0.64), 0px 12px 16px rgba(0, 0, 0, 0.48)"
+    }
+  },
+  "typography": {
+    "fontFamily": "'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    "display": {
+      "large": {
+        "size": "3.5625rem",
+        "lineHeight": "4rem",
+        "weight": 400,
+        "tracking": "0em"
+      },
+      "medium": {
+        "size": "2.8125rem",
+        "lineHeight": "3.25rem",
+        "weight": 400,
+        "tracking": "0em"
+      },
+      "small": {
+        "size": "2.25rem",
+        "lineHeight": "2.75rem",
+        "weight": 400,
+        "tracking": "0em"
+      }
+    },
+    "headline": {
+      "large": {
+        "size": "2rem",
+        "lineHeight": "2.5rem",
+        "weight": 400,
+        "tracking": "0em"
+      },
+      "medium": {
+        "size": "1.75rem",
+        "lineHeight": "2.25rem",
+        "weight": 400,
+        "tracking": "0em"
+      },
+      "small": {
+        "size": "1.5rem",
+        "lineHeight": "2rem",
+        "weight": 400,
+        "tracking": "0em"
+      }
+    },
+    "title": {
+      "large": {
+        "size": "1.375rem",
+        "lineHeight": "1.75rem",
+        "weight": 500,
+        "tracking": "0em"
+      },
+      "medium": {
+        "size": "1rem",
+        "lineHeight": "1.5rem",
+        "weight": 500,
+        "tracking": "0.009375em"
+      },
+      "small": {
+        "size": "0.875rem",
+        "lineHeight": "1.25rem",
+        "weight": 500,
+        "tracking": "0.00625em"
+      }
+    },
+    "body": {
+      "large": {
+        "size": "1rem",
+        "lineHeight": "1.5rem",
+        "weight": 400,
+        "tracking": "0.03125em"
+      },
+      "medium": {
+        "size": "0.875rem",
+        "lineHeight": "1.25rem",
+        "weight": 400,
+        "tracking": "0.017857em"
+      },
+      "small": {
+        "size": "0.75rem",
+        "lineHeight": "1rem",
+        "weight": 400,
+        "tracking": "0.033333em"
+      }
+    },
+    "label": {
+      "large": {
+        "size": "0.875rem",
+        "lineHeight": "1.25rem",
+        "weight": 500,
+        "tracking": "0.00625em"
+      },
+      "medium": {
+        "size": "0.75rem",
+        "lineHeight": "1rem",
+        "weight": 500,
+        "tracking": "0.041667em"
+      },
+      "small": {
+        "size": "0.6875rem",
+        "lineHeight": "1rem",
+        "weight": 500,
+        "tracking": "0.045455em"
+      }
+    }
+  },
+  "shape": {
+    "small": "0.5rem",
+    "medium": "0.75rem",
+    "large": "1rem",
+    "extraLarge": "1.5rem",
+    "doubleExtraLarge": "2rem",
+    "tripleExtraLarge": "2.5rem",
+    "quadrupleExtraLarge": "3rem",
+    "quintupleExtraLarge": "3.5rem",
+    "full": "9999px"
+  },
+  "spacing": {
+    "1": "0.25rem",
+    "2": "0.5rem",
+    "3": "0.75rem",
+    "4": "1rem",
+    "5": "1.25rem",
+    "6": "1.5rem",
+    "8": "2rem",
+    "10": "2.5rem",
+    "12": "3rem",
+    "16": "4rem",
+    "20": "5rem",
+    "24": "6rem"
+  },
+  "dimension": {
+    "icon": {
+      "small": "1rem",
+      "medium": "1.5rem",
+      "large": "3rem"
+    }
+  },
+  "breakpoints": {
+    "sm": "40rem",
+    "md": "56rem",
+    "lg": "72rem",
+    "xl": "90rem"
+  },
+  "layout": {
+    "containers": {
+      "compact": "56rem",
+      "medium": "72rem",
+      "expanded": "90rem"
+    },
+    "appBarHeights": {
+      "small": "3.5rem",
+      "medium": "4.5rem",
+      "large": "6rem"
+    }
+  },
+  "motion": {
+    "duration": {
+      "short1": "50ms",
+      "short2": "100ms",
+      "medium1": "150ms",
+      "medium2": "200ms",
+      "long1": "300ms",
+      "long2": "400ms",
+      "extraLong1": "500ms"
+    },
+    "easing": {
+      "standard": "cubic-bezier(0.2, 0, 0, 1)",
+      "standardAccelerate": "cubic-bezier(0.3, 0, 0.8, 0.15)",
+      "standardDecelerate": "cubic-bezier(0, 0, 0, 1)",
+      "emphasized": "cubic-bezier(0.3, 0, 0.2, 1)",
+      "emphasizedAccelerate": "cubic-bezier(0.3, 0, 0.8, 0.15)",
+      "emphasizedDecelerate": "cubic-bezier(0.05, 0.7, 0.1, 1)"
+    }
+  },
+  "density": {
+    "reference": {
+      "default": 0,
+      "comfortable": -1,
+      "compact": -2
+    },
+    "topAppBar": {
+      "default": 0,
+      "comfortable": -2,
+      "compact": -4
+    },
+    "navigation": {
+      "rail": {
+        "default": 0,
+        "compact": -1
+      },
+      "drawer": {
+        "default": 0,
+        "compact": -2
+      },
+      "bottomBar": {
+        "default": 0,
+        "compact": -1
+      }
+    }
+  }
+}

--- a/scripts/export-design-tokens.ts
+++ b/scripts/export-design-tokens.ts
@@ -1,0 +1,14 @@
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildDesignTokenExport } from '../src/theme/tokens';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const outputPath = path.resolve(__dirname, '../reports/design-tokens.json');
+
+const tokens = buildDesignTokenExport();
+
+await writeFile(outputPath, `${JSON.stringify(tokens, null, 2)}\n`, 'utf8');
+
+console.log(`Design tokens export saved to ${path.relative(process.cwd(), outputPath)}`);

--- a/src/assets/generated/material-base-palette.css
+++ b/src/assets/generated/material-base-palette.css
@@ -91,14 +91,16 @@
   --md-sys-state-layer-primary: rgba(0, 83, 219, 0.12);
   --md-sys-state-layer-primary-strong: rgba(0, 83, 219, 0.2);
   --md-sys-state-layer-on-surface: rgba(27, 27, 31, 0.12);
+  --md-sys-elevation-level0: none;
   --md-sys-elevation-level1: 0px 1px 3px rgba(17, 24, 39, 0.16), 0px 2px 6px rgba(17, 24, 39, 0.12);
   --md-sys-elevation-level2:
     0px 4px 12px rgba(17, 24, 39, 0.16), 0px 2px 6px rgba(17, 24, 39, 0.12);
   --md-sys-elevation-level3:
     0px 8px 20px rgba(17, 24, 39, 0.24), 0px 4px 8px rgba(17, 24, 39, 0.16);
-  --shadow-elevation-1: var(--md-sys-elevation-level1);
-  --shadow-elevation-2: var(--md-sys-elevation-level2);
-  --shadow-elevation-3: var(--md-sys-elevation-level3);
+  --md-sys-elevation-level4:
+    0px 12px 28px rgba(17, 24, 39, 0.24), 0px 8px 12px rgba(17, 24, 39, 0.2);
+  --md-sys-elevation-level5:
+    0px 16px 40px rgba(17, 24, 39, 0.28), 0px 12px 16px rgba(17, 24, 39, 0.2);
 }
 
 :root[data-theme='dark'] {
@@ -194,10 +196,10 @@
   --md-sys-state-layer-primary: rgba(180, 197, 255, 0.16);
   --md-sys-state-layer-primary-strong: rgba(180, 197, 255, 0.24);
   --md-sys-state-layer-on-surface: rgba(228, 226, 230, 0.12);
+  --md-sys-elevation-level0: none;
   --md-sys-elevation-level1: 0px 1px 3px rgba(0, 0, 0, 0.55), 0px 2px 6px rgba(0, 0, 0, 0.45);
   --md-sys-elevation-level2: 0px 4px 12px rgba(0, 0, 0, 0.48), 0px 2px 8px rgba(0, 0, 0, 0.32);
   --md-sys-elevation-level3: 0px 10px 24px rgba(0, 0, 0, 0.55), 0px 6px 16px rgba(0, 0, 0, 0.36);
-  --shadow-elevation-1: var(--md-sys-elevation-level1);
-  --shadow-elevation-2: var(--md-sys-elevation-level2);
-  --shadow-elevation-3: var(--md-sys-elevation-level3);
+  --md-sys-elevation-level4: 0px 16px 32px rgba(0, 0, 0, 0.6), 0px 8px 12px rgba(0, 0, 0, 0.42);
+  --md-sys-elevation-level5: 0px 20px 48px rgba(0, 0, 0, 0.64), 0px 12px 16px rgba(0, 0, 0, 0.48);
 }

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -399,15 +399,15 @@ html {
   }
 
   .md-elevation-1 {
-    box-shadow: var(--shadow-elevation-1);
+    box-shadow: var(--md-sys-elevation-level1);
   }
 
   .md-elevation-2 {
-    box-shadow: var(--shadow-elevation-2);
+    box-shadow: var(--md-sys-elevation-level2);
   }
 
   .md-elevation-3 {
-    box-shadow: var(--shadow-elevation-3);
+    box-shadow: var(--md-sys-elevation-level3);
   }
 
   .app-shell {
@@ -588,7 +588,7 @@ html {
       var(--md-sys-color-surface-container-highest, var(--md-sys-color-surface-container-high)) 94%,
       transparent
     );
-    box-shadow: var(--shadow-elevation-1);
+    box-shadow: var(--md-sys-elevation-level1);
   }
 
   .md3-top-app-bar__container {
@@ -759,7 +759,7 @@ html {
     border-radius: var(--md-sys-border-radius-full);
     background-color: var(--md-sys-color-primary);
     color: var(--md-sys-color-on-primary);
-    box-shadow: var(--shadow-elevation-2);
+    box-shadow: var(--md-sys-elevation-level2);
     transition:
       background-color 180ms ease,
       color 180ms ease,
@@ -1003,12 +1003,12 @@ html {
       transparent
     );
     border-right: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 30%, transparent);
-    box-shadow: var(--shadow-elevation-1);
+    box-shadow: var(--md-sys-elevation-level1);
   }
 
   .md3-navigation-drawer--modal {
     border-right: none;
-    box-shadow: var(--shadow-elevation-3);
+    box-shadow: var(--md-sys-elevation-level3);
   }
 
   .md3-navigation-drawer--compact {
@@ -1247,13 +1247,13 @@ html {
   .md3-button--filled {
     --md3-button-color: var(--md-sys-color-on-primary);
     --md3-button-container: var(--md-sys-color-primary);
-    --md3-button-shadow: var(--shadow-elevation-1);
+    --md3-button-shadow: var(--md-sys-elevation-level1);
     --md3-button-state-layer: var(--md-sys-state-layer-on-primary);
   }
 
   .btn-filled:hover,
   .md3-button--filled:hover {
-    --md3-button-shadow: var(--shadow-elevation-2);
+    --md3-button-shadow: var(--md-sys-elevation-level2);
   }
 
   .btn-filled:disabled,
@@ -1272,7 +1272,7 @@ html {
       var(--md-sys-color-secondary) 35%,
       var(--md-sys-color-secondary-container) 65%
     );
-    --md3-button-shadow: var(--shadow-elevation-1);
+    --md3-button-shadow: var(--md-sys-elevation-level1);
     --md3-button-state-layer: var(--md-sys-state-layer-on-secondary-container);
   }
 
@@ -1369,7 +1369,7 @@ html {
         transparent
       );
     border-radius: var(--md-sys-shape-corner-extra-large, 1.5rem);
-    box-shadow: var(--shadow-elevation-1);
+    box-shadow: var(--md-sys-elevation-level1);
     transition:
       transform 180ms ease,
       box-shadow 180ms ease,
@@ -1408,7 +1408,7 @@ html {
 
   .card--interactive:hover {
     transform: translateY(-2px);
-    box-shadow: var(--shadow-elevation-2);
+    box-shadow: var(--md-sys-elevation-level2);
     border-color: color-mix(
       in srgb,
       var(--md-sys-color-primary) 25%,
@@ -1559,7 +1559,7 @@ html {
     background-color: var(--md-sys-color-surface-container);
     border: 1px solid var(--md-sys-color-outline);
     color: var(--md-sys-color-on-surface);
-    box-shadow: var(--shadow-elevation-1);
+    box-shadow: var(--md-sys-elevation-level1);
   }
 
   .input::placeholder {
@@ -1568,7 +1568,7 @@ html {
 
   .input:focus-visible {
     border-color: var(--md-sys-color-primary);
-    box-shadow: var(--shadow-elevation-2);
+    box-shadow: var(--md-sys-elevation-level2);
     outline: none;
   }
 
@@ -1605,7 +1605,7 @@ html {
     --md3-button-container: var(--md-sys-color-primary-container);
     --md3-button-color: var(--md-sys-color-on-primary-container);
     --md3-button-outline-color: var(--md-sys-color-primary-container);
-    --md3-button-shadow: var(--shadow-elevation-2);
+    --md3-button-shadow: var(--md-sys-elevation-level2);
     --md3-button-state-layer: var(--md-sys-state-layer-on-primary-container);
     border-radius: var(--md-sys-border-radius-4xl);
     box-shadow: var(--md3-button-shadow);
@@ -1620,7 +1620,7 @@ html {
 
   .md3-fab:hover {
     transform: translateY(-2px);
-    box-shadow: var(--shadow-elevation-3);
+    box-shadow: var(--md-sys-elevation-level3);
   }
 
   .md3-fab .md3-button__icon,
@@ -1825,7 +1825,7 @@ html {
     outline-offset: 2px;
     box-shadow:
       0 0 0 3px color-mix(in srgb, var(--md-sys-color-primary) 24%, transparent 76%),
-      var(--shadow-elevation-1);
+      var(--md-sys-elevation-level1);
   }
 
   .pill-item:hover {
@@ -1840,7 +1840,7 @@ html {
       var(--md-sys-color-surface) 84%
     );
     color: var(--md-sys-color-on-primary-container);
-    box-shadow: var(--shadow-elevation-1);
+    box-shadow: var(--md-sys-elevation-level1);
   }
 
   .course-item__cta {
@@ -2080,7 +2080,7 @@ html[data-theme='dark'] .text-primary-800 {
   border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 60%, transparent);
   background: var(--md-sys-color-surface-container);
   color: var(--md-sys-color-on-surface);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
   display: flex;
   flex-direction: column;
   gap: var(--md-sys-spacing-2);

--- a/src/components/layout/Md3BottomAppBar.stories.ts
+++ b/src/components/layout/Md3BottomAppBar.stories.ts
@@ -1,18 +1,42 @@
 import type { Meta, StoryObj } from '@storybook/vue3';
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { ref } from 'vue';
 import Md3BottomAppBar from './Md3BottomAppBar.vue';
+import { teacherBottomActions } from './storyMetrics';
+
+const CUSTOM_VIEWPORTS = {
+  pixel7: {
+    name: 'Pixel 7',
+    styles: { width: '412px', height: '915px' },
+    type: 'mobile' as const,
+  },
+  desktop1440: {
+    name: 'Desktop 1440',
+    styles: { width: '1440px', height: '900px' },
+    type: 'desktop' as const,
+  },
+};
 
 const meta: Meta<typeof Md3BottomAppBar> = {
   title: 'Layout/Md3BottomAppBar',
   component: Md3BottomAppBar,
   args: {
     ariaLabel: 'Navegação principal',
+    actions: teacherBottomActions,
+    activeId: 'overview',
   },
   parameters: {
+    viewport: {
+      viewports: {
+        ...INITIAL_VIEWPORTS,
+        ...CUSTOM_VIEWPORTS,
+      },
+      defaultViewport: 'pixel7',
+    },
     docs: {
       description: {
         component:
-          'Barra inferior MD3 com até cinco ações principais, replicando a navegação móvel do shell responsivo.',
+          'Barra inferior MD3 com até cinco ações principais, replicando a navegação móvel do shell responsivo. Os badges exibem as mesmas métricas consumidas pelo painel docente.',
       },
     },
   },
@@ -22,16 +46,9 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const demoActions = [
-  { id: 'overview', label: 'Panorama', icon: 'compass' },
-  { id: 'lessons', label: 'Aulas', icon: 'book-open' },
-  { id: 'exercises', label: 'Exercícios', icon: 'clipboard-list' },
-  { id: 'governance', label: 'Governança', icon: 'shield-check' },
-];
-
 export const Interactive: Story = {
   args: {
-    actions: demoActions,
+    actions: teacherBottomActions,
     activeId: 'overview',
   },
   render: (args) => ({
@@ -41,13 +58,13 @@ export const Interactive: Story = {
       const onSelect = (id: string) => {
         activeId.value = id;
       };
-      return { args, activeId, onSelect, demoActions };
+      return { args, activeId, onSelect };
     },
     template: `
       <div style="padding:2rem;background:var(--md-sys-color-surface);display:flex;flex-direction:column;gap:1rem;">
         <Md3BottomAppBar
           v-bind="args"
-          :actions="args.actions || demoActions"
+          :actions="args.actions"
           :active-id="activeId"
           @update:active-id="onSelect"
           @select="onSelect"
@@ -63,10 +80,18 @@ export const Interactive: Story = {
 export const ComDisabled: Story = {
   args: {
     actions: [
-      ...demoActions.slice(0, 3),
+      ...teacherBottomActions.slice(0, 3),
       { id: 'settings', label: 'Configurações', icon: 'settings', disabled: true },
     ],
     activeId: 'lessons',
   },
   render: Interactive.render,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Exemplo com ação extra desabilitada mantendo as métricas reais nas demais entradas.',
+      },
+    },
+  },
 };

--- a/src/components/layout/Md3NavigationDrawer.stories.ts
+++ b/src/components/layout/Md3NavigationDrawer.stories.ts
@@ -1,6 +1,21 @@
 import type { Meta, StoryObj } from '@storybook/vue3';
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { ref } from 'vue';
 import Md3NavigationDrawer from './Md3NavigationDrawer.vue';
+import { teacherDrawerItems } from './storyMetrics';
+
+const CUSTOM_VIEWPORTS = {
+  pixel7: {
+    name: 'Pixel 7',
+    styles: { width: '412px', height: '915px' },
+    type: 'mobile' as const,
+  },
+  desktop1440: {
+    name: 'Desktop 1440',
+    styles: { width: '1440px', height: '900px' },
+    type: 'desktop' as const,
+  },
+};
 
 const meta: Meta<typeof Md3NavigationDrawer> = {
   title: 'Layout/Md3NavigationDrawer',
@@ -8,6 +23,22 @@ const meta: Meta<typeof Md3NavigationDrawer> = {
   args: {
     density: 'default',
     variant: 'standard',
+    items: teacherDrawerItems,
+  },
+  parameters: {
+    viewport: {
+      viewports: {
+        ...INITIAL_VIEWPORTS,
+        ...CUSTOM_VIEWPORTS,
+      },
+      defaultViewport: 'desktop1440',
+    },
+    docs: {
+      description: {
+        component:
+          'Navigation drawer padrão com badges reais do painel docente. Em telas largas ele substitui o rail quando precisamos de descrições ricas.',
+      },
+    },
   },
   argTypes: {
     density: {
@@ -25,32 +56,21 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const drawerItems = [
-  { id: 'overview', label: 'Panorama', description: 'Resumo da disciplina', icon: 'layout-grid' },
-  { id: 'modules', label: 'Módulos', description: 'Aulas e materiais', icon: 'layers', badge: '5' },
-  {
-    id: 'assessments',
-    label: 'Avaliações',
-    description: 'Provas e entregas',
-    icon: 'clipboard-list',
-  },
-];
-
 export const Standard: Story = {
   render: (args) => ({
     components: { Md3NavigationDrawer },
     setup() {
-      const activeId = ref('overview');
+      const activeId = ref(args.activeId ?? 'overview');
       const handleSelect = (id: string) => {
         activeId.value = id;
       };
-      return { args, activeId, handleSelect, drawerItems };
+      return { args, activeId, handleSelect };
     },
     template: `
       <div style="display:flex;gap:2rem;">
         <Md3NavigationDrawer
           v-bind="args"
-          :items="args.items || drawerItems"
+          :items="args.items"
           :active-id="activeId"
           @update:active-id="handleSelect"
         />
@@ -61,16 +81,31 @@ export const Standard: Story = {
       </div>
     `,
   }),
-  args: {
-    items: drawerItems,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Drawer padrão em viewport desktop. Os badges de aulas, exercícios e governança refletem os relatórios do painel docente.',
+      },
+    },
   },
 };
 
 export const Modal: Story = {
   args: {
-    items: drawerItems,
     variant: 'modal',
     density: 'compact',
   },
   render: Standard.render,
+  parameters: {
+    viewport: {
+      defaultViewport: 'pixel7',
+    },
+    docs: {
+      description: {
+        story:
+          'Drawer modal em viewport mobile. Use junto ao bottom bar para orientar navegação por métricas enquanto mantém foco no conteúdo.',
+      },
+    },
+  },
 };

--- a/src/components/layout/Md3NavigationRail.stories.ts
+++ b/src/components/layout/Md3NavigationRail.stories.ts
@@ -1,6 +1,21 @@
 import type { Meta, StoryObj } from '@storybook/vue3';
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { ref } from 'vue';
 import Md3NavigationRail from './Md3NavigationRail.vue';
+import { teacherRailItems } from './storyMetrics';
+
+const CUSTOM_VIEWPORTS = {
+  pixel7: {
+    name: 'Pixel 7',
+    styles: { width: '412px', height: '915px' },
+    type: 'mobile' as const,
+  },
+  desktop1440: {
+    name: 'Desktop 1440',
+    styles: { width: '1440px', height: '900px' },
+    type: 'desktop' as const,
+  },
+};
 
 const meta: Meta<typeof Md3NavigationRail> = {
   title: 'Layout/Md3NavigationRail',
@@ -8,6 +23,22 @@ const meta: Meta<typeof Md3NavigationRail> = {
   args: {
     density: 'default',
     variant: 'expanded',
+    items: teacherRailItems,
+  },
+  parameters: {
+    viewport: {
+      viewports: {
+        ...INITIAL_VIEWPORTS,
+        ...CUSTOM_VIEWPORTS,
+      },
+      defaultViewport: 'desktop1440',
+    },
+    docs: {
+      description: {
+        component:
+          'Navigation rail expandido no desktop com badges conectadas às métricas reais do painel docente. Ajuste o viewport para Pixel 7 para validar o comportamento colapsado usado em telas menores.',
+      },
+    },
   },
   argTypes: {
     density: {
@@ -25,27 +56,21 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const demoItems = [
-  { id: 'overview', label: 'Panorama', icon: 'compass' },
-  { id: 'lessons', label: 'Aulas', icon: 'book-open', badge: '12' },
-  { id: 'exams', label: 'Avaliações', icon: 'file-text' },
-];
-
 export const Interactive: Story = {
   render: (args) => ({
     components: { Md3NavigationRail },
     setup() {
-      const activeId = ref('overview');
+      const activeId = ref(args.activeId ?? 'overview');
       const onSelect = (id: string) => {
         activeId.value = id;
       };
-      return { args, activeId, onSelect, demoItems };
+      return { args, activeId, onSelect };
     },
     template: `
       <div style="display:flex;gap:2rem;min-height:20rem;">
         <Md3NavigationRail
           v-bind="args"
-          :items="args.items || demoItems"
+          :items="args.items"
           :active-id="activeId"
           @update:active-id="onSelect"
         />
@@ -56,15 +81,38 @@ export const Interactive: Story = {
       </div>
     `,
   }),
-  args: {
-    items: demoItems,
-  },
 };
 
 export const Collapsed: Story = {
   args: {
-    items: demoItems,
     variant: 'collapsed',
+  },
+  render: Interactive.render,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Rail colapsado destacando apenas ícones no desktop. Continua exibindo os badges derivados das métricas do painel.',
+      },
+    },
+  },
+};
+
+export const MobileRailPeek: Story = {
+  args: {
+    variant: 'collapsed',
+    density: 'compact',
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'pixel7',
+    },
+    docs: {
+      description: {
+        story:
+          'Viewport mobile simulando a transição para o modo drawer/bottom bar. O rail permanece colapsado como affordance lateral quando há espaço disponível.',
+      },
+    },
   },
   render: Interactive.render,
 };

--- a/src/components/layout/storyMetrics.ts
+++ b/src/components/layout/storyMetrics.ts
@@ -1,0 +1,141 @@
+import courseContentSummary from '../../../reports/course-content-summary.json';
+import contentObservability from '../../../reports/content-observability.json';
+import governanceAlert from '../../../reports/governance-alert.json';
+
+type CourseSummary = (typeof courseContentSummary.courses)[number];
+type CourseObservability = (typeof contentObservability.courses)[number];
+
+const TARGET_COURSE_ID = 'algi';
+
+function findCourseSummary(courseId: string): CourseSummary | undefined {
+  return courseContentSummary.courses.find((course) => course.id === courseId);
+}
+
+function findCourseObservability(courseId: string): CourseObservability | undefined {
+  return contentObservability.courses.find((course) => course.id === courseId);
+}
+
+const courseSummary = findCourseSummary(TARGET_COURSE_ID);
+const courseObservability = findCourseObservability(TARGET_COURSE_ID);
+
+const lessonsPublished = courseSummary?.summary.lessons.published ?? 0;
+const lessonsTotal = courseSummary?.summary.lessons.total ?? 0;
+const exercisesUpcoming = courseSummary?.summary.exercises.upcoming ?? 0;
+
+const totalBlocks = courseObservability?.lessons.totalBlocks ?? 0;
+const legacyBlocks = courseObservability?.lessons.legacyBlocks ?? 0;
+const md3Blocks = courseObservability?.lessons.md3Blocks ?? 0;
+
+const migrationRatio = totalBlocks > 0 ? md3Blocks / totalBlocks : 0;
+const migrationPercent = Math.round(migrationRatio * 100);
+
+const governanceWarnings = governanceAlert.validationTotals.warnings;
+const governanceProblems = governanceAlert.validationTotals.problems;
+const governanceStatus = governanceAlert.validationStatus;
+
+export const teacherNavigationMetrics = {
+  courseTitle: courseSummary?.title ?? 'Curso MD3',
+  lessonsPublished,
+  lessonsTotal,
+  exercisesUpcoming,
+  migrationPercent,
+  md3Blocks,
+  legacyBlocks,
+  governanceWarnings,
+  governanceProblems,
+  governanceStatus,
+};
+
+function formatLessonBadge(): string {
+  if (!lessonsTotal) {
+    return '—';
+  }
+  return `${lessonsPublished}/${lessonsTotal}`;
+}
+
+function formatExercisesBadge(): string {
+  if (!exercisesUpcoming) {
+    return '—';
+  }
+  return String(exercisesUpcoming);
+}
+
+function formatGovernanceBadge(): string {
+  if (governanceProblems > 0) {
+    return `${governanceProblems} problema${governanceProblems > 1 ? 's' : ''}`;
+  }
+
+  if (governanceWarnings > 0) {
+    return `${governanceWarnings} aviso${governanceWarnings > 1 ? 's' : ''}`;
+  }
+
+  return 'Saudável';
+}
+
+function formatMigrationBadge(): string {
+  if (!migrationPercent) {
+    return legacyBlocks > 0 ? 'Em migração' : '—';
+  }
+  return `${migrationPercent}% MD3`;
+}
+
+export const teacherShellNavigation = [
+  {
+    id: 'overview',
+    label: 'Panorama',
+    icon: 'compass',
+    badge: formatMigrationBadge(),
+    to: { name: 'course-overview' },
+  },
+  {
+    id: 'lessons',
+    label: 'Aulas',
+    icon: 'book-open',
+    badge: formatLessonBadge(),
+    to: { name: 'course-lessons' },
+  },
+  {
+    id: 'exercises',
+    label: 'Exercícios',
+    icon: 'clipboard-list',
+    badge: formatExercisesBadge(),
+    to: { name: 'course-exercises' },
+  },
+  {
+    id: 'governance',
+    label: 'Governança',
+    icon: 'shield-check',
+    badge: formatGovernanceBadge(),
+    disabled: governanceStatus !== 'passed',
+    to: governanceStatus === 'passed' ? { name: 'course-governance' } : undefined,
+  },
+] as const;
+
+export const teacherRailItems = teacherShellNavigation.map(({ id, label, icon, badge }) => ({
+  id,
+  label,
+  icon,
+  badge,
+}));
+
+export const teacherDrawerItems = teacherShellNavigation.map(({ id, label, badge, icon }) => ({
+  id,
+  label,
+  icon,
+  badge,
+  description:
+    id === 'overview'
+      ? 'Resumo do plano e progresso de migração'
+      : id === 'lessons'
+        ? 'Grade oficial e conteúdos publicados'
+        : id === 'exercises'
+          ? 'Listas, avaliações e prazos'
+          : 'Alertas de validação e governança',
+}));
+
+export const teacherBottomActions = teacherShellNavigation.map(({ id, label, icon }) => ({
+  id,
+  label,
+  icon,
+  disabled: id === 'governance' && governanceStatus !== 'passed',
+}));

--- a/src/components/lesson/BibliographyBlock.vue
+++ b/src/components/lesson/BibliographyBlock.vue
@@ -79,7 +79,7 @@ function sanitizeEntry(value: unknown): string {
   display: flex;
   flex-direction: column;
   gap: var(--md-sys-spacing-5);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .lesson-bibliography__title {

--- a/src/components/lesson/Callout.vue
+++ b/src/components/lesson/Callout.vue
@@ -204,7 +204,7 @@ function resolveVideoAccessibleName(block: RichVideo, index: number): string {
   background: var(--callout-bg);
   border: 1px solid var(--callout-border);
   color: var(--callout-text);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
   align-items: start;
 }
 
@@ -278,7 +278,7 @@ function resolveVideoAccessibleName(block: RichVideo, index: number): string {
   padding-top: 56.25%;
   border-radius: var(--md-sys-shape-corner-large, var(--md-sys-border-radius-large));
   overflow: hidden;
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .callout__video-frame iframe {

--- a/src/components/lesson/CardGrid.vue
+++ b/src/components/lesson/CardGrid.vue
@@ -281,7 +281,7 @@ function sanitizeList(items?: unknown[]): string[] {
   border-radius: var(--md-sys-border-radius-large);
   padding: var(--md-sys-spacing-5);
   border: 1px solid transparent;
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
   transition:
     transform 180ms ease,
     box-shadow 180ms ease;
@@ -289,7 +289,7 @@ function sanitizeList(items?: unknown[]): string[] {
 
 .card-grid__card:hover {
   transform: translateY(-2px);
-  box-shadow: var(--shadow-elevation-2);
+  box-shadow: var(--md-sys-elevation-level2);
 }
 
 .card-grid__card--surface {

--- a/src/components/lesson/ChecklistBlock.vue
+++ b/src/components/lesson/ChecklistBlock.vue
@@ -40,7 +40,7 @@ const sanitizedItems = computed(() => props.data.items.map((item) => sanitizeHtm
   display: flex;
   flex-direction: column;
   gap: var(--md-sys-spacing-5);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .lesson-checklist__title {

--- a/src/components/lesson/ClassDesigner.vue
+++ b/src/components/lesson/ClassDesigner.vue
@@ -474,13 +474,13 @@ function connectorForType(type: UmlRelationship['type']): string {
   border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 55%, transparent);
   background: var(--md-sys-color-surface);
   color: var(--md-sys-color-on-surface);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
   transition: box-shadow 160ms ease;
 }
 
 .class-designer__class:hover,
 .class-designer__class:focus-within {
-  box-shadow: var(--shadow-elevation-2);
+  box-shadow: var(--md-sys-elevation-level2);
 }
 
 .class-designer__class-header {

--- a/src/components/lesson/CodeBlock.vue
+++ b/src/components/lesson/CodeBlock.vue
@@ -168,7 +168,7 @@ watch(
       transparent
     );
   border-radius: var(--md-sys-shape-corner-extra-large, var(--md-sys-border-radius-xl));
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
   margin-block: var(--code-block-spacing, 0);
   overflow: hidden;
   position: relative;

--- a/src/components/lesson/ContentBlock.vue
+++ b/src/components/lesson/ContentBlock.vue
@@ -966,7 +966,7 @@ function sanitizeContent(value: unknown): string {
   background: var(--md-sys-color-surface-container-highest);
   border-radius: var(--md-sys-border-radius-large);
   padding: var(--md-sys-spacing-6);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
   display: flex;
   flex-direction: column;
   gap: var(--md-sys-spacing-4);
@@ -1051,11 +1051,11 @@ function sanitizeContent(value: unknown): string {
   display: flex;
   flex-direction: column;
   gap: var(--md-sys-spacing-3);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .content-block--nested .content-block__sub-block {
-  box-shadow: var(--shadow-elevation-0);
+  box-shadow: var(--md-sys-elevation-level0);
 }
 
 .content-block__sub-title {
@@ -1078,7 +1078,7 @@ function sanitizeContent(value: unknown): string {
 .content-block__figure img {
   max-width: 100%;
   border-radius: var(--md-sys-border-radius-large);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .content-block__figure-caption {
@@ -1098,7 +1098,7 @@ function sanitizeContent(value: unknown): string {
   width: 100%;
   border-radius: var(--md-sys-border-radius-large);
   overflow: hidden;
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .content-block__video-frame iframe {

--- a/src/components/lesson/FlightPlan.vue
+++ b/src/components/lesson/FlightPlan.vue
@@ -37,7 +37,7 @@ const sanitizedItems = computed(() => props.data.items.map((item) => sanitizeHtm
   grid-template-columns: auto 1fr;
   gap: var(--md-sys-spacing-4);
   align-items: start;
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .lesson-flight-plan__icon {

--- a/src/components/lesson/LegacyHtml.vue
+++ b/src/components/lesson/LegacyHtml.vue
@@ -251,7 +251,7 @@ html[data-theme='dark'] .legacy-html :deep(.rounded-lg),
 html[data-theme='dark'] .legacy-html :deep(.rounded-xl) {
   background-color: var(--md-sys-color-surface-container);
   border-color: color-mix(in srgb, var(--md-sys-color-outline) 50%, transparent);
-  box-shadow: var(--shadow-elevation-2);
+  box-shadow: var(--md-sys-elevation-level2);
 }
 
 .legacy-html :deep(h1),
@@ -344,7 +344,7 @@ html[data-theme='dark'] .legacy-html :deep(.rounded-xl) {
 .legacy-html :deep(img) {
   border-radius: var(--md-sys-border-radius-large);
   border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 40%, transparent);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
   max-width: 100%;
   height: auto;
 }
@@ -420,7 +420,7 @@ html[data-theme='dark'] .legacy-html :deep(.rounded-xl) {
   border-radius: var(--md-sys-border-radius-large);
   border: none;
   cursor: pointer;
-  box-shadow: var(--shadow-elevation-2);
+  box-shadow: var(--md-sys-elevation-level2);
   transition:
     transform 0.2s ease,
     box-shadow 0.2s ease;
@@ -428,7 +428,7 @@ html[data-theme='dark'] .legacy-html :deep(.rounded-xl) {
 
 .legacy-html :deep(.btn:hover) {
   transform: translateY(-1px);
-  box-shadow: var(--shadow-elevation-3);
+  box-shadow: var(--md-sys-elevation-level3);
 }
 
 .legacy-html :deep(.btn-tonal) {
@@ -437,7 +437,7 @@ html[data-theme='dark'] .legacy-html :deep(.rounded-xl) {
 }
 
 .legacy-html :deep(.btn-tonal:hover) {
-  box-shadow: var(--shadow-elevation-2);
+  box-shadow: var(--md-sys-elevation-level2);
 }
 
 .legacy-html :deep(.code-block) {

--- a/src/components/lesson/LegacySection.vue
+++ b/src/components/lesson/LegacySection.vue
@@ -77,13 +77,13 @@ const idLabel = computed(() => (id.value ? toTitleCase(id.value) : ''));
   border-radius: var(--md-sys-border-radius-large);
   background-color: var(--md-sys-color-surface);
   border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 45%, transparent);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 html[data-theme='dark'] .legacy-section {
   background-color: var(--md-sys-color-surface-container);
   border-color: color-mix(in srgb, var(--md-sys-color-outline) 35%, transparent);
-  box-shadow: var(--shadow-elevation-2);
+  box-shadow: var(--md-sys-elevation-level2);
 }
 
 .legacy-section__header {
@@ -101,7 +101,7 @@ html[data-theme='dark'] .legacy-section {
   border-radius: var(--md-sys-border-radius-full);
   background-color: var(--md-sys-color-primary-container);
   color: var(--md-sys-color-on-primary-container);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .legacy-section__chip-icon {
@@ -140,7 +140,7 @@ html[data-theme='dark'] .legacy-section {
   background-color: var(--md-sys-color-surface-container);
   border-radius: var(--md-sys-border-radius-large);
   border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 40%, transparent);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
   padding: var(--md-sys-spacing-4);
   display: flex;
   flex-direction: column;
@@ -150,7 +150,7 @@ html[data-theme='dark'] .legacy-section {
 html[data-theme='dark'] .legacy-section__body > :deep([data-legacy-card]) {
   background-color: var(--md-sys-color-surface-container-high);
   border-color: color-mix(in srgb, var(--md-sys-color-outline) 35%, transparent);
-  box-shadow: var(--shadow-elevation-2);
+  box-shadow: var(--md-sys-elevation-level2);
 }
 
 .legacy-section__body :deep(h3),
@@ -244,7 +244,7 @@ html[data-theme='dark'] .legacy-section__body :deep(pre) {
   background-color: var(--md-sys-color-surface);
   border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 35%, transparent);
   border-radius: var(--md-sys-border-radius-large);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
   padding: var(--md-sys-spacing-4);
   display: flex;
   flex-direction: column;
@@ -254,7 +254,7 @@ html[data-theme='dark'] .legacy-section__body :deep(pre) {
 html[data-theme='dark'] .legacy-section__body :deep([data-legacy-grid] > [data-legacy-card]) {
   background-color: var(--md-sys-color-surface-container-high);
   border-color: color-mix(in srgb, var(--md-sys-color-outline) 30%, transparent);
-  box-shadow: var(--shadow-elevation-2);
+  box-shadow: var(--md-sys-elevation-level2);
 }
 
 .legacy-section__body :deep(table) {

--- a/src/components/lesson/LessonChart.vue
+++ b/src/components/lesson/LessonChart.vue
@@ -166,7 +166,7 @@ function formatNumber(value: number): string {
   display: flex;
   flex-direction: column;
   gap: var(--md-sys-spacing-4);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
   --lesson-chart-ring: color-mix(
     in srgb,
     var(--md-sys-color-outline-variant) 60%,

--- a/src/components/lesson/LessonPlan.vue
+++ b/src/components/lesson/LessonPlan.vue
@@ -157,7 +157,7 @@ function createNameVariations(original: string): string[] {
   display: flex;
   flex-direction: column;
   gap: var(--md-sys-spacing-5);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .lesson-plan__title {
@@ -173,7 +173,7 @@ function createNameVariations(original: string): string[] {
   display: flex;
   flex-direction: column;
   gap: var(--md-sys-spacing-2);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .lesson-plan__unit-title {
@@ -203,7 +203,7 @@ function createNameVariations(original: string): string[] {
   align-items: center;
   text-align: center;
   gap: var(--md-sys-spacing-3);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .lesson-plan__icon {

--- a/src/components/lesson/Md3Flowchart.vue
+++ b/src/components/lesson/Md3Flowchart.vue
@@ -236,7 +236,7 @@ function nodeTypeLabel(type: FlowNodeType): string {
   background: var(--md-sys-color-surface);
   color: var(--md-sys-color-on-surface);
   border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 60%, transparent);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
   position: relative;
 }
 
@@ -255,7 +255,7 @@ function nodeTypeLabel(type: FlowNodeType): string {
 .flowchart__node:hover::after,
 .flowchart__node:focus-within::after {
   border-color: color-mix(in srgb, var(--md-sys-color-primary) 35%, transparent);
-  box-shadow: var(--shadow-elevation-2);
+  box-shadow: var(--md-sys-elevation-level2);
 }
 
 .flowchart__node-header {

--- a/src/components/lesson/Md3LogicOperators.vue
+++ b/src/components/lesson/Md3LogicOperators.vue
@@ -13,7 +13,7 @@
         Operador E (AND)
       </h4>
       <div class="logic-operators__section">
-        <div class="card shadow-elevation-2 p-6 logic-operators__explanation">
+        <div class="card md-elevation-2 p-6 logic-operators__explanation">
           <p :style="{ marginBottom: 'var(--md-sys-spacing-4)' }">
             O operador <strong>E</strong> (ou <code class="inline-code">AND</code>) é exigente. Ele
             só resulta em <strong>verdadeiro</strong> se <strong>TODAS</strong> as condições
@@ -66,7 +66,7 @@
       </h4>
       <div class="logic-operators__section">
         <div
-          class="card shadow-elevation-2 logic-operators__explanation"
+          class="card md-elevation-2 logic-operators__explanation"
           :style="{ padding: 'var(--md-sys-spacing-6)' }"
         >
           <p :style="{ marginBottom: 'var(--md-sys-spacing-4)' }">
@@ -120,7 +120,7 @@
       </h4>
       <div class="logic-operators__section">
         <div
-          class="card shadow-elevation-2 logic-operators__explanation"
+          class="card md-elevation-2 logic-operators__explanation"
           :style="{ padding: 'var(--md-sys-spacing-6)' }"
         >
           <p :style="{ marginBottom: 'var(--md-sys-spacing-4)' }">

--- a/src/components/lesson/Md3Table.vue
+++ b/src/components/lesson/Md3Table.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="card shadow-elevation-2">
+  <div class="card md-elevation-2">
     <div class="overflow-x-auto -mx-2 sm:mx-0">
       <table class="w-full md3-table min-w-[480px]">
         <thead class="bg-surface-variant text-on-surface-variant">

--- a/src/components/lesson/MemoryDiagram.vue
+++ b/src/components/lesson/MemoryDiagram.vue
@@ -32,7 +32,7 @@ defineProps<Props>();
   flex-direction: column;
   gap: var(--md-sys-spacing-3);
   align-items: center;
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .memory-diagram__title {

--- a/src/components/lesson/PipelineCanvas.vue
+++ b/src/components/lesson/PipelineCanvas.vue
@@ -461,13 +461,13 @@ function cleanString(value: string | undefined | null): string {
   border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 55%, transparent);
   background: var(--md-sys-color-surface);
   color: var(--md-sys-color-on-surface);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
   transition: box-shadow 160ms ease;
 }
 
 .pipeline-canvas__stage:hover,
 .pipeline-canvas__stage:focus-within {
-  box-shadow: var(--shadow-elevation-2);
+  box-shadow: var(--md-sys-elevation-level2);
 }
 
 .pipeline-canvas__stage-header {

--- a/src/components/lesson/Roadmap.vue
+++ b/src/components/lesson/Roadmap.vue
@@ -43,7 +43,7 @@ defineProps<{ steps: RoadmapStep[] }>();
       var(--md-sys-color-outline-variant, var(--md-sys-color-outline)) 70%,
       transparent
     );
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .md-roadmap__marker {

--- a/src/components/lesson/SystemMapper.vue
+++ b/src/components/lesson/SystemMapper.vue
@@ -343,7 +343,7 @@ function cleanString(value: string | undefined | null): string {
   border: 1px solid color-mix(in srgb, var(--md-sys-color-outline) 55%, transparent);
   background: var(--md-sys-color-surface);
   color: var(--md-sys-color-on-surface);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .system-mapper__factor-header {

--- a/src/components/lesson/Timeline.vue
+++ b/src/components/lesson/Timeline.vue
@@ -54,7 +54,7 @@ function sanitizeContent(value: unknown): string {
   display: flex;
   flex-direction: column;
   gap: var(--md-sys-spacing-5);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
   border: 1px solid
     color-mix(
       in srgb,
@@ -117,7 +117,7 @@ function sanitizeContent(value: unknown): string {
   justify-content: center;
   font-weight: 700;
   font-size: 1.25rem;
-  box-shadow: var(--shadow-elevation-2);
+  box-shadow: var(--md-sys-elevation-level2);
 }
 
 .lesson-timeline__marker span {
@@ -131,7 +131,7 @@ function sanitizeContent(value: unknown): string {
   padding: var(--md-sys-spacing-4);
   border-radius: var(--md-sys-shape-corner-large, var(--md-sys-border-radius-large));
   background: color-mix(in srgb, var(--md-sys-color-surface) 85%, transparent 15%);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .lesson-timeline__step-title {

--- a/src/components/lesson/TruthTable.vue
+++ b/src/components/lesson/TruthTable.vue
@@ -267,7 +267,7 @@ const hasHeader = computed(() => Boolean(props.title || props.description));
 const rootClasses = computed(() => [
   'md3-truth-table',
   'card',
-  'shadow-elevation-2',
+  'md-elevation-2',
   props.dense ? 'md3-truth-table--dense' : null,
 ]);
 

--- a/src/components/lesson/VideosBlock.vue
+++ b/src/components/lesson/VideosBlock.vue
@@ -114,7 +114,7 @@ function toEmbedUrl(url: string): string {
   display: flex;
   flex-direction: column;
   gap: var(--md-sys-spacing-5);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .lesson-videos__header {
@@ -142,7 +142,7 @@ function toEmbedUrl(url: string): string {
   display: flex;
   flex-direction: column;
   gap: var(--md-sys-spacing-3);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .lesson-videos__item-title {
@@ -158,7 +158,7 @@ function toEmbedUrl(url: string): string {
   border-radius: var(--md-sys-border-radius-large);
   overflow: hidden;
   background: var(--md-sys-color-surface-variant);
-  box-shadow: var(--shadow-elevation-1);
+  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .lesson-videos__iframe {

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -11,7 +11,7 @@
           </p>
         </div>
         <div class="grid gap-3 sm:grid-cols-2 md:w-64 md:grid-cols-1">
-          <div class="surface-tonal md-shape-large p-4 shadow-elevation-1">
+          <div class="surface-tonal md-shape-large p-4 md-elevation-1">
             <p class="text-label-medium uppercase tracking-[0.2em] text-on-surface-variant">
               Disciplinas
             </p>

--- a/src/theme/material-theme.ts
+++ b/src/theme/material-theme.ts
@@ -10,9 +10,11 @@ import {
   APP_BAR_HEIGHTS,
   BREAKPOINTS,
   COLOR_ROLE_TOKENS,
+  DENSITY_SCALE,
   DIMENSION_SCALE,
   ELEVATION_SHADOWS,
   LAYOUT_CONTAINERS,
+  MOTION_TOKENS,
   SHAPE_SCALE,
   SPACING_SCALE,
   STATE_LAYER_OPACITY,
@@ -176,13 +178,12 @@ function applyScheme(mode: ThemeMode) {
   });
 
   const elevation = ELEVATION_SHADOWS[mode];
+  rootStyle.setProperty('--md-sys-elevation-level0', elevation.level0);
   rootStyle.setProperty('--md-sys-elevation-level1', elevation.level1);
   rootStyle.setProperty('--md-sys-elevation-level2', elevation.level2);
   rootStyle.setProperty('--md-sys-elevation-level3', elevation.level3);
-  // Maintain legacy aliases while components migrate fully to the new tokens.
-  rootStyle.setProperty('--shadow-elevation-1', elevation.level1);
-  rootStyle.setProperty('--shadow-elevation-2', elevation.level2);
-  rootStyle.setProperty('--shadow-elevation-3', elevation.level3);
+  rootStyle.setProperty('--md-sys-elevation-level4', elevation.level4);
+  rootStyle.setProperty('--md-sys-elevation-level5', elevation.level5);
 
   document.documentElement.dataset.theme = mode;
   rootStyle.setProperty('color-scheme', mode);
@@ -281,6 +282,32 @@ function applyStaticTokens() {
   (Object.entries(APP_BAR_HEIGHTS) as Array<[string, string]>).forEach(([key, value]) => {
     rootStyle.setProperty(`--md-sys-app-bar-height-${key}`, value);
   });
+
+  (Object.entries(MOTION_TOKENS.duration) as Array<[string, string]>).forEach(([key, value]) => {
+    const normalizedKey = key.replace(/([A-Z])/g, '-$1').toLowerCase();
+    rootStyle.setProperty(`--md-sys-motion-duration-${normalizedKey}`, value);
+  });
+
+  (Object.entries(MOTION_TOKENS.easing) as Array<[string, string]>).forEach(([key, value]) => {
+    const normalizedKey = key.replace(/([A-Z])/g, '-$1').toLowerCase();
+    rootStyle.setProperty(`--md-sys-motion-easing-${normalizedKey}`, value);
+  });
+
+  (Object.entries(DENSITY_SCALE.reference) as Array<[string, number]>).forEach(([key, value]) => {
+    rootStyle.setProperty(`--md-sys-density-reference-${key}`, String(value));
+  });
+
+  (Object.entries(DENSITY_SCALE.topAppBar) as Array<[string, number]>).forEach(([key, value]) => {
+    rootStyle.setProperty(`--md-sys-density-top-app-bar-${key}`, String(value));
+  });
+
+  (Object.entries(DENSITY_SCALE.navigation) as Array<[string, Record<string, number>]>).forEach(
+    ([group, values]) => {
+      (Object.entries(values) as Array<[string, number]>).forEach(([key, value]) => {
+        rootStyle.setProperty(`--md-sys-density-${group}-${key}`, String(value));
+      });
+    }
+  );
 
   staticTokensApplied = true;
 }

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -60,17 +60,23 @@ export const STRONG_STATE_LAYER_OPACITY: Record<ThemeMode, number> = {
 
 export const ELEVATION_SHADOWS: Record<
   ThemeMode,
-  Record<'level1' | 'level2' | 'level3', string>
+  Record<'level0' | 'level1' | 'level2' | 'level3' | 'level4' | 'level5', string>
 > = {
   light: {
+    level0: 'none',
     level1: '0px 1px 3px rgba(17, 24, 39, 0.16), 0px 2px 6px rgba(17, 24, 39, 0.12)',
     level2: '0px 4px 12px rgba(17, 24, 39, 0.16), 0px 2px 6px rgba(17, 24, 39, 0.12)',
     level3: '0px 8px 20px rgba(17, 24, 39, 0.24), 0px 4px 8px rgba(17, 24, 39, 0.16)',
+    level4: '0px 12px 28px rgba(17, 24, 39, 0.24), 0px 8px 12px rgba(17, 24, 39, 0.2)',
+    level5: '0px 16px 40px rgba(17, 24, 39, 0.28), 0px 12px 16px rgba(17, 24, 39, 0.2)',
   },
   dark: {
+    level0: 'none',
     level1: '0px 1px 3px rgba(0, 0, 0, 0.55), 0px 2px 6px rgba(0, 0, 0, 0.45)',
     level2: '0px 4px 12px rgba(0, 0, 0, 0.48), 0px 2px 8px rgba(0, 0, 0, 0.32)',
     level3: '0px 10px 24px rgba(0, 0, 0, 0.55), 0px 6px 16px rgba(0, 0, 0, 0.36)',
+    level4: '0px 16px 32px rgba(0, 0, 0, 0.6), 0px 8px 12px rgba(0, 0, 0, 0.42)',
+    level5: '0px 20px 48px rgba(0, 0, 0, 0.64), 0px 12px 16px rgba(0, 0, 0, 0.48)',
   },
 };
 
@@ -139,6 +145,53 @@ export const DIMENSION_SCALE = {
   },
 };
 
+export const MOTION_TOKENS = {
+  duration: {
+    short1: '50ms',
+    short2: '100ms',
+    medium1: '150ms',
+    medium2: '200ms',
+    long1: '300ms',
+    long2: '400ms',
+    extraLong1: '500ms',
+  },
+  easing: {
+    standard: 'cubic-bezier(0.2, 0, 0, 1)',
+    standardAccelerate: 'cubic-bezier(0.3, 0, 0.8, 0.15)',
+    standardDecelerate: 'cubic-bezier(0, 0, 0, 1)',
+    emphasized: 'cubic-bezier(0.3, 0, 0.2, 1)',
+    emphasizedAccelerate: 'cubic-bezier(0.3, 0, 0.8, 0.15)',
+    emphasizedDecelerate: 'cubic-bezier(0.05, 0.7, 0.1, 1)',
+  },
+} as const;
+
+export const DENSITY_SCALE = {
+  reference: {
+    default: 0,
+    comfortable: -1,
+    compact: -2,
+  },
+  topAppBar: {
+    default: 0,
+    comfortable: -2,
+    compact: -4,
+  },
+  navigation: {
+    rail: {
+      default: 0,
+      compact: -1,
+    },
+    drawer: {
+      default: 0,
+      compact: -2,
+    },
+    bottomBar: {
+      default: 0,
+      compact: -1,
+    },
+  },
+} as const;
+
 export const BREAKPOINTS = {
   sm: '40rem',
   md: '56rem',
@@ -157,3 +210,27 @@ export const APP_BAR_HEIGHTS = {
   medium: '4.5rem',
   large: '6rem',
 };
+
+export function buildDesignTokenExport() {
+  return {
+    color: {
+      roles: COLOR_ROLE_TOKENS,
+      stateLayerOpacity: STATE_LAYER_OPACITY,
+      strongStateLayerOpacity: STRONG_STATE_LAYER_OPACITY,
+    },
+    elevation: ELEVATION_SHADOWS,
+    typography: TYPOGRAPHY_SCALE,
+    shape: SHAPE_SCALE,
+    spacing: SPACING_SCALE,
+    dimension: DIMENSION_SCALE,
+    breakpoints: BREAKPOINTS,
+    layout: {
+      containers: LAYOUT_CONTAINERS,
+      appBarHeights: APP_BAR_HEIGHTS,
+    },
+    motion: MOTION_TOKENS,
+    density: DENSITY_SCALE,
+  } as const;
+}
+
+export type DesignTokenExport = ReturnType<typeof buildDesignTokenExport>;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -68,12 +68,12 @@ function createModeCss(mode: ThemeMode): string {
   );
 
   const elevation = ELEVATION_SHADOWS[mode];
+  lines.push(`  --md-sys-elevation-level0: ${elevation.level0};`);
   lines.push(`  --md-sys-elevation-level1: ${elevation.level1};`);
   lines.push(`  --md-sys-elevation-level2: ${elevation.level2};`);
   lines.push(`  --md-sys-elevation-level3: ${elevation.level3};`);
-  lines.push(`  --shadow-elevation-1: var(--md-sys-elevation-level1);`);
-  lines.push(`  --shadow-elevation-2: var(--md-sys-elevation-level2);`);
-  lines.push(`  --shadow-elevation-3: var(--md-sys-elevation-level3);`);
+  lines.push(`  --md-sys-elevation-level4: ${elevation.level4};`);
+  lines.push(`  --md-sys-elevation-level5: ${elevation.level5};`);
 
   lines.push('}');
   return lines.join('\n');


### PR DESCRIPTION
## Summary
- add shared story metrics and update MD3 layout stories with viewport presets for mobile and desktop scenarios
- extend the design token catalog with motion and density tokens, remove legacy shadow aliases, and wire a JSON export script for automation
- regenerate the design token artifacts and refresh the documentation to describe the new tokens and workflow

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d9dac28f24832cbb5d25b4ccd62463