### PR TITLE
feat: normalize course content manifests

### DIFF
--- a/src/content/__tests__/loaders.test.ts
+++ b/src/content/__tests__/loaders.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { normalizeManifest } from '../loaders';
+
+describe('normalizeManifest', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('normalizes a valid manifest with metadata', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const moduleExport = {
+      default: {
+        version: 'v1',
+        generatedAt: '2024-01-01T00:00:00Z',
+        entries: [{ id: 'lesson-1' }],
+      },
+    };
+
+    const result = normalizeManifest<{ id: string }>(moduleExport, { context: 'test' });
+
+    expect(result.entries).toEqual([{ id: 'lesson-1' }]);
+    expect(result.version).toBe('v1');
+    expect(result.generatedAt).toBe('2024-01-01T00:00:00Z');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns and returns an empty array when entries array is empty', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const moduleExport = {
+      default: {
+        version: 'v1',
+        generatedAt: '2024-01-01T00:00:00Z',
+        entries: [],
+      },
+    };
+
+    const result = normalizeManifest<{ id: string }>(moduleExport, { context: 'test' });
+
+    expect(result.entries).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith('[test] Manifest entries array is empty.');
+  });
+
+  it('warns and returns [] when entries are malformed', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const moduleExport = {
+      default: {
+        version: 'v1',
+        generatedAt: '2024-01-01T00:00:00Z',
+        entries: 'not-an-array',
+      },
+    };
+
+    const result = normalizeManifest<{ id: string }>(moduleExport, { context: 'test' });
+
+    expect(result.entries).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith('[test] Manifest is missing a valid "entries" array.');
+  });
+});

--- a/src/content/loaders.ts
+++ b/src/content/loaders.ts
@@ -1,0 +1,71 @@
+export interface ManifestPayload<T> {
+  entries?: unknown;
+  version?: unknown;
+  generatedAt?: unknown;
+}
+
+export interface NormalizedManifest<T> {
+  entries: T[];
+  version?: string;
+  generatedAt?: string;
+}
+
+interface NormalizeOptions {
+  context?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function logWarning(context: string, message: string, detail?: unknown) {
+  const label = context ? `[${context}]` : '[content manifest]';
+  if (typeof detail === 'undefined') {
+    console.warn(`${label} ${message}`);
+  } else {
+    console.warn(`${label} ${message}`, detail);
+  }
+}
+
+export function normalizeManifest<T>(
+  moduleExport: unknown,
+  options: NormalizeOptions = {}
+): NormalizedManifest<T> {
+  const context = options.context ?? 'content manifest';
+  const payload = (moduleExport as { default?: unknown })?.default ?? moduleExport;
+
+  if (Array.isArray(payload)) {
+    if (payload.length === 0) {
+      logWarning(context, 'Manifest entries array is empty.');
+    }
+
+    return {
+      entries: payload as T[],
+    };
+  }
+
+  if (isRecord(payload)) {
+    const { entries, version, generatedAt } = payload as ManifestPayload<T>;
+    if (!Array.isArray(entries)) {
+      logWarning(context, 'Manifest is missing a valid "entries" array.');
+      return {
+        entries: [],
+        version: typeof version === 'string' ? version : undefined,
+        generatedAt: typeof generatedAt === 'string' ? generatedAt : undefined,
+      };
+    }
+
+    if (entries.length === 0) {
+      logWarning(context, 'Manifest entries array is empty.');
+    }
+
+    return {
+      entries: entries as T[],
+      version: typeof version === 'string' ? version : undefined,
+      generatedAt: typeof generatedAt === 'string' ? generatedAt : undefined,
+    };
+  }
+
+  logWarning(context, 'Manifest payload is malformed.', payload);
+  return { entries: [] };
+}

--- a/src/pages/CourseHome.vue
+++ b/src/pages/CourseHome.vue
@@ -117,7 +117,7 @@ import { computed, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { ChevronRight, Grid3x3, List } from 'lucide-vue-next';
 import Md3Button from '@/components/Md3Button.vue';
-import { extractManifestEntries } from '@/utils/contentManifest';
+import { normalizeManifest } from '@/content/loaders';
 
 interface LessonRef {
   id: string;
@@ -177,7 +177,10 @@ async function loadLessons(id: string) {
     if (!importer) throw new Error(`Lessons manifest not found for ${path}`);
 
     const module = await importer();
-    lessons.value = extractManifestEntries<LessonRef>(module);
+    const { entries } = normalizeManifest<LessonRef>(module, {
+      context: `CourseHome:lessons:${id}`,
+    });
+    lessons.value = entries;
   } catch (err) {
     console.error('[CourseHome] Failed to load lessons.json', err);
     lessons.value = [];
@@ -191,7 +194,10 @@ async function loadExercises(id: string) {
     if (!importer) throw new Error(`Exercises manifest not found for ${path}`);
 
     const module = await importer();
-    exercises.value = extractManifestEntries<ExerciseRef>(module);
+    const { entries } = normalizeManifest<ExerciseRef>(module, {
+      context: `CourseHome:exercises:${id}`,
+    });
+    exercises.value = entries;
   } catch (err) {
     console.warn('[CourseHome] Exercises not available', err);
     exercises.value = [];

--- a/src/pages/CourseLayout.vue
+++ b/src/pages/CourseLayout.vue
@@ -53,7 +53,7 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { RouterLink, useRoute } from 'vue-router';
 import { ArrowLeft } from 'lucide-vue-next';
 import Md3Button from '@/components/Md3Button.vue';
-import { extractManifestEntries } from '@/utils/contentManifest';
+import { normalizeManifest } from '@/content/loaders';
 
 interface CourseMeta {
   id: string;
@@ -109,7 +109,9 @@ async function loadLessons(id: string) {
     if (!importer) throw new Error(`Lessons manifest not found for ${path}`);
 
     const module = await importer();
-    const entries = extractManifestEntries<LessonSummary>(module);
+    const { entries } = normalizeManifest<LessonSummary>(module, {
+      context: `CourseLayout:lessons:${id}`,
+    });
     lessons.value = entries.map((lesson) => ({
       id: lesson.id,
       title: lesson.title,
@@ -127,7 +129,9 @@ async function loadExercises(id: string) {
     if (!importer) throw new Error(`Exercises manifest not found for ${path}`);
 
     const module = await importer();
-    const entries = extractManifestEntries<ExerciseSummary>(module);
+    const { entries } = normalizeManifest<ExerciseSummary>(module, {
+      context: `CourseLayout:exercises:${id}`,
+    });
     exercises.value = entries.map((exercise) => ({
       id: exercise.id,
       title: exercise.title,

--- a/src/pages/ExerciseView.vue
+++ b/src/pages/ExerciseView.vue
@@ -49,7 +49,7 @@ import { computed, defineAsyncComponent, onMounted, ref, shallowRef, watch } fro
 import { RouterLink, useRoute } from 'vue-router';
 import { ArrowLeft, ChevronRight } from 'lucide-vue-next';
 import Md3Button from '@/components/Md3Button.vue';
-import { extractManifestEntries } from '@/utils/contentManifest';
+import { normalizeManifest } from '@/content/loaders';
 
 interface GenerationMetadata {
   generatedBy: string;
@@ -94,7 +94,9 @@ async function loadExercise() {
     if (!indexImporter) throw new Error(`Exercise index not found for path: ${indexPath}`);
 
     const indexModule = await indexImporter();
-    const index = extractManifestEntries<ExerciseRef>(indexModule);
+    const { entries: index } = normalizeManifest<ExerciseRef>(indexModule, {
+      context: `ExerciseView:index:${currentCourse}`,
+    });
     const entry = index.find((item) => item.id === currentExercise);
     if (!entry) throw new Error(`Exercise ${currentExercise} not found`);
 

--- a/src/pages/LessonView.vue
+++ b/src/pages/LessonView.vue
@@ -52,7 +52,7 @@ import Prism from 'prismjs';
 import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
 import type { LessonBlock } from '@/components/lesson/blockRegistry';
 import Md3Button from '@/components/Md3Button.vue';
-import { extractManifestEntries } from '@/utils/contentManifest';
+import { normalizeManifest } from '@/content/loaders';
 
 import 'prismjs/components/prism-markup';
 import 'prismjs/components/prism-javascript';
@@ -111,10 +111,9 @@ async function loadLesson() {
     if (!indexImporter) throw new Error(`Could not find lesson index for path: ${indexPath}`);
 
     const indexModule: any = await indexImporter();
-    const index = extractManifestEntries<LessonRef>(indexModule);
-    if (!Array.isArray(index)) {
-      throw new Error('Lesson index payload is invalid.');
-    }
+    const { entries: index } = normalizeManifest<LessonRef>(indexModule, {
+      context: `LessonView:index:${currentCourse}`,
+    });
 
     const entry = index.find((item) => item.id === currentLesson);
     if (!entry) throw new Error(`Lesson ${currentLesson} not found`);


### PR DESCRIPTION
## Summary
- add a normalizeManifest helper to consistently unwrap content manifests and log invalid payloads
- update course layout, home, lesson, and exercise views to consume the normalized entries
- cover the helper with Vitest cases for valid, empty, and malformed manifests

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d9f3ed3068832ca05761e8d204df73