### PR TITLE
Normalize lesson icon wrappers to MD3 tokens

### DIFF
--- a/src/components/lesson/AudioBlock.vue
+++ b/src/components/lesson/AudioBlock.vue
@@ -77,11 +77,12 @@ const mediaType = computed(() => {
 }
 
 .md-audio-block__icon {
+  --md-audio-block-icon-size: var(--md-sys-spacing-10);
   display: inline-grid;
   place-items: center;
-  height: 3rem;
-  width: 3rem;
-  border-radius: 1rem;
+  width: var(--md-audio-block-icon-size);
+  height: var(--md-audio-block-icon-size);
+  border-radius: var(--md-sys-border-radius-large);
   background: var(--md-sys-color-primary-container);
   color: var(--md-sys-color-on-primary-container);
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--md-sys-color-primary) 30%, transparent);

--- a/src/components/lesson/Callout.vue
+++ b/src/components/lesson/Callout.vue
@@ -1,7 +1,7 @@
 <template>
   <article class="callout" :class="variantClass">
     <div v-if="icon" class="callout__icon" aria-hidden="true">
-      <component :is="icon" />
+      <component :is="icon" class="md-icon md-icon--md" />
     </div>
 
     <div class="callout__content">
@@ -209,19 +209,15 @@ function resolveVideoAccessibleName(block: RichVideo, index: number): string {
 }
 
 .callout__icon {
+  --callout-icon-size: var(--md-sys-spacing-10);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.75rem;
-  height: 2.75rem;
+  width: var(--callout-icon-size);
+  height: var(--callout-icon-size);
   border-radius: var(--md-sys-border-radius-full);
   background: color-mix(in srgb, var(--callout-accent) 14%, transparent);
   color: var(--callout-accent);
-}
-
-.callout__icon :deep(svg) {
-  width: 1.5rem;
-  height: 1.5rem;
 }
 
 .callout__content {
@@ -351,8 +347,7 @@ function resolveVideoAccessibleName(block: RichVideo, index: number): string {
   }
 
   .callout__icon {
-    width: 2.25rem;
-    height: 2.25rem;
+    --callout-icon-size: var(--md-sys-spacing-8);
   }
 }
 </style>

--- a/src/components/lesson/CardGrid.vue
+++ b/src/components/lesson/CardGrid.vue
@@ -13,9 +13,15 @@
       >
         <div v-if="card.badge" class="card-grid__badge">{{ card.badge }}</div>
 
-        <component v-if="card.iconComponent" :is="card.iconComponent" class="card-grid__icon" />
+        <span v-if="card.iconComponent" class="card-grid__icon" aria-hidden="true">
+          <component :is="card.iconComponent" class="md-icon md-icon--md" />
+        </span>
 
-        <div v-else-if="card.icon" class="card-grid__icon card-grid__icon--placeholder">
+        <div
+          v-else-if="card.icon"
+          class="card-grid__icon card-grid__icon--placeholder"
+          aria-hidden="true"
+        >
           {{ card.icon }}
         </div>
 
@@ -416,11 +422,12 @@ function sanitizeList(items?: unknown[]): string[] {
 }
 
 .card-grid__icon {
+  --card-grid-icon-size: var(--md-sys-spacing-10);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 3rem;
-  height: 3rem;
+  width: var(--card-grid-icon-size);
+  height: var(--card-grid-icon-size);
   border-radius: var(--md-sys-border-radius-full);
   background: color-mix(in srgb, currentColor 12%, transparent 88%);
   margin-bottom: var(--md-sys-spacing-3);
@@ -428,11 +435,6 @@ function sanitizeList(items?: unknown[]): string[] {
 
 .card-grid__icon--placeholder {
   font-weight: 600;
-  font-size: 1.2rem;
-}
-
-.card-grid__icon :deep(svg) {
-  width: 1.5rem;
-  height: 1.5rem;
+  font-size: var(--md-sys-typescale-title-large-size, 1.375rem);
 }
 </style>

--- a/src/components/lesson/ChecklistBlock.vue
+++ b/src/components/lesson/ChecklistBlock.vue
@@ -7,7 +7,7 @@
 
     <ul class="lesson-checklist__list" role="list">
       <li v-for="(item, index) in sanitizedItems" :key="index" class="lesson-checklist__item">
-        <CheckCircle class="lesson-checklist__icon" aria-hidden="true" />
+        <CheckCircle class="lesson-checklist__icon md-icon md-icon--md" aria-hidden="true" />
         <p class="lesson-checklist__text" v-html="item"></p>
       </li>
     </ul>
@@ -70,14 +70,8 @@ const sanitizedItems = computed(() => props.data.items.map((item) => sanitizeHtm
 }
 
 .lesson-checklist__icon {
-  width: 2rem;
-  height: 2rem;
   color: var(--md-sys-color-success);
-}
-
-.lesson-checklist__icon :deep(svg) {
-  width: 100%;
-  height: 100%;
+  flex-shrink: 0;
 }
 
 .lesson-checklist__text {

--- a/src/components/lesson/FlightPlan.vue
+++ b/src/components/lesson/FlightPlan.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="lesson-flight-plan">
-    <Rocket class="lesson-flight-plan__icon" aria-hidden="true" />
+    <Rocket class="lesson-flight-plan__icon md-icon md-icon--md" aria-hidden="true" />
 
     <div class="lesson-flight-plan__content">
       <h3 class="lesson-flight-plan__title">{{ data.title }}</h3>
@@ -41,14 +41,8 @@ const sanitizedItems = computed(() => props.data.items.map((item) => sanitizeHtm
 }
 
 .lesson-flight-plan__icon {
-  width: 3rem;
-  height: 3rem;
   color: var(--md-sys-color-primary);
-}
-
-.lesson-flight-plan__icon :deep(svg) {
-  width: 100%;
-  height: 100%;
+  flex-shrink: 0;
 }
 
 .lesson-flight-plan__content {
@@ -84,8 +78,7 @@ const sanitizedItems = computed(() => props.data.items.map((item) => sanitizeHtm
   }
 
   .lesson-flight-plan__icon {
-    width: 2.75rem;
-    height: 2.75rem;
+    align-self: start;
   }
 }
 </style>

--- a/src/components/lesson/LessonPlan.vue
+++ b/src/components/lesson/LessonPlan.vue
@@ -11,7 +11,9 @@
 
     <div v-if="cards.length" class="lesson-plan__grid">
       <article v-for="(card, index) in cards" :key="index" class="lesson-plan__card">
-        <component :is="card.iconComponent" class="lesson-plan__icon" aria-hidden="true" />
+        <span class="lesson-plan__icon" aria-hidden="true">
+          <component :is="card.iconComponent" class="md-icon md-icon--md" />
+        </span>
         <h4 class="lesson-plan__card-title">{{ card.title }}</h4>
         <p class="lesson-plan__card-content" v-html="card.content"></p>
       </article>
@@ -207,19 +209,15 @@ function createNameVariations(original: string): string[] {
 }
 
 .lesson-plan__icon {
-  width: 3rem;
-  height: 3rem;
+  --lesson-plan-icon-size: var(--md-sys-spacing-10);
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: var(--lesson-plan-icon-size);
+  height: var(--lesson-plan-icon-size);
   border-radius: var(--md-sys-border-radius-full);
   background: color-mix(in srgb, var(--md-sys-color-primary) 16%, transparent);
   color: var(--md-sys-color-primary);
-}
-
-.lesson-plan__icon :deep(svg) {
-  width: 1.5rem;
-  height: 1.5rem;
 }
 
 .lesson-plan__card-title {


### PR DESCRIPTION
## Summary
- align Callout, FlightPlan, LessonPlan, CardGrid, AudioBlock, and ChecklistBlock icons with the shared md-icon utility classes and MD3 spacing tokens
- replace hard-coded 2–3rem icon containers with token-based sizing so lesson cards use consistent icon dimensions
- smoke-test lesson and exercise renders in the Vite preview to confirm the tighter icons stay centered without clipping

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da6427d6f8832c9ae1a8ca628abfc3