### PR TITLE
Add TGS lessons 14-18 content

### DIFF
--- a/src/content/courses/tgs/lessons.json
+++ b/src/content/courses/tgs/lessons.json
@@ -146,6 +146,61 @@
       "formatVersion": "md3.lesson.v1"
     },
     {
+      "id": "lesson-14",
+      "title": "Aula 14: Correção e Feedback da NP1",
+      "file": "lesson-14.json",
+      "available": true,
+      "description": "Promove devolutiva estruturada da NP1 com discussão coletiva dos resultados.",
+      "summary": "Realiza devolutiva colaborativa da NP1, destacando melhorias e planos de reforço.",
+      "tags": ["aula-14-np1"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-15",
+      "title": "Aula 15: Tipos de Sistemas Empresariais",
+      "file": "lesson-15.json",
+      "available": true,
+      "description": "Examina categorias de sistemas empresariais e seus usos em áreas corporativas distintas.",
+      "summary": "Analisa categorias de sistemas empresariais e critérios para selecionar soluções alinhadas ao negócio.",
+      "tags": ["aula-15-sistemas-empresariais"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-16",
+      "title": "Aula 16: Integração de Sistemas Empresariais",
+      "file": "lesson-16.json",
+      "available": true,
+      "description": "Apresenta modelos e tecnologias para conectar sistemas empresariais e garantir fluxo contínuo de informações.",
+      "summary": "Investiga estratégias de integração e governança para manter interoperabilidade entre sistemas empresariais.",
+      "tags": ["aula-16-integracao"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-17",
+      "title": "Aula 17: Business Intelligence e Dashboards",
+      "file": "lesson-17.json",
+      "available": true,
+      "description": "Debate aplicações de BI e demonstra dashboards que transformam dados em insights acionáveis.",
+      "summary": "Explora práticas de BI e dashboards para transformar dados em decisões acionáveis.",
+      "tags": ["aula-17-bi"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-18",
+      "title": "Aula 18: CRM e Relacionamento com Clientes",
+      "file": "lesson-18.json",
+      "available": true,
+      "description": "Apresenta conceitos de CRM e discute casos sobre fidelização e personalização de experiências.",
+      "summary": "Discute estratégias de CRM e fidelização integrando jornada do cliente e automação.",
+      "tags": ["aula-18-crm"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
       "id": "lesson-28",
       "title": "Aula 28: Avaliação – NP2",
       "file": "lesson-28.json",
@@ -167,5 +222,29 @@
       "duration": 110,
       "formatVersion": "md3.lesson.v1"
     }
-  ]
+  ],
+  "metadata": {
+    "metadata": {
+      "metadata": {
+        "metadata": {
+          "metadata": {},
+          "filePath": "/workspace/edu/src/content/courses/tgs/lessons.json",
+          "legacy": false,
+          "missing": false
+        },
+        "filePath": "/workspace/edu/src/content/courses/tgs/lessons.json",
+        "legacy": false,
+        "missing": false
+      },
+      "filePath": "/workspace/edu/src/content/courses/tgs/lessons.json",
+      "legacy": false,
+      "missing": false
+    },
+    "filePath": "/workspace/edu/src/content/courses/tgs/lessons.json",
+    "legacy": false,
+    "missing": false
+  },
+  "filePath": "/workspace/edu/src/content/courses/tgs/lessons.json",
+  "legacy": false,
+  "missing": false
 }

--- a/src/content/courses/tgs/lessons/lesson-14.json
+++ b/src/content/courses/tgs/lessons/lesson-14.json
@@ -1,0 +1,178 @@
+{
+  "id": "lesson-14",
+  "title": "Aula 14: Correção e Feedback da NP1",
+  "objective": "Revisar a avaliação NP1, consolidar aprendizados e orientar próximos passos.",
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Plano da Aula",
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "CONTEÚDO",
+          "content": "Panorama geral do desempenho na NP1, análise coletiva de itens-chave e planejamento de reforço."
+        },
+        {
+          "icon": "bullseye",
+          "title": "OBJETIVOS",
+          "content": "- Entender critérios de correção e oportunidades de melhoria.\n- Comparar abordagens adotadas pelas equipes.\n- Definir planos individuais de estudo para a próxima etapa."
+        },
+        {
+          "icon": "users",
+          "title": "METODOLOGIA",
+          "content": "Devolutiva dialogada, estudo de caso com respostas-modelo, debate orientado e demonstração de boas práticas de resolução."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Como conduziremos a devolutiva",
+      "steps": [
+        {
+          "title": "Aquecimento",
+          "content": "Apresentação dos indicadores gerais (média, dispersão, questões mais desafiadoras) e combinados para a conversa."
+        },
+        {
+          "title": "Estudo de Caso: Questão 2",
+          "content": "Releitura coletiva do enunciado e comparação entre uma resposta incompleta e outra exemplar, destacando critérios de pontuação."
+        },
+        {
+          "title": "Demonstração guiada",
+          "content": "O docente reconstrói, passo a passo, a estratégia de resolução para um item que gerou maior índice de erro."
+        },
+        {
+          "title": "Debate em duplas",
+          "content": "Duplas discutem decisões adotadas na prova e registram aprendizados em um canvas de melhorias."
+        },
+        {
+          "title": "Planejamento",
+          "content": "Cada estudante elabora um plano de reforço com foco nas competências que precisam ser consolidadas para as próximas avaliações."
+        }
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Indicadores para observar",
+      "cards": [
+        {
+          "title": "Acertos conceituais",
+          "content": "Identifique quais conceitos de TGS foram utilizados corretamente e quais precisam de revisão."
+        },
+        {
+          "title": "Argumentação",
+          "content": "Avalie se a resposta explicita conexões sistêmicas (entradas, processos, feedbacks) de forma lógica."
+        },
+        {
+          "title": "Gestão do tempo",
+          "content": "Reflita sobre como distribuiu o tempo entre questões e quais estratégias podem otimizar a próxima prova."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Debate orientado",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Forme um círculo rápido com colegas que atingiram resultados distintos. Cada pessoa compartilha uma decisão acertada e um ponto a melhorar na prova."
+        },
+        {
+          "type": "paragraph",
+          "text": "Use perguntas disparadoras: Qual conceito você aplicaria diferente? Como garantir que os exemplos contemplem a visão sistêmica completa?"
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "good-practice",
+      "title": "Checklist rápido pós-NP1",
+      "content": [
+        {
+          "type": "list",
+          "ordered": false,
+          "items": [
+            "Atualizei meus resumos com os pontos sinalizados na correção?",
+            "Organizei dúvidas para levar ao plantão ou fórum?",
+            "Combinei com o grupo como aplicar o feedback no projeto integrador?"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "checklist",
+      "title": "Plano individual",
+      "items": [
+        "Registrar três prioridades de estudo para as próximas semanas.",
+        "Identificar materiais de apoio disponíveis no AVA.",
+        "Agendar momento de revisão conjunta com colegas."
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Publique no AVA, até às 23h59 de hoje, um registro reflexivo com: (1) o principal aprendizado da devolutiva, (2) um compromisso de melhoria e (3) o material que pretende consultar para reforço. Anexe o canvas de melhorias preenchido pela dupla."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-14-correcao-e-feedback-da-np1",
+  "summary": "Realiza a devolutiva estruturada da NP1, promovendo reflexão crítica e planejamento de reforço com base nos critérios de correção.",
+  "objectives": [
+    "Compreender a distribuição de desempenho e os critérios usados na correção da NP1.",
+    "Comparar respostas reais e identificar boas práticas de argumentação sistêmica.",
+    "Planejar ações de reforço alinhadas às competências da disciplina."
+  ],
+  "competencies": [
+    "Pensamento sistêmico aplicado",
+    "Autoavaliação acadêmica",
+    "Planejamento de aprendizagem"
+  ],
+  "skills": [
+    "Interpretar feedbacks qualitativos e quantitativos.",
+    "Argumentar com base em evidências coletivas.",
+    "Definir metas de estudo coerentes com lacunas identificadas."
+  ],
+  "outcomes": [
+    "Atualiza o portfólio com reflexões sobre a NP1.",
+    "Ajusta estratégias individuais de estudo e participação.",
+    "Integra o feedback ao projeto integrador da turma."
+  ],
+  "prerequisites": [
+    "Trazer a prova NP1 corrigida.",
+    "Revisar as anotações pessoais feitas durante a avaliação."
+  ],
+  "tags": ["aula-14-np1"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Relatório analítico da NP1",
+      "url": "https://example.edu/tgs/np1/relatorio",
+      "type": "report"
+    },
+    {
+      "label": "Canvas de melhorias",
+      "url": "https://example.edu/tgs/modelos/canvas-melhorias",
+      "type": "template"
+    }
+  ],
+  "bibliography": [
+    "BERTALANFFY, L. Teoria Geral dos Sistemas. Vozes, 2015.",
+    "SENGE, P. A Quinta Disciplina. Best Seller, 2020."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Registro reflexivo e plano de ação publicados no AVA."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-02-10T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-14.vue
+++ b/src/content/courses/tgs/lessons/lesson-14.vue
@@ -1,0 +1,17 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-14',
+  title: 'Aula 14: Correção e Feedback da NP1',
+  objective: 'Revisar a avaliação NP1, consolidar aprendizados e orientar próximos passos.',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-14.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-15.json
+++ b/src/content/courses/tgs/lessons/lesson-15.json
@@ -1,0 +1,208 @@
+{
+  "id": "lesson-15",
+  "title": "Aula 15: Tipos de Sistemas Empresariais",
+  "objective": "Analisar classificações de sistemas empresariais e relacioná-las a necessidades organizacionais.",
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Plano da Aula",
+      "cards": [
+        {
+          "icon": "book-open",
+          "title": "CONTEÚDOS",
+          "content": "Panorama dos principais sistemas empresariais (ERP, CRM, SCM, BPM, BI) e critérios de seleção."
+        },
+        {
+          "icon": "bullseye",
+          "title": "OBJETIVOS",
+          "content": "- Diferenciar categorias de sistemas empresariais.\n- Avaliar aderência de soluções a cenários reais.\n- Mapear impactos sistêmicos de cada escolha."
+        },
+        {
+          "icon": "users",
+          "title": "METODOLOGIA",
+          "content": "Estudo de caso em squads, debate socrático e demonstração guiada de catálogo de soluções."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Por que existem tantos sistemas empresariais?",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Cada sistema nasce para resolver uma dor específica do negócio. Quando avaliamos pela ótica sistêmica, enxergamos dependências, integrações e trade-offs que vão além do software isolado."
+        },
+        {
+          "type": "callout",
+          "variant": "info",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "Pergunta norteadora: quais fluxos de informação o sistema precisa orquestrar para gerar valor perceptível?"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Panorama dos sistemas empresariais",
+      "headers": ["Categoria", "Objetivo principal", "Indicadores afetados", "Exemplo"],
+      "rows": [
+        [
+          "ERP",
+          "Integrar processos centrais (finanças, estoque, RH)",
+          "OTIF, custo operacional, conformidade",
+          "TOTVS Protheus"
+        ],
+        [
+          "CRM",
+          "Gerenciar relacionamento, pipeline e pós-venda",
+          "CAC, NPS, taxa de conversão",
+          "Salesforce"
+        ],
+        [
+          "SCM",
+          "Otimizar cadeia de suprimentos e logística",
+          "Lead time, nível de estoque, fill rate",
+          "SAP SCM"
+        ],
+        [
+          "BPM/Workflow",
+          "Orquestrar processos e garantir conformidade",
+          "Tempo de ciclo, retrabalho, SLA",
+          "Pipefy"
+        ],
+        [
+          "BI/Analytics",
+          "Transformar dados em insights acionáveis",
+          "Tempo de decisão, assertividade, ROI de campanhas",
+          "Power BI"
+        ]
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Estudo de caso em squads",
+      "cards": [
+        {
+          "title": "Retail Mix",
+          "content": "Rede varejista com gargalos de estoque e visão fragmentada de clientes. Qual combinação de sistemas atende melhor?"
+        },
+        {
+          "title": "HealthConnect",
+          "content": "Clínica que precisa integrar prontuários, agenda médica e faturamento, mantendo compliance LGPD."
+        },
+        {
+          "title": "Indústria 4.0",
+          "content": "Fábrica que adota sensores IoT e precisa sincronizar produção, manutenção e cadeia logística."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Debate socrático",
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "title": "Critérios de aderência",
+              "text": "Quais dimensões (processos, pessoas, dados, tecnologia) pesaram na escolha do sistema?"
+            },
+            {
+              "title": "Riscos sistêmicos",
+              "text": "Que efeitos colaterais podem emergir em outros subsistemas da organização?"
+            },
+            {
+              "title": "Governança",
+              "text": "Como garantir atualização, suporte e evolução contínua do sistema selecionado?"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "good-practice",
+      "title": "Demonstração guiada",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "A turma acompanha, em tempo real, a navegação por um catálogo de soluções SaaS. Observe como filtros por segmento, porte e integrações ajudam a estreitar opções."
+        },
+        {
+          "type": "paragraph",
+          "text": "Anote integrações essenciais e requisitos técnicos que surgirem durante a demonstração para alimentar o estudo de caso."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Poste no AVA, até às 22h de amanhã, a análise do seu squad com: (1) sistema(s) recomendados, (2) justificativa sistêmica e (3) integrações prioritárias. Inclua uma evidência (print ou link) da ferramenta utilizada na demonstração."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-15-tipos-de-sistemas-empresariais",
+  "summary": "Compara categorias de sistemas empresariais, relacionando critérios de escolha a casos reais e integrações necessárias.",
+  "objectives": [
+    "Diferenciar sistemas empresariais por propósito e escopo.",
+    "Relacionar necessidades organizacionais a soluções tecnológicas específicas.",
+    "Identificar critérios de governança e integração para adoção de sistemas."
+  ],
+  "competencies": [
+    "Análise sistêmica de processos",
+    "Tomada de decisão baseada em dados",
+    "Colaboração interdisciplinar"
+  ],
+  "skills": [
+    "Mapear requisitos de negócio e traduzi-los em capacidades de sistemas.",
+    "Argumentar escolhas tecnológicas considerando impactos organizacionais.",
+    "Utilizar catálogos e matrizes comparativas como suporte à decisão."
+  ],
+  "outcomes": [
+    "Entrega estudo de caso justificando sistemas selecionados.",
+    "Documenta riscos e integrações essenciais.",
+    "Compartilha aprendizados coletivos no AVA."
+  ],
+  "prerequisites": [
+    "Revisar conceitos das aulas 9 a 12 sobre níveis de SI.",
+    "Trazer notas da NP1 para conectar lacunas a novos conteúdos."
+  ],
+  "tags": ["aula-15-sistemas-empresariais"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Catálogo Gartner de aplicações empresariais",
+      "url": "https://example.edu/tgs/recursos/catalogo-sistemas",
+      "type": "guide"
+    },
+    {
+      "label": "Ficha de estudo de caso",
+      "url": "https://example.edu/tgs/modelos/ficha-case",
+      "type": "template"
+    }
+  ],
+  "bibliography": [
+    "LAUDON, Kenneth; LAUDON, Jane. Sistemas de Informação Gerenciais. Pearson, 2024.",
+    "TURBAN, Efraim et al. Tecnologia da Informação para Gestão. Bookman, 2023."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Análise do estudo de caso registrada e debatida no AVA."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-02-10T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-15.vue
+++ b/src/content/courses/tgs/lessons/lesson-15.vue
@@ -1,0 +1,18 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-15',
+  title: 'Aula 15: Tipos de Sistemas Empresariais',
+  objective:
+    'Analisar classificações de sistemas empresariais e relacioná-las a necessidades organizacionais.',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-15.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-16.json
+++ b/src/content/courses/tgs/lessons/lesson-16.json
@@ -1,0 +1,205 @@
+{
+  "id": "lesson-16",
+  "title": "Aula 16: Integração de Sistemas Empresariais",
+  "objective": "Discutir estratégias de integração e interoperabilidade entre sistemas empresariais.",
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Plano da Aula",
+      "cards": [
+        {
+          "icon": "gears",
+          "title": "CONTEÚDO",
+          "content": "Arquiteturas de integração, padrões (ETL, APIs, eventos) e governança de dados."
+        },
+        {
+          "icon": "bullseye",
+          "title": "OBJETIVOS",
+          "content": "- Compreender desafios de interoperabilidade.\n- Avaliar modelos de integração adequados a diferentes cenários.\n- Planejar ações de governança e monitoramento."
+        },
+        {
+          "icon": "users",
+          "title": "METODOLOGIA",
+          "content": "Demonstração técnica guiada, estudo de caso crítico e debate estruturado sobre impactos organizacionais."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Jornada de integração",
+      "steps": [
+        {
+          "title": "Diagnóstico",
+          "content": "Mapear fluxos de dados, sistemas origem e destino, bem como requisitos de tempo real vs. batelada."
+        },
+        {
+          "title": "Desenho",
+          "content": "Selecionar padrões (API, mensageria, ETL, iPaaS) considerando acoplamento e governança."
+        },
+        {
+          "title": "Implementação",
+          "content": "Configurar conectores, orquestrar transformações e validar qualidade dos dados."
+        },
+        {
+          "title": "Monitoramento",
+          "content": "Estabelecer observabilidade, SLAs e mecanismos de reação a falhas."
+        },
+        {
+          "title": "Evolução",
+          "content": "Revisar arquitetura periodicamente frente a novas demandas ou sistemas adicionados."
+        }
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Padrões de integração",
+      "cards": [
+        {
+          "title": "API REST",
+          "content": "Integração síncrona e padronizada. Ideal para necessidades em tempo quase real com baixo volume."
+        },
+        {
+          "title": "Event Streaming",
+          "content": "Publicação/assinatura para eventos de negócio (Kafka, Pulsar). Suporta escalabilidade e desacoplamento."
+        },
+        {
+          "title": "ETL/ELT",
+          "content": "Bateladas para consolidar dados em data warehouses e lakes. Útil para BI e compliance."
+        },
+        {
+          "title": "ESB/iPaaS",
+          "content": "Plataformas que orquestram integrações complexas, tratam protocolos heterogêneos e monitoram fluxos."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Estudo de caso crítico",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Uma rede hospitalar precisa sincronizar prontuários, faturamento e logística farmacêutica. Quais riscos surgem com integrações ponto a ponto?"
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "items": [
+            "Inconsistência de dados entre sistemas clínicos e financeiros.",
+            "Dificuldade de rastrear falhas ou mensagens perdidas.",
+            "Aumento de custo de manutenção quando novos sistemas entram em operação."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "good-practice",
+      "title": "Demonstração hands-on",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "O docente demonstra, em uma plataforma iPaaS, como construir um fluxo que integra ERP → CRM → BI usando conectores, transformações e validações. Observe logs, métricas e alertas configurados."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Debate estruturado",
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "title": "Governança",
+              "text": "Como definir proprietários de dados e responsabilidades por integrações?"
+            },
+            {
+              "title": "Segurança",
+              "text": "Que controles (criptografia, máscaras, RBAC) são essenciais em fluxos sensíveis?"
+            },
+            {
+              "title": "Escalabilidade",
+              "text": "O que muda quando eventos em tempo real passam a representar 80% do tráfego?"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "checklist",
+      "title": "Diagnóstico relâmpago",
+      "items": [
+        "Identificar três integrações críticas da organização estudada.",
+        "Avaliar riscos de indisponibilidade e redundância de dados.",
+        "Elencar indicadores para acompanhar saúde das integrações."
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Registre no AVA, até às 23h de amanhã, um diagnóstico das integrações do estudo de caso: (1) mapa do fluxo atual, (2) proposta de melhoria com justificativa e (3) métricas para monitoramento. Anexe o checklist preenchido em sala."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-16-integracao-de-sistemas-empresariais",
+  "summary": "Explora padrões de integração, desafios de governança e estratégias para garantir interoperabilidade sustentável entre sistemas empresariais.",
+  "objectives": [
+    "Reconhecer padrões e tecnologias de integração aplicáveis a diferentes cenários.",
+    "Avaliar riscos e impactos organizacionais decorrentes de integrações mal planejadas.",
+    "Propor ações de governança e monitoramento para fluxos críticos de dados."
+  ],
+  "competencies": [
+    "Arquitetura de sistemas",
+    "Gestão de dados e integrações",
+    "Resolução colaborativa de problemas"
+  ],
+  "skills": [
+    "Mapear fluxos sistêmicos de dados.",
+    "Selecionar padrões de integração alinhados a requisitos de negócio.",
+    "Definir indicadores para monitorar integrações em produção."
+  ],
+  "outcomes": [
+    "Apresenta diagnóstico e plano de integração para o estudo de caso.",
+    "Documenta riscos e controles de governança.",
+    "Compartilha evidências no AVA seguindo o roteiro proposto."
+  ],
+  "prerequisites": [
+    "Revisar taxonomias de sistemas estudadas na aula 15.",
+    "Trazer o mapa de processos elaborado na aula 12."
+  ],
+  "tags": ["aula-16-integracao"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Guia rápido de padrões de integração",
+      "url": "https://example.edu/tgs/guias/padroes-integracao",
+      "type": "guide"
+    },
+    {
+      "label": "Acesso demo iPaaS",
+      "url": "https://example.edu/tgs/demo/ipaas",
+      "type": "tool"
+    }
+  ],
+  "bibliography": [
+    "HOHPE, Gregor; WOOLF, Bobby. Enterprise Integration Patterns. Addison-Wesley, 2012.",
+    "KREPS, Jay. I Love Logs: Data Lakes, Event Streams, and the Rise of Real-Time. O'Reilly, 2022."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Entrega de diagnóstico de integração e plano de monitoramento no AVA."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-02-10T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-16.vue
+++ b/src/content/courses/tgs/lessons/lesson-16.vue
@@ -1,0 +1,17 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-16',
+  title: 'Aula 16: Integração de Sistemas Empresariais',
+  objective: 'Discutir estratégias de integração e interoperabilidade entre sistemas empresariais.',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-16.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-17.json
+++ b/src/content/courses/tgs/lessons/lesson-17.json
@@ -1,0 +1,201 @@
+{
+  "id": "lesson-17",
+  "title": "Aula 17: Business Intelligence e Dashboards",
+  "objective": "Explorar conceitos de BI e avaliar dashboards como apoio à decisão.",
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Plano da Aula",
+      "cards": [
+        {
+          "icon": "monitor",
+          "title": "CONTEÚDO",
+          "content": "Cadeia de BI, storytelling com dados e avaliação crítica de dashboards."
+        },
+        {
+          "icon": "target",
+          "title": "OBJETIVOS",
+          "content": "- Diferenciar componentes do ecossistema de BI.\n- Identificar boas práticas de visualização.\n- Interpretar indicadores para tomada de decisão."
+        },
+        {
+          "icon": "desktop",
+          "title": "METODOLOGIA",
+          "content": "Demonstração guiada em ferramenta BI, estudo de caso comparativo e debate orientado sobre decisões suportadas pelos dashboards."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Do dado ao insight",
+      "steps": [
+        {
+          "title": "Coleta",
+          "content": "Identificar fontes confiáveis e garantir governança dos dados que alimentarão o dashboard."
+        },
+        {
+          "title": "Transformação",
+          "content": "Modelar tabelas, calcular indicadores e tratar exceções."
+        },
+        {
+          "title": "Visualização",
+          "content": "Escolher gráficos adequados, destacar alertas e construir narrativas."
+        },
+        {
+          "title": "Ação",
+          "content": "Definir planos de ação com base nas variações observadas e monitorar impactos."
+        }
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Checklist de design de dashboard",
+      "cards": [
+        {
+          "title": "Propósito",
+          "content": "O painel responde a perguntas de negócio específicas?"
+        },
+        {
+          "title": "Contexto",
+          "content": "Existem benchmarks, metas e filtros claros para leitura?"
+        },
+        {
+          "title": "Interação",
+          "content": "O usuário pode explorar detalhes sem perder a visão geral?"
+        },
+        {
+          "title": "Acessibilidade",
+          "content": "Cores, tipografia e legendas atendem pessoas com diferentes necessidades?"
+        }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Demonstração guiada",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/bi-demo",
+          "title": "Construindo um dashboard em 10 minutos",
+          "caption": "Trecho gravado pela docente mostrando conexão de dados, criação de KPIs e publicação segura."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Estudo de caso comparativo",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Compare dois dashboards: um de vendas regionais e outro de suporte ao cliente. Em grupos, identifiquem quais decisões cada painel facilita e quais dados adicionais seriam necessários."
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "items": [
+            "Quais KPIs aparecem e o que eles significam?",
+            "O layout direciona a atenção corretamente?",
+            "Há alertas para desvios críticos?"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Debate orientado",
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "title": "Confiança nos dados",
+              "text": "Como garantir que decisões não sejam tomadas com dados desatualizados ou enviesados?"
+            },
+            {
+              "title": "Ação versus observação",
+              "text": "Quando um dashboard deve disparar processos automáticos e quando apenas informar gestores?"
+            },
+            {
+              "title": "Mensuração de impacto",
+              "text": "Como avaliar se o dashboard realmente mudou o comportamento da equipe?"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "good-practice",
+      "title": "Boas práticas destacadas",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Registre os princípios de design que emergirem da demonstração: hierarquia visual, contextualização, storytelling e atualização contínua."
+        }
+      ]
+    },
+    {
+      "type": "checklist",
+      "title": "TED",
+      "items": [
+        "Publicar no AVA, até às 21h de amanhã, uma captura do dashboard analisado.",
+        "Descrever duas decisões que podem ser tomadas a partir dele.",
+        "Apontar um indicador adicional ou ajuste visual que aumentaria o valor do painel."
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-17-business-intelligence-e-dashboards",
+  "summary": "Discute fundamentos de BI, avalia dashboards reais e orienta o uso de indicadores para decisões baseadas em dados.",
+  "objectives": [
+    "Compreender o ciclo de BI da coleta ao insight.",
+    "Analisar dashboards com critérios de design e negócio.",
+    "Planejar ações baseadas em indicadores chave."
+  ],
+  "competencies": [
+    "Pensamento analítico",
+    "Comunicação baseada em dados",
+    "Tomada de decisão orientada a evidências"
+  ],
+  "skills": [
+    "Interpretar KPIs e relacioná-los a objetivos estratégicos.",
+    "Identificar melhorias em dashboards existentes.",
+    "Produzir narrativas visuais claras para stakeholders."
+  ],
+  "outcomes": [
+    "Registra análise crítica de dashboard no AVA.",
+    "Propõe ajustes que elevam maturidade de BI da organização.",
+    "Aplica boas práticas de storytelling com dados em projetos acadêmicos."
+  ],
+  "prerequisites": [
+    "Revisar conceitos de integração da aula 16.",
+    "Explorar previamente o dataset disponibilizado no AVA."
+  ],
+  "tags": ["aula-17-bi"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Dataset de vendas trimestrais",
+      "url": "https://example.edu/tgs/datasets/vendas-trimestre",
+      "type": "dataset"
+    },
+    {
+      "label": "Guia rápido de visualização",
+      "url": "https://example.edu/tgs/guias/design-dashboard",
+      "type": "guide"
+    }
+  ],
+  "bibliography": [
+    "FEW, Stephen. Information Dashboard Design. Analytics Press, 2013.",
+    "KNAFLIC, Cole Nussbaumer. Storytelling com Dados. Alta Books, 2021."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Checklist de análise de dashboard entregue no AVA."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-02-10T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-17.vue
+++ b/src/content/courses/tgs/lessons/lesson-17.vue
@@ -1,0 +1,17 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-17',
+  title: 'Aula 17: Business Intelligence e Dashboards',
+  objective: 'Explorar conceitos de BI e avaliar dashboards como apoio à decisão.',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-17.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-18.json
+++ b/src/content/courses/tgs/lessons/lesson-18.json
@@ -1,0 +1,219 @@
+{
+  "id": "lesson-18",
+  "title": "Aula 18: CRM e Relacionamento com Clientes",
+  "objective": "Analisar estratégias de CRM para fortalecer o relacionamento com clientes.",
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Plano da Aula",
+      "cards": [
+        {
+          "icon": "book-open",
+          "title": "CONTEÚDOS",
+          "content": "Conceitos de CRM, jornada do cliente, automação de marketing e indicadores de fidelização."
+        },
+        {
+          "icon": "bullseye",
+          "title": "OBJETIVOS",
+          "content": "- Mapear etapas do relacionamento com clientes.\n- Avaliar funcionalidades essenciais de plataformas CRM.\n- Conectar dados de CRM a estratégias de fidelização."
+        },
+        {
+          "icon": "users",
+          "title": "METODOLOGIA",
+          "content": "Estudo de caso, demonstração prática e debate orientado sobre dilemas éticos e estratégicos."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Jornada do cliente e pontos de contato",
+      "steps": [
+        {
+          "title": "Aquisição",
+          "content": "Leads chegam via campanhas digitais. Como o CRM captura a origem e segmenta automaticamente?"
+        },
+        {
+          "title": "Conversão",
+          "content": "Equipe comercial acompanha pipeline, define tarefas e nutre oportunidades com conteúdos personalizados."
+        },
+        {
+          "title": "Entrega",
+          "content": "Integração com ERP garante emissão de pedidos, faturamento e onboarding consistente."
+        },
+        {
+          "title": "Retenção",
+          "content": "Dashboards de NPS, tickets e churn alimentam squads de sucesso do cliente."
+        },
+        {
+          "title": "Evangelização",
+          "content": "Programas de indicação e comunidades fortalecem advocacy e feedback contínuo."
+        }
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Componentes essenciais de um CRM",
+      "cards": [
+        {
+          "title": "360º do cliente",
+          "content": "Histórico consolidado de interações, compras, tickets e preferências."
+        },
+        {
+          "title": "Automação",
+          "content": "Fluxos de e-mail, scoring de leads, campanhas omnichannel com base em gatilhos."
+        },
+        {
+          "title": "Inteligência",
+          "content": "Dashboards de funil, previsão de vendas e análises de churn."
+        },
+        {
+          "title": "Integrações",
+          "content": "Conexões com ERP, plataformas de marketing, centrais de atendimento e ferramentas de BI."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Estudo de caso: Startup SaaS",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Uma startup cresce 20% ao mês, mas enfrenta churn alto após 90 dias. Analise como o CRM pode apoiar ações de sucesso do cliente."
+        },
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "title": "Dados necessários",
+              "text": "Que informações devem ser monitoradas para identificar sinais de abandono?"
+            },
+            {
+              "title": "Fluxos automáticos",
+              "text": "Quais gatilhos podem gerar contatos proativos da equipe de sucesso?"
+            },
+            {
+              "title": "Debate",
+              "text": "Quando insistir em retenção pode ser invasivo ou antiético?"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "good-practice",
+      "title": "Demonstração prática",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "A docente percorre um pipeline em uma ferramenta CRM (ex.: RD Station), mostrando criação de persona, configuração de gatilhos e painel de NPS. Registre telas que evidenciem métricas críticas."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Debate orientado",
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "title": "Privacidade",
+              "text": "Como equilibrar personalização e respeito à LGPD?"
+            },
+            {
+              "title": "Cultura",
+              "text": "Como engajar equipe de vendas e pós-venda no uso do CRM?"
+            },
+            {
+              "title": "Valor",
+              "text": "Quais métricas comprovam o ROI de iniciativas de fidelização?"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Indicadores para monitorar",
+      "content": [
+        {
+          "type": "list",
+          "ordered": false,
+          "items": [
+            "Taxa de conversão por etapa do funil.",
+            "Tempo médio de resposta (SLA).",
+            "Net Promoter Score (NPS).",
+            "Customer Lifetime Value (CLV)."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "checklist",
+      "title": "TED",
+      "items": [
+        "Registrar no AVA, até às 22h de amanhã, um plano de ação de CRM com três iniciativas priorizadas.",
+        "Anexar evidências da demonstração (print ou descrição) que embasam as escolhas.",
+        "Indicar como cada iniciativa será medida (indicador, meta e frequência)."
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-18-crm-e-relacionamento-com-clientes",
+  "summary": "Explora conceitos e práticas de CRM, conectando jornada do cliente, automação e indicadores de fidelização a decisões estratégicas.",
+  "objectives": [
+    "Mapear jornada do cliente e relacioná-la a funcionalidades de CRM.",
+    "Avaliar impactos éticos e estratégicos de ações de relacionamento.",
+    "Planejar iniciativas de fidelização baseadas em dados."
+  ],
+  "competencies": [
+    "Gestão de relacionamento",
+    "Comunicação orientada ao cliente",
+    "Uso estratégico de dados"
+  ],
+  "skills": [
+    "Configurar fluxos básicos em plataformas CRM.",
+    "Interpretar indicadores de fidelização e satisfação.",
+    "Elaborar planos de ação alinhados à jornada do cliente."
+  ],
+  "outcomes": [
+    "Entrega plano de ação de CRM contextualizado ao estudo de caso.",
+    "Relaciona métricas a objetivos de retenção.",
+    "Compartilha reflexões éticas no AVA."
+  ],
+  "prerequisites": [
+    "Revisar análise de dashboards da aula 17.",
+    "Ler o material introdutório de CRM disponibilizado no AVA."
+  ],
+  "tags": ["aula-18-crm"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Template de plano de fidelização",
+      "url": "https://example.edu/tgs/modelos/plano-crm",
+      "type": "template"
+    },
+    {
+      "label": "Playbook de atendimento omnichannel",
+      "url": "https://example.edu/tgs/guias/playbook-omnichannel",
+      "type": "guide"
+    }
+  ],
+  "bibliography": [
+    "PAYNE, Adrian; FROW, Pennie. Strategic Customer Management. Cambridge University Press, 2017.",
+    "KOTLER, Philip; KARTAJAYA, Hermawan; SETIAWAN, Iwan. Marketing 5.0. Wiley, 2021."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Plano de ação de CRM publicado com indicadores definidos."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-02-10T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-18.vue
+++ b/src/content/courses/tgs/lessons/lesson-18.vue
@@ -1,0 +1,17 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-18',
+  title: 'Aula 18: CRM e Relacionamento com Clientes',
+  objective: 'Analisar estratégias de CRM para fortalecer o relacionamento com clientes.',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-18.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>


### PR DESCRIPTION
## Summary
- scaffolded and populated lessons 14–18 for the TGS course with detailed plans, activities, and AVA-oriented TED tasks
- updated the TGS lessons manifest to expose the new lessons with summaries, tags, and availability metadata

## Testing
- npm run validate:content
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68da85fae9f4832ca16fe5d6c537d98e