### PR TITLE
Add lesson metadata summary and fallback bibliography

### DIFF
--- a/src/components/lesson/LessonMetadataSummary.vue
+++ b/src/components/lesson/LessonMetadataSummary.vue
@@ -1,0 +1,293 @@
+<template>
+  <section v-if="hasAnyContent" class="lesson-metadata-summary">
+    <header class="lesson-metadata-summary__header">
+      <h3 class="lesson-metadata-summary__title">Resumo da aula</h3>
+    </header>
+
+    <div class="lesson-metadata-summary__grid">
+      <div
+        v-for="section in listSections"
+        :key="section.id"
+        class="lesson-metadata-summary__section"
+      >
+        <h4 class="lesson-metadata-summary__section-title">{{ section.title }}</h4>
+        <ul class="lesson-metadata-summary__list" role="list">
+          <li
+            v-for="(item, index) in section.items"
+            :key="index"
+            class="lesson-metadata-summary__list-item"
+          >
+            {{ item }}
+          </li>
+        </ul>
+      </div>
+
+      <div v-if="resources.length" class="lesson-metadata-summary__section">
+        <h4 class="lesson-metadata-summary__section-title">Recursos</h4>
+        <ul class="lesson-metadata-summary__list" role="list">
+          <li
+            v-for="(resource, index) in resources"
+            :key="index"
+            class="lesson-metadata-summary__resource"
+          >
+            <a
+              v-if="resource.url"
+              class="lesson-metadata-summary__resource-link"
+              :href="resource.url"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {{ resource.label }}
+            </a>
+            <span v-else class="lesson-metadata-summary__resource-label">{{ resource.label }}</span>
+            <span v-if="resource.type" class="lesson-metadata-summary__chip">
+              {{ resource.type }}
+            </span>
+          </li>
+        </ul>
+      </div>
+
+      <div
+        v-if="assessment"
+        class="lesson-metadata-summary__section lesson-metadata-summary__assessment"
+      >
+        <h4 class="lesson-metadata-summary__section-title">Avaliação</h4>
+        <div class="lesson-metadata-summary__assessment-content">
+          <span v-if="assessment.type" class="lesson-metadata-summary__chip">
+            {{ assessment.type }}
+          </span>
+          <p
+            v-if="assessment.description && sanitizedAssessmentHtml"
+            class="lesson-metadata-summary__assessment-description"
+            v-html="sanitizedAssessmentHtml"
+          ></p>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { sanitizeHtml } from '@/utils/sanitizeHtml';
+
+export interface LessonMetadataResource {
+  label: string;
+  url?: string;
+  type?: string;
+}
+
+export interface LessonMetadataAssessment {
+  type?: string;
+  description?: string;
+}
+
+export interface LessonMetadataSummaryProps {
+  objectives?: string[];
+  competencies?: string[];
+  skills?: string[];
+  outcomes?: string[];
+  prerequisites?: string[];
+  resources?: LessonMetadataResource[];
+  assessment?: LessonMetadataAssessment;
+}
+
+const props = defineProps<LessonMetadataSummaryProps>();
+
+interface MetadataSection {
+  id: string;
+  title: string;
+  items: string[];
+}
+
+const listSections = computed<MetadataSection[]>(() => {
+  const sections: MetadataSection[] = [];
+
+  function addSection(id: string, title: string, entries: unknown) {
+    if (!Array.isArray(entries) || entries.length === 0) {
+      return;
+    }
+
+    const normalized = entries
+      .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+      .filter((entry) => entry.length > 0);
+
+    if (normalized.length === 0) {
+      return;
+    }
+
+    sections.push({ id, title, items: normalized });
+  }
+
+  addSection('objectives', 'Objetivos', props.objectives);
+  addSection('competencies', 'Competências', props.competencies);
+  addSection('skills', 'Habilidades', props.skills);
+  addSection('outcomes', 'Resultados esperados', props.outcomes);
+  addSection('prerequisites', 'Pré-requisitos', props.prerequisites);
+
+  return sections;
+});
+
+const resources = computed(() => {
+  if (!Array.isArray(props.resources)) {
+    return [] as LessonMetadataResource[];
+  }
+
+  return props.resources
+    .map((resource) => {
+      if (!resource || typeof resource !== 'object') {
+        return null;
+      }
+
+      const label = typeof resource.label === 'string' ? resource.label.trim() : '';
+      if (!label) {
+        return null;
+      }
+
+      const normalized: LessonMetadataResource = { label };
+      const url = typeof resource.url === 'string' ? resource.url.trim() : '';
+      if (url) {
+        normalized.url = url;
+      }
+      const type = typeof resource.type === 'string' ? resource.type.trim() : '';
+      if (type) {
+        normalized.type = type;
+      }
+      return normalized;
+    })
+    .filter((resource): resource is LessonMetadataResource => Boolean(resource));
+});
+
+const assessment = computed(() => {
+  const value = props.assessment;
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const type = typeof value.type === 'string' ? value.type.trim() : '';
+  const description = typeof value.description === 'string' ? value.description : '';
+
+  if (!type && !description.trim()) {
+    return null;
+  }
+
+  return {
+    type: type || undefined,
+    description: description || undefined,
+  } satisfies LessonMetadataAssessment;
+});
+
+const sanitizedAssessmentHtml = computed(() => {
+  if (!assessment.value || !assessment.value.description) {
+    return '';
+  }
+
+  return sanitizeHtml(assessment.value.description);
+});
+
+const hasAnyContent = computed(
+  () => listSections.value.length > 0 || resources.value.length > 0 || Boolean(assessment.value)
+);
+</script>
+
+<style scoped>
+.lesson-metadata-summary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--md-sys-spacing-5);
+  padding: var(--md-sys-spacing-6);
+  border-radius: var(--md-sys-border-radius-large);
+  background: var(--md-sys-color-surface-container);
+  box-shadow: var(--md-sys-elevation-level1);
+}
+
+.lesson-metadata-summary__title {
+  font-size: var(--md-sys-typescale-headline-small-size, 1.5rem);
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface);
+}
+
+.lesson-metadata-summary__grid {
+  display: grid;
+  gap: var(--md-sys-spacing-5);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.lesson-metadata-summary__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--md-sys-spacing-3);
+}
+
+.lesson-metadata-summary__section-title {
+  font-size: var(--md-sys-typescale-title-medium-size, 1.125rem);
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface);
+}
+
+.lesson-metadata-summary__list {
+  display: grid;
+  gap: var(--md-sys-spacing-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.lesson-metadata-summary__list-item {
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: var(--md-sys-typescale-body-medium-size, 0.9375rem);
+  line-height: 1.6;
+}
+
+.lesson-metadata-summary__resource {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--md-sys-spacing-2);
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: var(--md-sys-typescale-body-medium-size, 0.9375rem);
+}
+
+.lesson-metadata-summary__resource-link {
+  color: var(--md-sys-color-primary);
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.lesson-metadata-summary__chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  background: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+  font-size: var(--md-sys-typescale-label-medium-size, 0.875rem);
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.lesson-metadata-summary__assessment-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--md-sys-spacing-2);
+}
+
+.lesson-metadata-summary__assessment-description {
+  color: var(--md-sys-color-on-surface-variant);
+  margin: 0;
+  font-size: var(--md-sys-typescale-body-medium-size, 0.9375rem);
+  line-height: 1.6;
+}
+
+.lesson-metadata-summary__assessment-description :deep(a) {
+  color: var(--md-sys-color-primary);
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .lesson-metadata-summary {
+    padding: var(--md-sys-spacing-5);
+  }
+}
+</style>

--- a/src/components/lesson/LessonRenderer.vue
+++ b/src/components/lesson/LessonRenderer.vue
@@ -1,14 +1,15 @@
 <template>
-  <section
-    v-if="data && data.content && data.content.length"
-    class="lesson-renderer md-stack md-stack-6"
-  >
+  <section v-if="hasRenderableContent" class="lesson-renderer md-stack md-stack-6">
+    <LessonMetadataSummary v-if="metadataSummary" v-bind="metadataSummary" />
+
     <template v-for="(entry, index) in resolvedBlocks" :key="index">
       <component v-if="entry.component" :is="entry.component" v-bind="entry.props" />
       <div v-else class="prose max-w-none text-[var(--md-sys-color-on-surface-variant)]">
         <p>{{ entry.error }}</p>
       </div>
     </template>
+
+    <BibliographyBlock v-if="bibliographyFallback" :data="bibliographyFallback" />
   </section>
   <p v-else class="prose max-w-none text-[var(--md-sys-color-on-surface-variant)]">
     Nenhum conteúdo disponível para esta aula.
@@ -17,21 +18,24 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import type { NormalizedLesson } from '@/content/schema/lesson';
+import BibliographyBlock from './BibliographyBlock.vue';
+import LessonMetadataSummary, {
+  type LessonMetadataAssessment,
+  type LessonMetadataResource,
+  type LessonMetadataSummaryProps,
+} from './LessonMetadataSummary.vue';
 import type { LessonBlock } from './blockRegistry';
 import { resolveBlock } from './blockRegistry';
 
-type LessonContent = {
-  id: string;
-  title: string;
-  objective?: string;
-  content: LessonBlock[];
-};
+type LessonContent = NormalizedLesson & { content: LessonBlock[] };
 
 const props = defineProps<{ data: LessonContent }>();
 
+const blocks = computed<LessonBlock[]>(() => props.data?.content ?? []);
+
 const resolvedBlocks = computed(() => {
-  const blocks = props.data?.content ?? [];
-  return blocks.map((block) => {
+  return blocks.value.map((block) => {
     const resolution = resolveBlock(block);
     return {
       ...resolution,
@@ -41,6 +45,200 @@ const resolvedBlocks = computed(() => {
     };
   });
 });
+
+const metadataSummary = computed<LessonMetadataSummaryProps | null>(() => {
+  const summary: LessonMetadataSummaryProps = {};
+  let hasSummary = false;
+
+  const objectives = toStringArray(props.data?.objectives);
+  if (objectives.length) {
+    summary.objectives = objectives;
+    hasSummary = true;
+  }
+
+  const competencies = toStringArray(props.data?.competencies);
+  if (competencies.length) {
+    summary.competencies = competencies;
+    hasSummary = true;
+  }
+
+  const skills = toStringArray(props.data?.skills);
+  if (skills.length) {
+    summary.skills = skills;
+    hasSummary = true;
+  }
+
+  const outcomes = toStringArray(props.data?.outcomes);
+  if (outcomes.length) {
+    summary.outcomes = outcomes;
+    hasSummary = true;
+  }
+
+  const prerequisites = toStringArray(props.data?.prerequisites);
+  if (prerequisites.length) {
+    summary.prerequisites = prerequisites;
+    hasSummary = true;
+  }
+
+  const resources = normalizeResources(props.data?.resources);
+  if (resources.length) {
+    summary.resources = resources;
+    hasSummary = true;
+  }
+
+  const assessment = normalizeAssessment(props.data?.assessment);
+  if (assessment) {
+    summary.assessment = assessment;
+    hasSummary = true;
+  }
+
+  return hasSummary ? summary : null;
+});
+
+const hasBibliographyBlock = computed(() =>
+  blocks.value.some((block) => {
+    const type = getBlockType(block);
+    return type === 'bibliography' || type === 'bibliographyblock';
+  })
+);
+
+interface BibliographyFallbackData {
+  title: string;
+  items: string[];
+}
+
+const bibliographyFallback = computed<BibliographyFallbackData | null>(() => {
+  const entries = normalizeBibliography(props.data?.bibliography);
+  if (!entries.length || hasBibliographyBlock.value) {
+    return null;
+  }
+
+  return {
+    title: 'Bibliografia',
+    items: entries,
+  };
+});
+
+const hasRenderableContent = computed(
+  () =>
+    Boolean(metadataSummary.value) ||
+    resolvedBlocks.value.length > 0 ||
+    Boolean(bibliographyFallback.value)
+);
+
+function getBlockType(block: LessonBlock): string {
+  const type = typeof block?.type === 'string' ? block.type.trim().toLowerCase() : '';
+  return type;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+    .filter((entry) => entry.length > 0);
+}
+
+function normalizeResources(value: unknown): LessonMetadataResource[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const resources: LessonMetadataResource[] = [];
+
+  value.forEach((entry) => {
+    if (!entry || typeof entry !== 'object') {
+      return;
+    }
+
+    const label = toOptionalString((entry as Record<string, unknown>).label);
+    if (!label) {
+      return;
+    }
+
+    const resource: LessonMetadataResource = { label };
+
+    const url = toOptionalString((entry as Record<string, unknown>).url);
+    if (url) {
+      resource.url = url;
+    }
+
+    const type = toOptionalString((entry as Record<string, unknown>).type);
+    if (type) {
+      resource.type = type;
+    }
+
+    resources.push(resource);
+  });
+
+  return resources;
+}
+
+function normalizeAssessment(value: unknown): LessonMetadataAssessment | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const type = toOptionalString((value as Record<string, unknown>).type);
+  const rawDescription =
+    typeof (value as Record<string, unknown>).description === 'string'
+      ? (value as Record<string, unknown>).description
+      : undefined;
+  const hasDescription = typeof rawDescription === 'string' && rawDescription.trim().length > 0;
+
+  if (!type && !hasDescription) {
+    return undefined;
+  }
+
+  const assessment: LessonMetadataAssessment = {};
+
+  if (type) {
+    assessment.type = type;
+  }
+
+  if (hasDescription && rawDescription) {
+    assessment.description = rawDescription;
+  }
+
+  return assessment;
+}
+
+function normalizeBibliography(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => {
+      if (typeof entry === 'string') {
+        return entry.trim();
+      }
+
+      if (!entry || typeof entry !== 'object') {
+        return '';
+      }
+
+      const html = toOptionalString((entry as Record<string, unknown>).html);
+      if (html) {
+        return html;
+      }
+
+      const text = toOptionalString((entry as Record<string, unknown>).text);
+      return text ?? '';
+    })
+    .filter((entry) => entry.length > 0);
+}
+
+function toOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
 </script>
 
 <style scoped>

--- a/src/components/lesson/__tests__/LessonRenderer.test.ts
+++ b/src/components/lesson/__tests__/LessonRenderer.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import LessonRenderer from '../LessonRenderer.vue';
+import ddmLesson01 from '@/content/courses/ddm/lessons/lesson-01.json';
+
+describe('LessonRenderer', () => {
+  it('renders metadata summary with resources and assessment', () => {
+    const wrapper = mount(LessonRenderer, {
+      props: {
+        data: {
+          id: 'demo',
+          title: 'Demo Lesson',
+          objectives: ['Conhecer a estrutura do curso', 'Explorar o ecossistema Android'],
+          competencies: ['Planejamento de jornadas'],
+          resources: [
+            {
+              label: 'Android Developers',
+              url: 'https://developer.android.com',
+              type: 'artigo',
+            },
+            {
+              label: 'Recurso interno',
+            },
+          ],
+          assessment: {
+            type: 'diagnóstico',
+            description: 'Checklist inicial com participação e expectativas.',
+          },
+          bibliography: ['Autor. Título. 2024.'],
+          content: [],
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Resumo da aula');
+    expect(wrapper.text()).toContain('Objetivos');
+    expect(wrapper.text()).toContain('Competências');
+    expect(wrapper.findAll('.lesson-metadata-summary__list-item').length).toBeGreaterThan(1);
+    expect(wrapper.findAll('.lesson-metadata-summary__resource').length).toBe(2);
+    expect(wrapper.find('.lesson-bibliography').exists()).toBe(true);
+    expect(wrapper.text()).not.toContain('Nenhum conteúdo disponível para esta aula.');
+  });
+
+  it('smoke-tests ddm lesson 01 metadata', () => {
+    const lesson = ddmLesson01 as any;
+    const wrapper = mount(LessonRenderer, {
+      props: {
+        data: {
+          id: lesson.id,
+          title: lesson.title,
+          objective: lesson.objective,
+          objectives: lesson.objectives,
+          competencies: lesson.competencies,
+          resources: lesson.resources,
+          assessment: lesson.assessment,
+          bibliography: lesson.bibliography,
+          content: [],
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Objetivos');
+    expect(wrapper.text()).toContain('Bibliografia');
+    expect(wrapper.findAll('.lesson-bibliography__item').length).toBeGreaterThan(0);
+    expect(wrapper.text()).not.toContain('Nenhum conteúdo disponível para esta aula.');
+  });
+
+  it('omits fallback bibliography when explicit block is provided', () => {
+    const wrapper = mount(LessonRenderer, {
+      props: {
+        data: {
+          id: 'with-block',
+          title: 'With block',
+          content: [
+            {
+              type: 'bibliography',
+              title: 'Leituras obrigatórias',
+              items: ['Item existente'],
+            },
+          ],
+          bibliography: ['Item duplicado'],
+        },
+      },
+    });
+
+    const bibliographySections = wrapper.findAll('.lesson-bibliography');
+    expect(bibliographySections.length).toBe(1);
+    expect(wrapper.text()).toContain('Leituras obrigatórias');
+    expect(wrapper.text()).not.toContain('Bibliografia');
+  });
+});


### PR DESCRIPTION
## Summary
- extend the lesson view and renderer to surface top-level metadata like objectives, competencies, resources, and assessment details
- add a dedicated lesson metadata summary component with styling and automatic bibliography fallback when no block is provided
- add regression tests that smoke test the renderer with sample lessons and ensure the fallback logic behaves correctly

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68da4bf50044832cb16573e95a157d14