### PR TITLE
Atualiza referências das avaliações NP2 e NP3 de TGS

### DIFF
--- a/reports/content-validation-report.json
+++ b/reports/content-validation-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-29T01:32:41.398Z",
+  "generatedAt": "2025-09-29T13:02:50.174Z",
   "status": "passed",
   "totals": {
     "courses": 5,

--- a/src/content/courses/tgs/lessons.json
+++ b/src/content/courses/tgs/lessons.json
@@ -146,9 +146,9 @@
       "formatVersion": "md3.lesson.v1"
     },
     {
-      "id": "lesson-14",
+      "id": "lesson-28",
       "title": "Aula 28: Avaliação – NP2",
-      "file": "lesson-14.json",
+      "file": "lesson-28.json",
       "available": true,
       "description": "Aplica avaliação NP2 integrando sistemas abertos, fluxos e homeostase em estudos de caso.",
       "summary": "Avaliação NP2 voltada à síntese de sistemas abertos, fluxos e homeostase, articulando teoria e estudos de caso.",
@@ -157,9 +157,9 @@
       "formatVersion": "md3.lesson.v1"
     },
     {
-      "id": "lesson-15",
+      "id": "lesson-40",
       "title": "Aula 40: Avaliação Final – NP3",
-      "file": "lesson-15.json",
+      "file": "lesson-40.json",
       "available": true,
       "description": "Conduz avaliação final integradora cobrindo todos os temas da disciplina.",
       "summary": "Avaliação final NP3 integrando todos os conteúdos da disciplina, com foco na aplicação crítica da Teoria Geral dos Sistemas.",

--- a/src/content/courses/tgs/lessons/lesson-28.json
+++ b/src/content/courses/tgs/lessons/lesson-28.json
@@ -1,5 +1,5 @@
 {
-  "id": "lesson-14",
+  "id": "lesson-28",
   "title": "Aula 28: Avaliação – NP2",
   "objective": "Mensurar a capacidade de aplicar pensamento sistêmico na análise de organizações complexas.",
   "content": [

--- a/src/content/courses/tgs/lessons/lesson-28.vue
+++ b/src/content/courses/tgs/lessons/lesson-28.vue
@@ -1,14 +1,14 @@
 <script lang="ts">
 export const meta = {
-  id: 'lesson-15',
-  title: 'Aula 40: Avaliação Final – NP3',
+  id: 'lesson-28',
+  title: 'Aula 28: Avaliação – NP2',
   available: true,
 };
 </script>
 
 <script setup lang="ts">
 import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
-import lessonData from './lesson-15.json';
+import lessonData from './lesson-28.json';
 </script>
 
 <template>

--- a/src/content/courses/tgs/lessons/lesson-40.json
+++ b/src/content/courses/tgs/lessons/lesson-40.json
@@ -1,5 +1,5 @@
 {
-  "id": "lesson-15",
+  "id": "lesson-40",
   "title": "Aula 40: Avaliação Final – NP3",
   "objective": "Verificar a capacidade de síntese e aplicação dos conceitos sistêmicos em cenários complexos.",
   "content": [

--- a/src/content/courses/tgs/lessons/lesson-40.vue
+++ b/src/content/courses/tgs/lessons/lesson-40.vue
@@ -1,14 +1,14 @@
 <script lang="ts">
 export const meta = {
-  id: 'lesson-14',
-  title: 'Aula 28: Avaliação – NP2',
+  id: 'lesson-40',
+  title: 'Aula 40: Avaliação Final – NP3',
   available: true,
 };
 </script>
 
 <script setup lang="ts">
 import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
-import lessonData from './lesson-14.json';
+import lessonData from './lesson-40.json';
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- renomeia os arquivos de conteúdo e wrappers das avaliações para `lesson-28` e `lesson-40`
- atualiza o manifesto de lições do curso TGS para apontar para os novos identificadores
- mantém o relatório de validação de conteúdo sincronizado com a última execução

## Testing
- `npm run validate:content`


------
https://chatgpt.com/codex/tasks/task_e_68da83239bc8832cac8c26140d116ceb