### PR TITLE
Add ERP lessons 19-27 for TGS module

### DIFF
--- a/reports/content-validation-report.json
+++ b/reports/content-validation-report.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2025-09-29T13:02:50.174Z",
+  "generatedAt": "2025-09-29T13:36:06.296Z",
   "status": "passed",
   "totals": {
     "courses": 5,
-    "lessons": 72,
+    "lessons": 86,
     "lessonsWithIssues": 0,
     "problems": 0,
     "warnings": 0

--- a/src/content/courses/tgs/lessons.json
+++ b/src/content/courses/tgs/lessons.json
@@ -201,6 +201,105 @@
       "formatVersion": "md3.lesson.v1"
     },
     {
+      "id": "lesson-19",
+      "title": "Aula 19: Introdução aos Sistemas ERP",
+      "file": "lesson-19.json",
+      "available": true,
+      "description": "Apresenta fundamentos de ERP, evolução histórica e benefícios estratégicos da integração de processos.",
+      "summary": "Apresenta fundamentos dos sistemas ERP, sua evolução e implicações estratégicas para o negócio.",
+      "tags": ["aula-19-erp"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-20",
+      "title": "Aula 20: Módulos Essenciais e Processos Integrados",
+      "file": "lesson-20.json",
+      "available": true,
+      "description": "Explora módulos centrais do ERP e relaciona dependências em fluxos procure-to-pay.",
+      "summary": "Mapeia módulos centrais do ERP e suas integrações para suportar processos ponta a ponta.",
+      "tags": ["aula-20-modulos-erp"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-21",
+      "title": "Aula 21: Integração ERP com a Cadeia de Suprimentos",
+      "file": "lesson-21.json",
+      "available": true,
+      "description": "Analisa fluxos order-to-cash e integrações do ERP com WMS e TMS em cadeias logísticas.",
+      "summary": "Investiga integrações entre ERP, logística e parceiros para entregar experiência order-to-cash consistente.",
+      "tags": ["aula-21-order-to-cash"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-22",
+      "title": "Aula 22: Governança de Dados Mestres no ERP",
+      "file": "lesson-22.json",
+      "available": true,
+      "description": "Estrutura políticas e papéis para garantir qualidade e segurança dos dados mestres do ERP.",
+      "summary": "Detalha papéis, riscos e indicadores para governança de dados mestres em ambientes ERP.",
+      "tags": ["aula-22-dados-mestres"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-23",
+      "title": "Aula 23: Metodologias de Implantação de ERP",
+      "file": "lesson-23.json",
+      "available": true,
+      "description": "Compara abordagens de implantação, riscos e práticas de patrocínio em projetos ERP.",
+      "summary": "Analisa fases, abordagens e riscos de implantação de ERP com foco em patrocínio e governança.",
+      "tags": ["aula-23-implantacao-erp"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-24",
+      "title": "Aula 24 (Sábado Letivo): Estudo de Caso SAP em Operações",
+      "file": "lesson-24.json",
+      "available": true,
+      "description": "Realiza sábado letivo imersivo analisando caso SAP focado em produção, manutenção e estabilização pós-go-live.",
+      "summary": "Sábado letivo com estudo de caso SAP, conectando produção, manutenção e governança pós-go-live.",
+      "tags": ["aula-24-sabado-sap"],
+      "duration": 210,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-25",
+      "title": "Aula 25: Estudo de Caso TOTVS em Serviços",
+      "file": "lesson-25.json",
+      "available": true,
+      "description": "Estuda implantação TOTVS em empresa de serviços, relacionando operação, finanças e BI.",
+      "summary": "Analisa caso TOTVS em serviços destacando integração serviço-to-cash e ganhos financeiros.",
+      "tags": ["aula-25-totvs"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-26",
+      "title": "Aula 26: ERP, E-commerce e Plataformas Digitais",
+      "file": "lesson-26.json",
+      "available": true,
+      "description": "Debate integrações entre ERP, e-commerce, OMS e marketplaces com foco em experiência omnicanal.",
+      "summary": "Explora integrações digitais entre ERP e canais omnicanal, apontando dados críticos e monitoramento.",
+      "tags": ["aula-26-erp-ecommerce"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-27",
+      "title": "Aula 27: Fatores Críticos de Sucesso em Projetos ERP",
+      "file": "lesson-27.json",
+      "available": true,
+      "description": "Consolida fatores críticos de sucesso, indicadores e roadmap de maturidade pós-implantação de ERP.",
+      "summary": "Sintetiza fatores críticos de sucesso e propõe roadmap de maturidade para projetos ERP.",
+      "tags": ["aula-27-fcs-erp"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
       "id": "lesson-28",
       "title": "Aula 28: Avaliação – NP2",
       "file": "lesson-28.json",

--- a/src/content/courses/tgs/lessons/lesson-19.json
+++ b/src/content/courses/tgs/lessons/lesson-19.json
@@ -1,0 +1,262 @@
+{
+  "id": "lesson-19",
+  "title": "Aula 19: Introdução aos Sistemas ERP",
+  "objective": "Compreender o conceito de ERP, sua evolução histórica e o valor estratégico da integração de processos empresariais.",
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Plano da aula",
+      "cards": [
+        {
+          "icon": "book-open",
+          "title": "CONTEÚDO",
+          "content": "Conceito de ERP, evolução do mercado, benefícios esperados e limitações comuns."
+        },
+        {
+          "icon": "bullseye",
+          "title": "OBJETIVOS",
+          "content": "- Identificar elementos que caracterizam um ERP.\n- Reconhecer sinais de maturidade em organizações que adotam ERP.\n- Debater impactos sociotécnicos decorrentes da centralização de dados."
+        },
+        {
+          "icon": "users",
+          "title": "METODOLOGIA",
+          "content": "Exposição dialogada, análise de vídeo demonstrativo e trabalho em duplas para síntese crítica."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Evolução dos ERPs",
+      "steps": [
+        {
+          "title": "Anos 1960",
+          "content": "Surgimento do MRP focado em planejamento de materiais na indústria."
+        },
+        {
+          "title": "Anos 1980",
+          "content": "Expansão para MRP II com módulos financeiros e de chão de fábrica integrados."
+        },
+        {
+          "title": "Anos 1990",
+          "content": "Popularização do termo ERP e adoção de módulos corporativos padronizados."
+        },
+        {
+          "title": "Anos 2000",
+          "content": "Integração com web, CRM e SCM, além de arquiteturas orientadas a serviços."
+        },
+        {
+          "title": "Atualidade",
+          "content": "ERPs em nuvem, inteligência artificial embarcada e marketplaces de extensões."
+        }
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Benefícios percebidos",
+      "cards": [
+        {
+          "title": "Visão única",
+          "content": "Dados mestres consolidados para todas as áreas de negócio."
+        },
+        {
+          "title": "Padronização",
+          "content": "Processos modelados com melhores práticas incorporadas."
+        },
+        {
+          "title": "Conformidade",
+          "content": "Controles integrados que suportam auditorias internas e externas."
+        },
+        {
+          "title": "Escalabilidade",
+          "content": "Capacidade de crescer incorporando novos módulos e filiais."
+        }
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Panorama sistêmico do ERP",
+      "summary": "Como o ERP conecta fatores críticos para entregar valor organizacional.",
+      "factors": [
+        {
+          "id": "dados-mestres",
+          "name": "Dados mestres",
+          "summary": "Cadastro unificado de clientes, produtos e fornecedores.",
+          "kind": "stock",
+          "indicators": ["acuracia_cadastros", "tempo_atualizacao"]
+        },
+        {
+          "id": "processos-core",
+          "name": "Processos core",
+          "summary": "Fluxos de compras, vendas, produção e finanças.",
+          "kind": "flow",
+          "indicators": ["lead_time_pedidos", "ciclo_fechamento"]
+        },
+        {
+          "id": "usuarios",
+          "name": "Usuários",
+          "summary": "Colaboradores que executam e registram as operações.",
+          "kind": "driver",
+          "indicators": ["treinamentos_realizados", "satisfacao_usuario"]
+        },
+        {
+          "id": "governanca",
+          "name": "Governança",
+          "summary": "Políticas, papéis e controles aplicados ao ERP.",
+          "kind": "constraint",
+          "indicators": ["segregacao_funcoes", "auditorias_realizadas"]
+        },
+        {
+          "id": "valor-negocio",
+          "name": "Valor de negócio",
+          "summary": "Resultados percebidos pela organização.",
+          "kind": "outcome",
+          "indicators": ["otimizaçao_custos", "nivel_servico"]
+        }
+      ],
+      "loops": [
+        {
+          "id": "melhoria-continua",
+          "name": "Loop de melhoria contínua",
+          "polarity": "reinforcing",
+          "summary": "Dados confiáveis alimentam decisões melhores que retroalimentam a adesão ao ERP.",
+          "steps": [
+            {
+              "id": "step-1",
+              "from": "dados-mestres",
+              "to": "processos-core",
+              "effect": "reinforces",
+              "description": "Cadastros corretos reduzem retrabalho nos fluxos operacionais."
+            },
+            {
+              "id": "step-2",
+              "from": "processos-core",
+              "to": "valor-negocio",
+              "effect": "reinforces",
+              "description": "Processos padronizados melhoram produtividade e margens."
+            },
+            {
+              "id": "step-3",
+              "from": "valor-negocio",
+              "to": "usuarios",
+              "effect": "reinforces",
+              "description": "Resultados visíveis elevam engajamento dos usuários."
+            },
+            {
+              "id": "step-4",
+              "from": "usuarios",
+              "to": "dados-mestres",
+              "effect": "reinforces",
+              "description": "Usuários engajados registram dados com mais qualidade."
+            }
+          ]
+        }
+      ],
+      "insights": [
+        {
+          "id": "insight-1",
+          "label": "Qualidade dos dados",
+          "description": "É o ponto de partida para aproveitar benefícios do ERP."
+        },
+        {
+          "id": "insight-2",
+          "label": "Governança",
+          "description": "Define limites e responsabilidades que sustentam o ciclo virtuoso."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "ERP vs. Sistemas departamentais",
+      "headers": ["Aspecto", "ERP", "Sistemas isolados"],
+      "rows": [
+        ["Escopo", "Cobertura corporativa com módulos integrados", "Foco específico em uma área"],
+        ["Banco de dados", "Único e centralizado", "Múltiplos bancos desconectados"],
+        ["Processos", "Melhores práticas pré-configuradas", "Customizações ad-hoc"],
+        [
+          "Custo total",
+          "Elevado investimento inicial, ganhos de escala",
+          "Menor entrada, alto custo de manutenção"
+        ],
+        ["Evolução", "Roadmap do fornecedor e ecossistema de parceiros", "Depende do time local"]
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Demonstração sugerida",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/sap-introducao",
+          "title": "Tour guiado pelo SAP S/4HANA",
+          "caption": "Demonstra navegação pelos módulos Financeiro, Compras e Vendas com foco em integrações básicas."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/totvs-visao-geral",
+          "title": "Visão geral do TOTVS Protheus",
+          "caption": "Apresenta o conceito de menu por processos e o centro de comandos da solução."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 19 — Resumo crítico",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Produza um resumo crítico (máx. 400 palavras) relacionando benefícios e riscos da adoção de um ERP em uma organização à sua escolha. Envie no AVA até às 22h de amanhã com título 'Resumo ERP - Aula 19'."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-19-introducao-aos-sistemas-erp",
+  "summary": "Apresenta fundamentos dos sistemas ERP, sua evolução histórica e o papel estratégico da integração de processos empresariais.",
+  "objectives": [
+    "Definir ERP e reconhecer seus componentes estruturantes.",
+    "Relacionar evolução tecnológica com expansão de escopo dos ERPs.",
+    "Avaliar criticamente benefícios e desafios associados à adoção da solução."
+  ],
+  "competencies": [
+    "Pensamento sistêmico aplicado a processos corporativos",
+    "Avaliação crítica de tecnologias empresariais",
+    "Comunicação escrita"
+  ],
+  "outcomes": [
+    "Entrega resumo crítico refletindo impactos do ERP.",
+    "Identifica fatores sociotécnicos relevantes em discussões orais.",
+    "Relaciona exemplos práticos com conceitos apresentados."
+  ],
+  "prerequisites": [
+    "Revisar mapa de sistemas empresariais elaborado na aula 15.",
+    "Trazer exemplos de sistemas utilizados em experiências profissionais ou familiares."
+  ],
+  "tags": ["aula-19-erp"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Linha do tempo da evolução dos ERPs",
+      "url": "https://example.edu/tgs/guias/linha-tempo-erp",
+      "type": "guide"
+    },
+    {
+      "label": "Glossário ERP básico",
+      "url": "https://example.edu/tgs/guias/glossario-erp",
+      "type": "handout"
+    }
+  ],
+  "bibliography": [
+    "MONK, Ellen; WAGNER, Bret. Concepts in Enterprise Resource Planning. Cengage, 2021.",
+    "DAVENPORT, Thomas. Mission Critical: Realizing the Promise of Enterprise Systems. Harvard Business Review Press, 2000."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Resumo crítico publicado no AVA."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-02-15T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Notas de planejamento ERP"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-19.vue
+++ b/src/content/courses/tgs/lessons/lesson-19.vue
@@ -1,0 +1,18 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-19',
+  title: 'Aula 19: Introdução aos Sistemas ERP',
+  objective:
+    'Compreender o conceito de ERP, sua evolução histórica e o valor estratégico da integração de processos empresariais.',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-19.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-20.json
+++ b/src/content/courses/tgs/lessons/lesson-20.json
@@ -1,0 +1,291 @@
+{
+  "id": "lesson-20",
+  "title": "Aula 20: Módulos Essenciais e Processos Integrados",
+  "objective": "Explorar os módulos centrais de um ERP e compreender como eles suportam processos ponta a ponta.",
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Plano da aula",
+      "cards": [
+        {
+          "icon": "gears",
+          "title": "CONTEÚDO",
+          "content": "Módulos Financeiro, Controladoria, Suprimentos, Vendas, Produção e RH, além de integrações de dados mestres."
+        },
+        {
+          "icon": "bullseye",
+          "title": "OBJETIVOS",
+          "content": "- Relacionar módulos às macroetapas do negócio.\n- Identificar dependências de dados e eventos entre áreas.\n- Avaliar impactos da configuração inadequada de módulos."
+        },
+        {
+          "icon": "users",
+          "title": "METODOLOGIA",
+          "content": "Aula dialogada com análise de processos reais, dinâmica em grupos e fórum mediado no AVA."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Módulos e macroprocessos",
+      "headers": ["Módulo", "Processo suportado", "Indicadores críticos", "Stakeholders"],
+      "rows": [
+        [
+          "Financeiro",
+          "Contas a pagar e receber, fluxo de caixa",
+          "DSO, liquidez corrente",
+          "Tesouraria, diretoria"
+        ],
+        [
+          "Controladoria",
+          "Fechamento contábil, consolidação",
+          "Tempo de fechamento, compliance fiscal",
+          "Controladoria, auditoria"
+        ],
+        [
+          "Suprimentos",
+          "Compras, contratos, gestão de estoque",
+          "Lead time de compras, giro de estoque",
+          "Compradores, almoxarifado"
+        ],
+        [
+          "Vendas",
+          "Pedidos, faturamento, faturamento recorrente",
+          "Conversão, ticket médio",
+          "Comercial, faturamento"
+        ],
+        [
+          "Produção",
+          "Planejamento e execução",
+          "Eficiência global, desperdício",
+          "PCP, manufatura"
+        ],
+        ["RH", "Folha, benefícios, performance", "Turnover, absenteísmo", "RH, líderes de equipe"]
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Sequência recomendada de ativação",
+      "steps": [
+        {
+          "title": "Dados mestres",
+          "content": "Revisar cadastros de materiais, clientes e fornecedores antes da ativação."
+        },
+        {
+          "title": "Financeiro + Suprimentos",
+          "content": "Garantir conformidade fiscal e capacidade de reposição de estoque."
+        },
+        {
+          "title": "Vendas",
+          "content": "Sincronizar catálogo e políticas comerciais com estoques disponíveis."
+        },
+        {
+          "title": "Produção",
+          "content": "Planejar ordens de produção conectadas ao planejamento de materiais."
+        },
+        {
+          "title": "RH e controladoria",
+          "content": "Fechar ciclo de informações e entregar relatórios gerenciais integrados."
+        }
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Dinâmica: pontos de atenção",
+      "cards": [
+        {
+          "title": "Dependências",
+          "content": "Quais módulos precisam estar sincronizados para liberar a emissão de notas fiscais?"
+        },
+        {
+          "title": "Alertas",
+          "content": "Que eventos devem gerar notificações automáticas (ex.: estoque mínimo, pedido bloqueado)?"
+        },
+        {
+          "title": "Escalonamento",
+          "content": "Como a TI deve ser acionada quando um módulo crítico fica indisponível?"
+        },
+        {
+          "title": "Backups",
+          "content": "Que cadastros necessitam de versão histórica para auditoria?"
+        }
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Fluxo Procure-to-Pay",
+      "summary": "Interações entre módulos do ERP para compras e pagamentos.",
+      "factors": [
+        {
+          "id": "requisicao",
+          "name": "Requisição",
+          "summary": "Pedido interno de compra.",
+          "kind": "flow",
+          "indicators": ["tempo_aprovacao"]
+        },
+        {
+          "id": "pedido",
+          "name": "Pedido de compra",
+          "summary": "Documento formal enviado ao fornecedor.",
+          "kind": "flow",
+          "indicators": ["pedidos_em_aberto"]
+        },
+        {
+          "id": "recebimento",
+          "name": "Recebimento",
+          "summary": "Entrada física e fiscal de materiais.",
+          "kind": "flow",
+          "indicators": ["divergencias_recebimento"]
+        },
+        {
+          "id": "financeiro",
+          "name": "Liquidação financeira",
+          "summary": "Pagamento conforme condições negociadas.",
+          "kind": "flow",
+          "indicators": ["antecipacoes", "descontos_perdidos"]
+        },
+        {
+          "id": "relatorio",
+          "name": "Relatórios de controle",
+          "summary": "Visão consolidada para gestão.",
+          "kind": "outcome",
+          "indicators": ["economia_negociacao", "conformidade_fiscal"]
+        }
+      ],
+      "loops": [
+        {
+          "id": "controle",
+          "name": "Loop de controle de gastos",
+          "polarity": "balancing",
+          "summary": "Limites aprovados evitam estouro orçamentário e alimentam decisões futuras.",
+          "steps": [
+            {
+              "id": "c-step-1",
+              "from": "requisicao",
+              "to": "pedido",
+              "effect": "reinforces",
+              "description": "Requisições aprovadas convertem-se em pedidos alinhados à política de compras."
+            },
+            {
+              "id": "c-step-2",
+              "from": "pedido",
+              "to": "recebimento",
+              "effect": "reinforces",
+              "description": "Pedidos corretos reduzem divergências de recebimento."
+            },
+            {
+              "id": "c-step-3",
+              "from": "recebimento",
+              "to": "financeiro",
+              "effect": "reinforces",
+              "description": "Notas fiscais sem erro aceleram pagamentos."
+            },
+            {
+              "id": "c-step-4",
+              "from": "financeiro",
+              "to": "relatorio",
+              "effect": "reinforces",
+              "description": "Pagamentos rastreáveis produzem relatórios confiáveis."
+            },
+            {
+              "id": "c-step-5",
+              "from": "relatorio",
+              "to": "requisicao",
+              "effect": "balances",
+              "description": "Indicadores de gastos alimentam ajustes em limites e políticas."
+            }
+          ]
+        }
+      ],
+      "insights": [
+        {
+          "id": "insight-a",
+          "label": "Auditoria contínua",
+          "description": "Cada etapa registra evidências usadas para fiscalizações."
+        },
+        {
+          "id": "insight-b",
+          "label": "Papéis claros",
+          "description": "Perfis de aprovação bem definidos evitam gargalos."
+        }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Demonstrações recomendadas",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/sap-procure-to-pay",
+          "title": "SAP S/4HANA: fluxo procure-to-pay",
+          "caption": "Demonstração da criação da requisição até o pagamento com monitor de conformidade."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/totvs-compras-integradas",
+          "title": "TOTVS Protheus: compras integradas",
+          "caption": "Apresenta parametrização de aprovação múltipla e integração com estoque."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 20 — Fórum moderado",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Publique no fórum \"Integração Procure-to-Pay\" até às 20h de dois dias após a aula: descreva um gargalo vivido ou observado em processos de compras e indique qual módulo do ERP poderia mitigar o problema. Responda a pelo menos um colega com uma sugestão adicional."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-20-modulos-essenciais-e-processos-integrados",
+  "summary": "Mapeia módulos centrais do ERP e como eles suportam o fluxo procure-to-pay com indicadores e decisões integradas.",
+  "objectives": [
+    "Relacionar módulos a processos ponta a ponta.",
+    "Identificar indicadores e stakeholders responsáveis por cada módulo.",
+    "Planejar uma sequência de ativação coerente com governança de dados."
+  ],
+  "competencies": [
+    "Modelagem de processos empresariais",
+    "Gestão integrada de dados",
+    "Comunicação colaborativa online"
+  ],
+  "outcomes": [
+    "Participa ativamente do fórum relatando gargalos reais.",
+    "Elabora mapa de dependências entre módulos.",
+    "Sinaliza indicadores críticos para monitorar a integração."
+  ],
+  "prerequisites": [
+    "Concluir o resumo crítico da aula 19.",
+    "Revisar mapa de processos elaborado na aula 12."
+  ],
+  "tags": ["aula-20-modulos-erp"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Ficha técnica dos módulos SAP",
+      "url": "https://example.edu/tgs/guias/sap-modulos",
+      "type": "guide"
+    },
+    {
+      "label": "Catálogo TOTVS por processos",
+      "url": "https://example.edu/tgs/guias/totvs-processos",
+      "type": "handout"
+    }
+  ],
+  "bibliography": [
+    "SUMNER, Mary. Enterprise Resource Planning. Prentice Hall, 2018.",
+    "O'LEARY, Daniel. Enterprise Resource Planning Systems. Cambridge University Press, 2000."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Participação qualificada no fórum e registro dos aprendizados."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-02-15T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Roteiro de módulos ERP"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-20.vue
+++ b/src/content/courses/tgs/lessons/lesson-20.vue
@@ -1,0 +1,18 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-20',
+  title: 'Aula 20: Módulos Essenciais e Processos Integrados',
+  objective:
+    'Explorar os módulos centrais de um ERP e compreender como eles suportam processos ponta a ponta.',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-20.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-21.json
+++ b/src/content/courses/tgs/lessons/lesson-21.json
@@ -1,0 +1,282 @@
+{
+  "id": "lesson-21",
+  "title": "Aula 21: Integração ERP com a Cadeia de Suprimentos",
+  "objective": "Analisar como o ERP conecta fornecedores, estoques e distribuição em processos colaborativos.",
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Plano da aula",
+      "cards": [
+        {
+          "icon": "target",
+          "title": "CONTEÚDO",
+          "content": "Processos order-to-cash e plan-to-produce, integrações com WMS, TMS e portais de fornecedores."
+        },
+        {
+          "icon": "bullseye",
+          "title": "OBJETIVOS",
+          "content": "- Visualizar fluxos interorganizacionais suportados pelo ERP.\n- Identificar riscos quando integrações falham.\n- Discutir métricas logísticas e de serviço ao cliente."
+        },
+        {
+          "icon": "users",
+          "title": "METODOLOGIA",
+          "content": "Debate guiado com base em estudo de caso, construção de fluxograma e apresentação relâmpago."
+        }
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Pontos críticos de integração",
+      "cards": [
+        {
+          "title": "Portal do fornecedor",
+          "content": "Como as confirmações de entrega impactam planejamento de produção?"
+        },
+        {
+          "title": "WMS",
+          "content": "Quais dados de localização de estoque retornam ao ERP em tempo real?"
+        },
+        {
+          "title": "TMS",
+          "content": "Que eventos de transporte atualizam promessas ao cliente?"
+        },
+        {
+          "title": "Cliente",
+          "content": "Como status de pedido e faturas sincronizam com CRM e plataformas digitais?"
+        }
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Ciclo order-to-cash",
+      "summary": "Representação dos elos que suportam a entrega ao cliente.",
+      "factors": [
+        {
+          "id": "pedido-cliente",
+          "name": "Pedido do cliente",
+          "summary": "Entrada de demanda.",
+          "kind": "driver",
+          "indicators": ["sla_prometido"]
+        },
+        {
+          "id": "estoque",
+          "name": "Disponibilidade de estoque",
+          "summary": "Materiais prontos para expedição.",
+          "kind": "stock",
+          "indicators": ["dias_estoque", "otif"]
+        },
+        {
+          "id": "expedicao",
+          "name": "Expedição",
+          "summary": "Separação e despacho de mercadorias.",
+          "kind": "flow",
+          "indicators": ["tempo_separacao"]
+        },
+        {
+          "id": "transporte",
+          "name": "Transporte",
+          "summary": "Entrega ao cliente com rastreamento.",
+          "kind": "flow",
+          "indicators": ["atrasos_transporte"]
+        },
+        {
+          "id": "faturamento",
+          "name": "Faturamento",
+          "summary": "Emissão de nota e cobrança.",
+          "kind": "flow",
+          "indicators": ["tempo_faturamento"]
+        },
+        {
+          "id": "satisfacao",
+          "name": "Satisfação do cliente",
+          "summary": "Percepção de confiabilidade e serviço.",
+          "kind": "outcome",
+          "indicators": ["nps", "taxa_reclamacoes"]
+        }
+      ],
+      "loops": [
+        {
+          "id": "feedback-servico",
+          "name": "Feedback de serviço",
+          "polarity": "reinforcing",
+          "summary": "Clientes satisfeitos tendem a realizar novos pedidos, sustentando a cadeia.",
+          "steps": [
+            {
+              "id": "otc-1",
+              "from": "pedido-cliente",
+              "to": "estoque",
+              "effect": "reinforces",
+              "description": "Planejamento adequado garante disponibilidade."
+            },
+            {
+              "id": "otc-2",
+              "from": "estoque",
+              "to": "expedicao",
+              "effect": "reinforces",
+              "description": "Estoque correto acelera separação."
+            },
+            {
+              "id": "otc-3",
+              "from": "expedicao",
+              "to": "transporte",
+              "effect": "reinforces",
+              "description": "Despachos ágeis reduzem atrasos."
+            },
+            {
+              "id": "otc-4",
+              "from": "transporte",
+              "to": "faturamento",
+              "effect": "reinforces",
+              "description": "Confirmações de entrega disparam faturamento."
+            },
+            {
+              "id": "otc-5",
+              "from": "faturamento",
+              "to": "satisfacao",
+              "effect": "reinforces",
+              "description": "Cobranças corretas melhoram confiança."
+            },
+            {
+              "id": "otc-6",
+              "from": "satisfacao",
+              "to": "pedido-cliente",
+              "effect": "reinforces",
+              "description": "Clientes satisfeitos geram novos pedidos."
+            }
+          ]
+        },
+        {
+          "id": "monitoramento-riscos",
+          "name": "Monitoramento de riscos",
+          "polarity": "balancing",
+          "summary": "Alertas evitam ruptura de estoque e multas por atraso.",
+          "steps": [
+            {
+              "id": "risk-1",
+              "from": "estoque",
+              "to": "pedido-cliente",
+              "effect": "balances",
+              "description": "Sinais de ruptura disparam priorização de pedidos críticos."
+            },
+            {
+              "id": "risk-2",
+              "from": "transporte",
+              "to": "expedicao",
+              "effect": "balances",
+              "description": "Ocorrências logísticas ajustam planos de expedição."
+            }
+          ]
+        }
+      ],
+      "insights": [
+        {
+          "id": "insight-otc-1",
+          "label": "Integração com WMS",
+          "description": "Inventário em tempo real evita promessas não cumpridas."
+        },
+        {
+          "id": "insight-otc-2",
+          "label": "Rastreabilidade fiscal",
+          "description": "Notas fiscais alinhadas a eventos logísticos reduzem autuações."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Sinalizadores de risco logístico",
+      "steps": [
+        {
+          "title": "Pedido atrasado",
+          "content": "ERP identifica pedido sem confirmação de produção."
+        },
+        { "title": "Estoque crítico", "content": "Alertas do WMS são enviados ao planejamento." },
+        {
+          "title": "Ocorrência de transporte",
+          "content": "TMS registra evento e atualiza promessa ao cliente."
+        },
+        {
+          "title": "Reemissão fiscal",
+          "content": "ERP gera carta de correção ou nota complementar."
+        }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Casos recomendados",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/case-sap-scm",
+          "title": "Case SAP: integração SCM + ERP",
+          "caption": "Multinacional de bens de consumo reduz 20% dos atrasos com visibilidade ponta a ponta."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/case-totvs-logistica",
+          "title": "Case TOTVS: logística integrada",
+          "caption": "Rede varejista sincroniza ERP, WMS e TMS e melhora OTIF em 12 pontos."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 21 — Fluxograma order-to-cash",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Desenhe um fluxograma Order-to-Cash destacando integrações críticas entre ERP, WMS e TMS. Publique no AVA até às 23h de amanhã em PDF ou imagem, acompanhado de breve descrição (máx. 150 palavras)."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-21-integracao-erp-cadeia-de-suprimentos",
+  "summary": "Examplifica a integração do ERP com sistemas logísticos, destacando fluxos order-to-cash e riscos associados.",
+  "objectives": [
+    "Mapear fluxos logísticos suportados pelo ERP.",
+    "Reconhecer riscos e indicadores de integração com WMS/TMS.",
+    "Produzir fluxograma que evidencie responsabilidades e dados críticos."
+  ],
+  "competencies": [
+    "Gestão da cadeia de suprimentos",
+    "Modelagem visual de processos",
+    "Colaboração com parceiros externos"
+  ],
+  "outcomes": [
+    "Entrega fluxograma com integrações anotadas.",
+    "Identifica indicadores logísticos relevantes.",
+    "Apresenta argumentos sobre riscos e mitigação em sala."
+  ],
+  "prerequisites": [
+    "Participar do fórum da aula 20.",
+    "Revisar conceitos de integração da aula 16."
+  ],
+  "tags": ["aula-21-order-to-cash"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Template fluxograma O2C",
+      "url": "https://example.edu/tgs/templates/fluxograma-o2c",
+      "type": "template"
+    },
+    {
+      "label": "Checklist de integrações logísticas",
+      "url": "https://example.edu/tgs/guias/checklist-logistica",
+      "type": "guide"
+    }
+  ],
+  "bibliography": [
+    "CHOPRA, Sunil; MEINDL, Peter. Gestão da Cadeia de Suprimentos. Pearson, 2022.",
+    "JACOBS, F. Robert; CHASE, Richard. Administração da Produção e Operações. AMGH, 2021."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Entrega do fluxograma comentado no AVA."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-02-15T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Estudos de caso logística integrada"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-21.vue
+++ b/src/content/courses/tgs/lessons/lesson-21.vue
@@ -1,0 +1,18 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-21',
+  title: 'Aula 21: Integração ERP com a Cadeia de Suprimentos',
+  objective:
+    'Analisar como o ERP conecta fornecedores, estoques e distribuição em processos colaborativos.',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-21.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-22.json
+++ b/src/content/courses/tgs/lessons/lesson-22.json
@@ -1,0 +1,276 @@
+{
+  "id": "lesson-22",
+  "title": "Aula 22: Governança de Dados Mestres no ERP",
+  "objective": "Estruturar políticas e processos para garantir qualidade, consistência e segurança dos dados mestres.",
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Plano da aula",
+      "cards": [
+        {
+          "icon": "settings",
+          "title": "CONTEÚDO",
+          "content": "Dados mestres, hierarquias, workflows de aprovação, segregação de funções e políticas de segurança."
+        },
+        {
+          "icon": "bullseye",
+          "title": "OBJETIVOS",
+          "content": "- Definir papéis e responsabilidades para gestão de dados mestres.\n- Estabelecer métricas de qualidade.\n- Avaliar impactos de inconsistências na operação."
+        },
+        {
+          "icon": "users",
+          "title": "METODOLOGIA",
+          "content": "Workshop de desenho de políticas, discussão de incidentes reais e construção colaborativa de mapa mental."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Domínios de dados mestres",
+      "headers": ["Domínio", "Exemplos", "Riscos de baixa qualidade", "Controles sugeridos"],
+      "rows": [
+        [
+          "Produtos",
+          "SKU, unidade, impostos",
+          "Tributação incorreta, estoque divergente",
+          "Revisão fiscal, validação automática"
+        ],
+        [
+          "Clientes",
+          "CNPJ/CPF, crédito, endereço",
+          "Faturamento rejeitado, inadimplência",
+          "Consulta a bureaus, SLA de atualização"
+        ],
+        [
+          "Fornecedores",
+          "Dados bancários, condições",
+          "Pagamentos indevidos, compras bloqueadas",
+          "Validação bancária, segregação"
+        ],
+        [
+          "Localidades",
+          "Centros, armazéns",
+          "Logística ineficiente, relatórios errados",
+          "Checklist de abertura, auditoria"
+        ],
+        [
+          "Recursos humanos",
+          "Colaboradores, cargos",
+          "Erro em folha, acesso inadequado",
+          "Integração com SSO, dupla aprovação"
+        ]
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Papéis na governança",
+      "cards": [
+        {
+          "title": "Data owner",
+          "content": "Responsável por políticas, indicadores e aprovação final."
+        },
+        {
+          "title": "Data steward",
+          "content": "Orquestra cadastros, conduz limpezas e monitora qualidade."
+        },
+        {
+          "title": "Usuário chave",
+          "content": "Solicita alterações e valida aderência ao processo."
+        },
+        {
+          "title": "TI/Segurança",
+          "content": "Mantém controles de acesso, logs e trilhas de auditoria."
+        }
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Ciclo de governança",
+      "summary": "Fluxo contínuo de monitoramento e melhoria da qualidade de dados.",
+      "factors": [
+        {
+          "id": "politicas",
+          "name": "Políticas",
+          "summary": "Diretrizes e padrões documentados.",
+          "kind": "constraint",
+          "indicators": ["politicas_publicadas"]
+        },
+        {
+          "id": "cadastro",
+          "name": "Cadastro",
+          "summary": "Processo de criação e alteração de dados.",
+          "kind": "flow",
+          "indicators": ["tempo_cadastro", "erros_detectados"]
+        },
+        {
+          "id": "monitoramento",
+          "name": "Monitoramento",
+          "summary": "Medições de qualidade e auditorias.",
+          "kind": "flow",
+          "indicators": ["score_qualidade"]
+        },
+        {
+          "id": "remediacao",
+          "name": "Remediação",
+          "summary": "Correções e limpezas periódicas.",
+          "kind": "flow",
+          "indicators": ["registros_corrigidos"]
+        },
+        {
+          "id": "valor",
+          "name": "Valor entregue",
+          "summary": "Impacto percebido pelas áreas de negócio.",
+          "kind": "outcome",
+          "indicators": ["redução_retrabalho", "compliance_lgpd"]
+        }
+      ],
+      "loops": [
+        {
+          "id": "qualidade",
+          "name": "Loop de qualidade",
+          "polarity": "reinforcing",
+          "summary": "Melhor qualidade gera confiança e incentiva cumprimento das políticas.",
+          "steps": [
+            {
+              "id": "dq-1",
+              "from": "politicas",
+              "to": "cadastro",
+              "effect": "reinforces",
+              "description": "Políticas claras orientam cadastros corretos."
+            },
+            {
+              "id": "dq-2",
+              "from": "cadastro",
+              "to": "monitoramento",
+              "effect": "reinforces",
+              "description": "Registros completos facilitam medições."
+            },
+            {
+              "id": "dq-3",
+              "from": "monitoramento",
+              "to": "remediacao",
+              "effect": "reinforces",
+              "description": "Indicadores apontam prioridades de correção."
+            },
+            {
+              "id": "dq-4",
+              "from": "remediacao",
+              "to": "valor",
+              "effect": "reinforces",
+              "description": "Dados limpos reduzem retrabalho."
+            },
+            {
+              "id": "dq-5",
+              "from": "valor",
+              "to": "politicas",
+              "effect": "reinforces",
+              "description": "Benefícios percebidos estimulam revisão periódica das políticas."
+            }
+          ]
+        }
+      ],
+      "insights": [
+        {
+          "id": "insight-dados-1",
+          "label": "Workflow digital",
+          "description": "Automatizar aprovações reduz tempo de ciclo."
+        },
+        {
+          "id": "insight-dados-2",
+          "label": "Indicadores sociais",
+          "description": "Metas visíveis no cockpit do ERP promovem accountability."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Resposta a incidentes de dados",
+      "steps": [
+        {
+          "title": "Detecção",
+          "content": "Monitor identifica ruptura de qualidade ou violação de acesso."
+        },
+        { "title": "Comunicação", "content": "Data steward notifica stakeholders e abre chamado." },
+        {
+          "title": "Correção",
+          "content": "Equipe executa plano de remediação priorizando processos críticos."
+        },
+        { "title": "Prevenção", "content": "Revisão das políticas e atualização de treinamentos." }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Referências audiovisuais",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/sap-master-data-governance",
+          "title": "SAP MDG em ação",
+          "caption": "Demonstra workflow de aprovação e validações automáticas."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/totvs-governanca-dados",
+          "title": "TOTVS: governança de cadastros",
+          "caption": "Apresenta políticas de segregação de funções e auditoria."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 22 — Mapa mental",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Construa um mapa mental digital resumindo papéis, indicadores e controles de governança de dados mestres. Entregue o link ou arquivo no AVA até às 18h do próximo encontro presencial."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-22-governanca-dados-mestres-no-erp",
+  "summary": "Detalha como estruturar a governança de dados mestres em ERPs, com papéis, processos e indicadores de qualidade.",
+  "objectives": [
+    "Classificar domínios de dados mestres e riscos associados.",
+    "Estabelecer papéis e políticas para governança.",
+    "Planejar mapa mental que consolide práticas e indicadores."
+  ],
+  "competencies": ["Gestão de dados", "Governança corporativa", "Visualização de conhecimento"],
+  "outcomes": [
+    "Entrega mapa mental com papéis e indicadores.",
+    "Propõe controles compatíveis com a realidade organizacional.",
+    "Participa ativamente da discussão de incidentes."
+  ],
+  "prerequisites": [
+    "Realizar fluxograma da aula 21.",
+    "Revisar políticas institucionais de segurança da informação."
+  ],
+  "tags": ["aula-22-dados-mestres"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Checklist de qualidade de dados",
+      "url": "https://example.edu/tgs/guias/checklist-dados",
+      "type": "guide"
+    },
+    {
+      "label": "Ferramentas de mapa mental",
+      "url": "https://example.edu/tgs/ferramentas/mapas-mentais",
+      "type": "tool"
+    }
+  ],
+  "bibliography": [
+    "OTTO, Boris. Managing Master Data Quality. Springer, 2011.",
+    "REDMAN, Thomas. Data Driven. Harvard Business Review Press, 2015."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Mapa mental publicado com todos os requisitos."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-02-15T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Manual corporativo de governança de dados"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-22.vue
+++ b/src/content/courses/tgs/lessons/lesson-22.vue
@@ -1,0 +1,18 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-22',
+  title: 'Aula 22: Governança de Dados Mestres no ERP',
+  objective:
+    'Estruturar políticas e processos para garantir qualidade, consistência e segurança dos dados mestres.',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-22.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-23.json
+++ b/src/content/courses/tgs/lessons/lesson-23.json
@@ -1,0 +1,256 @@
+{
+  "id": "lesson-23",
+  "title": "Aula 23: Metodologias de Implantação de ERP",
+  "objective": "Avaliar abordagens de implantação, gestão da mudança e critérios de sucesso em projetos ERP.",
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Plano da aula",
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "CONTEÚDO",
+          "content": "Fases de projeto, abordagens big bang vs. ondas, gestão da mudança, indicadores de prontidão."
+        },
+        {
+          "icon": "bullseye",
+          "title": "OBJETIVOS",
+          "content": "- Comparar metodologias de implantação.\n- Identificar artefatos críticos (BPML, testes, cutover).\n- Planejar ações de gestão da mudança."
+        },
+        {
+          "icon": "users",
+          "title": "METODOLOGIA",
+          "content": "Discussão de casos, análise de linha do tempo e dinâmica de priorização de riscos."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Fases de implantação",
+      "steps": [
+        {
+          "title": "Descoberta",
+          "content": "Alinhamento estratégico, levantamento de processos atuais."
+        },
+        { "title": "Desenho", "content": "To-be, configurações, integrações planejadas." },
+        {
+          "title": "Construção",
+          "content": "Parametrização, desenvolvimentos complementares, testes unitários."
+        },
+        { "title": "Validação", "content": "Testes integrados, migração piloto, treinamento." },
+        { "title": "Cutover", "content": "Plano de virada, estabilização, suporte hiper-care." }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Comparativo de abordagens",
+      "headers": ["Abordagem", "Vantagens", "Riscos", "Quando usar"],
+      "rows": [
+        [
+          "Big bang",
+          "Transição única, simplifica interfaces temporárias",
+          "Maior impacto caso ocorra falha",
+          "Organizações com alta disciplina e forte patrocínio"
+        ],
+        [
+          "Ondas",
+          "Permite aprendizado incremental",
+          "Integrações temporárias e custo prolongado",
+          "Empresas multinegócio ou com alta complexidade"
+        ],
+        [
+          "Greenfield",
+          "Revisão completa de processos",
+          "Esforço elevado de gestão da mudança",
+          "Cenários com legado obsoleto"
+        ],
+        [
+          "Brownfield",
+          "Aproveita configurações existentes",
+          "Risco de carregar problemas antigos",
+          "Quando há boa aderência ao template global"
+        ]
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Riscos prioritários",
+      "cards": [
+        { "title": "Dados", "content": "Migração incompleta pode interromper faturamento." },
+        { "title": "Processos", "content": "Workflows não testados geram filas e retrabalho." },
+        { "title": "Pessoas", "content": "Usuários resistentes atrasam adoção." },
+        { "title": "Tecnologia", "content": "Infraestrutura insuficiente afeta performance." }
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Rede de patrocínio",
+      "summary": "Stakeholders que sustentam um projeto de implantação.",
+      "factors": [
+        {
+          "id": "patrocinador",
+          "name": "Patrocinador executivo",
+          "summary": "Define prioridades e aprova orçamento.",
+          "kind": "driver",
+          "indicators": ["decisoes_tomadas"]
+        },
+        {
+          "id": "pm",
+          "name": "PMO / gerente de projeto",
+          "summary": "Coordena cronograma, riscos e comunicação.",
+          "kind": "flow",
+          "indicators": ["status_semanais"]
+        },
+        {
+          "id": "processo",
+          "name": "Líderes de processo",
+          "summary": "Validam desenhos e testes.",
+          "kind": "flow",
+          "indicators": ["roteiros_aprovados"]
+        },
+        {
+          "id": "ti",
+          "name": "TI e integração",
+          "summary": "Garante infraestrutura, interfaces e segurança.",
+          "kind": "flow",
+          "indicators": ["defeitos_resolvidos"]
+        },
+        {
+          "id": "usuarios-finais",
+          "name": "Usuários finais",
+          "summary": "Adotam o sistema e executam processos.",
+          "kind": "outcome",
+          "indicators": ["adesao_treinamento", "satisfacao_lancamento"]
+        }
+      ],
+      "loops": [
+        {
+          "id": "patrocinio",
+          "name": "Loop de patrocínio",
+          "polarity": "reinforcing",
+          "summary": "Engajamento executivo garante recursos e remove impedimentos.",
+          "steps": [
+            {
+              "id": "s-1",
+              "from": "patrocinador",
+              "to": "pm",
+              "effect": "reinforces",
+              "description": "Direcionamentos claros aceleram decisões."
+            },
+            {
+              "id": "s-2",
+              "from": "pm",
+              "to": "processo",
+              "effect": "reinforces",
+              "description": "Coordenação eficiente garante entregas em tempo."
+            },
+            {
+              "id": "s-3",
+              "from": "processo",
+              "to": "ti",
+              "effect": "reinforces",
+              "description": "Requisitos consolidados orientam integrações."
+            },
+            {
+              "id": "s-4",
+              "from": "ti",
+              "to": "usuarios-finais",
+              "effect": "reinforces",
+              "description": "Soluções estáveis elevam confiança dos usuários."
+            },
+            {
+              "id": "s-5",
+              "from": "usuarios-finais",
+              "to": "patrocinador",
+              "effect": "reinforces",
+              "description": "Adoção positiva gera relatos de sucesso ao patrocinador."
+            }
+          ]
+        }
+      ],
+      "insights": [
+        {
+          "id": "insight-impl-1",
+          "label": "Comunicação",
+          "description": "Newsletters semanais evitam ruídos e boatos."
+        },
+        {
+          "id": "insight-impl-2",
+          "label": "Treinamento aplicado",
+          "description": "Treinar usando dados reais acelera transferência de conhecimento."
+        }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Estudos de caso",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/case-implantacao-sap",
+          "title": "Implantação SAP em indústria farmacêutica",
+          "caption": "Aborda estratégia em ondas com foco em validação regulatória."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/case-implantacao-totvs",
+          "title": "TOTVS em empresa de serviços",
+          "caption": "Explora abordagem big bang com squad de hiper-care."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 23 — Briefing de riscos",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Entregue até às 21h de dois dias após a aula um briefing (máx. 1 página) listando cinco riscos para um projeto ERP e respectivas respostas. Publique em PDF no AVA identificando responsáveis por cada ação."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-23-metodologias-de-implantacao-de-erp",
+  "summary": "Compara metodologias de implantação de ERP e destaca fatores de patrocínio, riscos e gestão da mudança.",
+  "objectives": [
+    "Discutir fases e abordagens de implantação.",
+    "Avaliar riscos críticos e planos de resposta.",
+    "Elaborar briefing de riscos alinhado à governança."
+  ],
+  "competencies": ["Gestão de projetos", "Liderança de mudanças", "Análise de riscos"],
+  "outcomes": [
+    "Entrega briefing com riscos priorizados.",
+    "Aplica conceitos de patrocínio ao estudo de caso.",
+    "Argumenta sobre escolha de abordagem ideal."
+  ],
+  "prerequisites": ["Concluir mapa mental da aula 22.", "Revisar leituras sobre governança."],
+  "tags": ["aula-23-implantacao-erp"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Template de plano de projeto ERP",
+      "url": "https://example.edu/tgs/templates/plano-projeto-erp",
+      "type": "template"
+    },
+    {
+      "label": "Matriz de riscos exemplo",
+      "url": "https://example.edu/tgs/guias/matriz-riscos-erp",
+      "type": "guide"
+    }
+  ],
+  "bibliography": [
+    "SOMERS, Toni; NELSON, Klara. The Impact of Critical Success Factors across the Stages of ERP Implementations. IEEE, 2004.",
+    "PMI. Practice Guide for Adaptive Project Management. Project Management Institute, 2023."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Briefing de riscos entregue no AVA."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-02-15T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Playbook interno de implantação"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-23.vue
+++ b/src/content/courses/tgs/lessons/lesson-23.vue
@@ -1,0 +1,18 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-23',
+  title: 'Aula 23: Metodologias de Implantação de ERP',
+  objective:
+    'Avaliar abordagens de implantação, gestão da mudança e critérios de sucesso em projetos ERP.',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-23.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-24.json
+++ b/src/content/courses/tgs/lessons/lesson-24.json
@@ -1,0 +1,276 @@
+{
+  "id": "lesson-24",
+  "title": "Aula 24 (Sábado Letivo): Estudo de Caso SAP em Operações",
+  "objective": "Vivenciar, em regime intensivo, a análise de um caso real de implantação SAP focado em operações industriais.",
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Plano da imersão",
+      "cards": [
+        {
+          "icon": "calendar-days",
+          "title": "CARGA HORÁRIA",
+          "content": "Sábado letivo das 8h às 12h30 com intervalos orientados e atividades guiadas."
+        },
+        {
+          "icon": "bullseye",
+          "title": "OBJETIVOS",
+          "content": "- Explorar documentação real de projeto SAP.\n- Mapear interdependências entre módulos de produção e manutenção.\n- Elaborar recomendações para estabilidade pós-go-live."
+        },
+        {
+          "icon": "users",
+          "title": "METODOLOGIA",
+          "content": "Trabalho em squads, análise documental, simulação de war room e apresentação final."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Agenda do sábado letivo",
+      "steps": [
+        { "title": "08h00 — Kick-off", "content": "Briefing do caso, papéis e entregáveis." },
+        {
+          "title": "09h00 — Deep dive",
+          "content": "Análise de documentos de blueprint, matriz de integrações e plano de testes."
+        },
+        {
+          "title": "10h30 — Simulação",
+          "content": "War room com incidentes simulados envolvendo SAP PP, MM e PM."
+        },
+        {
+          "title": "11h30 — Recomendações",
+          "content": "Elaboração de plano de estabilização e lições aprendidas."
+        },
+        {
+          "title": "12h15 — Pitch final",
+          "content": "Apresentação de sínteses para banca avaliadora."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Artefatos fornecidos",
+      "headers": ["Documento", "Descrição", "Uso durante a imersão"],
+      "rows": [
+        [
+          "Blueprint PP",
+          "Processos de planejamento e execução da produção",
+          "Identificar dependências com manutenção"
+        ],
+        ["Matriz de integrações", "Fluxos entre SAP, MES e sensores IoT", "Mapear pontos de falha"],
+        [
+          "Plano de testes",
+          "Roteiros de cenários críticos",
+          "Distribuir entre squads e avaliar cobertura"
+        ],
+        ["Dashboard de incidentes", "Registros pós-go-live", "Priorizar ações de estabilização"]
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Desafios para os squads",
+      "cards": [
+        {
+          "title": "Squad Produção",
+          "content": "Avaliar sincronização PP ↔ MES e gargalos de ordens."
+        },
+        {
+          "title": "Squad Manutenção",
+          "content": "Analisar integração PM com sensores e estoque de peças."
+        },
+        {
+          "title": "Squad Qualidade",
+          "content": "Checar rastreabilidade e registros de não conformidade."
+        },
+        {
+          "title": "Squad Governança",
+          "content": "Definir indicadores e ritos de acompanhamento pós-go-live."
+        }
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Mapa do caso SAP",
+      "summary": "Fluxos entre produção, manutenção e cadeia de suprimentos na planta industrial.",
+      "factors": [
+        {
+          "id": "planejamento",
+          "name": "Planejamento",
+          "summary": "MPS/MRP atualizados semanalmente.",
+          "kind": "driver",
+          "indicators": ["aderencia_plano"]
+        },
+        {
+          "id": "execucao",
+          "name": "Execução",
+          "summary": "Ordens de produção no SAP PP.",
+          "kind": "flow",
+          "indicators": ["oee", "tempo_ciclo"]
+        },
+        {
+          "id": "manutencao",
+          "name": "Manutenção",
+          "summary": "Planos preventivos no SAP PM.",
+          "kind": "flow",
+          "indicators": ["disponibilidade_maquinas"]
+        },
+        {
+          "id": "materiais",
+          "name": "Materiais",
+          "summary": "Peças de reposição e matérias-primas.",
+          "kind": "stock",
+          "indicators": ["estoque_segurança"]
+        },
+        {
+          "id": "performance",
+          "name": "Performance",
+          "summary": "Resultados de produção e qualidade.",
+          "kind": "outcome",
+          "indicators": ["yield", "refugos"]
+        }
+      ],
+      "loops": [
+        {
+          "id": "continuidade-operacional",
+          "name": "Continuidade operacional",
+          "polarity": "reinforcing",
+          "summary": "Planejamento alinhado com manutenção garante estabilidade de produção.",
+          "steps": [
+            {
+              "id": "sap-1",
+              "from": "planejamento",
+              "to": "execucao",
+              "effect": "reinforces",
+              "description": "Planos realistas reduzem ajustes de última hora."
+            },
+            {
+              "id": "sap-2",
+              "from": "execucao",
+              "to": "manutencao",
+              "effect": "reinforces",
+              "description": "Dados de produção alimentam gatilhos de manutenção."
+            },
+            {
+              "id": "sap-3",
+              "from": "manutencao",
+              "to": "materiais",
+              "effect": "reinforces",
+              "description": "Ordens de manutenção consomem peças que precisam ser repostas."
+            },
+            {
+              "id": "sap-4",
+              "from": "materiais",
+              "to": "planejamento",
+              "effect": "balances",
+              "description": "Níveis de estoque ajustam o plano mestre para evitar rupturas."
+            },
+            {
+              "id": "sap-5",
+              "from": "execucao",
+              "to": "performance",
+              "effect": "reinforces",
+              "description": "Execução estável melhora indicadores de performance."
+            },
+            {
+              "id": "sap-6",
+              "from": "performance",
+              "to": "planejamento",
+              "effect": "reinforces",
+              "description": "Resultados alimentam revisão de metas."
+            }
+          ]
+        }
+      ],
+      "insights": [
+        {
+          "id": "insight-sabado-1",
+          "label": "War room disciplinado",
+          "description": "Registro estruturado de incidentes acelera resolução."
+        },
+        {
+          "id": "insight-sabado-2",
+          "label": "Dados IoT",
+          "description": "Integrações com sensores exigem monitoramento contínuo."
+        }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Material preparatório",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/sap-pp-demo",
+          "title": "Demonstração SAP PP",
+          "caption": "Visão geral do planejamento e execução de ordens."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/sap-pm-dashboard",
+          "title": "Painel SAP PM",
+          "caption": "Monitora ordens preventivas e backlog de manutenção."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 24 — Diário de campo",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Registre um diário de campo (mín. 600 palavras) com aprendizados do sábado letivo, destacando evidências analisadas e decisões do squad. Submeta até às 20h do domingo subsequente."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-24-sabado-letivo-estudo-de-caso-sap",
+  "summary": "Sábado letivo imersivo analisando caso real de implantação SAP com foco em produção e manutenção.",
+  "objectives": [
+    "Interpretar documentação real de projeto SAP.",
+    "Diagnosticar interdependências entre módulos industriais.",
+    "Produzir recomendações de estabilização pós-go-live."
+  ],
+  "competencies": [
+    "Análise de casos complexos",
+    "Colaboração em squads",
+    "Gestão de operações industriais"
+  ],
+  "outcomes": [
+    "Entrega diário de campo completo.",
+    "Apresenta pitch com recomendações estruturadas.",
+    "Mapeia riscos prioritários da operação."
+  ],
+  "prerequisites": [
+    "Rever materiais de implantação das aulas 20-23.",
+    "Assistir previamente aos vídeos preparatórios."
+  ],
+  "tags": ["aula-24-sabado-sap"],
+  "duration": 210,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Pacote de documentos SAP",
+      "url": "https://example.edu/tgs/cases/sap-industria",
+      "type": "dataset"
+    },
+    {
+      "label": "Template de diário de campo",
+      "url": "https://example.edu/tgs/templates/diario-campo",
+      "type": "template"
+    }
+  ],
+  "bibliography": [
+    "SAP PRESS. Production Planning with SAP S/4HANA. SAP Press, 2023.",
+    "MALHOTRA, Manish. Implementing SAP Plant Maintenance (PM). SAP Press, 2022."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Diário de campo avaliando aprendizado da imersão."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-02-15T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Caso SAP fornecido pela parceira IndustrialTech"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-24.vue
+++ b/src/content/courses/tgs/lessons/lesson-24.vue
@@ -1,0 +1,18 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-24',
+  title: 'Aula 24 (Sábado Letivo): Estudo de Caso SAP em Operações',
+  objective:
+    'Vivenciar, em regime intensivo, a análise de um caso real de implantação SAP focado em operações industriais.',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-24.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-25.json
+++ b/src/content/courses/tgs/lessons/lesson-25.json
@@ -1,0 +1,236 @@
+{
+  "id": "lesson-25",
+  "title": "Aula 25: Estudo de Caso TOTVS em Serviços",
+  "objective": "Analisar implantação de TOTVS em uma empresa de serviços e identificar lições de integração financeira e operacional.",
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Plano da aula",
+      "cards": [
+        {
+          "icon": "desktop",
+          "title": "CONTEÚDO",
+          "content": "Contexto da empresa, módulos TOTVS implantados, integrações com CRM e BI."
+        },
+        {
+          "icon": "bullseye",
+          "title": "OBJETIVOS",
+          "content": "- Interpretar indicadores pós-implantação.\n- Identificar sinergias entre finanças, faturamento e prestação de serviços.\n- Construir recomendações de melhoria."
+        },
+        {
+          "icon": "users",
+          "title": "METODOLOGIA",
+          "content": "Análise de relatório gerencial, construção de sistemaMapper colaborativo e debates orientados."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Resultados pós-implantação",
+      "headers": ["Indicador", "Antes", "Depois", "Fonte"],
+      "rows": [
+        ["Prazo médio de faturamento", "12 dias", "4 dias", "ERP TOTVS + automação fiscal"],
+        ["Taxa de retrabalho", "15%", "4%", "Workflow TOTVS de ordens de serviço"],
+        ["Satisfação do cliente", "72 NPS", "84 NPS", "Pesquisa trimestral"],
+        ["Tempo de fechamento", "8 dias úteis", "3 dias úteis", "Financeiro integrado"],
+        ["Receita recorrente", "R$ 1,2M/mês", "R$ 1,6M/mês", "Dashboard BI"]
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Pontos de discussão",
+      "cards": [
+        {
+          "title": "Contrato ↔ Serviço",
+          "content": "Como o módulo de contratos conversa com a agenda de técnicos?"
+        },
+        {
+          "title": "Financeiro",
+          "content": "Quais controles garantem reconciliação com gateways de pagamento?"
+        },
+        { "title": "BI", "content": "Como as informações alimentam dashboards de churn e upsell?" },
+        {
+          "title": "Suporte",
+          "content": "Que lições foram aprendidas com o hiper-care de 30 dias?"
+        }
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Fluxo serviço-to-cash",
+      "summary": "Integração TOTVS entre atendimento, faturamento e análise financeira.",
+      "factors": [
+        {
+          "id": "agendamento",
+          "name": "Agendamento",
+          "summary": "Ordem de serviço aberta no TOTVS.",
+          "kind": "flow",
+          "indicators": ["tempo_agenda"]
+        },
+        {
+          "id": "execucao-servico",
+          "name": "Execução",
+          "summary": "Técnico registra execução via app.",
+          "kind": "flow",
+          "indicators": ["sla_execucao"]
+        },
+        {
+          "id": "faturamento",
+          "name": "Faturamento",
+          "summary": "Emissão automática de notas e boletos.",
+          "kind": "flow",
+          "indicators": ["tempo_faturamento"]
+        },
+        {
+          "id": "receita",
+          "name": "Receita recorrente",
+          "summary": "Consolidação financeira no TOTVS.",
+          "kind": "stock",
+          "indicators": ["inadimplencia"]
+        },
+        {
+          "id": "insights",
+          "name": "Insights BI",
+          "summary": "Painéis para retenção e upsell.",
+          "kind": "outcome",
+          "indicators": ["churn", "taxa_renovacao"]
+        }
+      ],
+      "loops": [
+        {
+          "id": "feedback-servico",
+          "name": "Feedback serviço-finanças",
+          "polarity": "reinforcing",
+          "summary": "Serviços bem executados geram receita estável e insights para novas ofertas.",
+          "steps": [
+            {
+              "id": "svc-1",
+              "from": "agendamento",
+              "to": "execucao-servico",
+              "effect": "reinforces",
+              "description": "Agendas organizadas reduzem deslocamentos."
+            },
+            {
+              "id": "svc-2",
+              "from": "execucao-servico",
+              "to": "faturamento",
+              "effect": "reinforces",
+              "description": "Dados de execução alimentam faturamento automático."
+            },
+            {
+              "id": "svc-3",
+              "from": "faturamento",
+              "to": "receita",
+              "effect": "reinforces",
+              "description": "Cobranças ágeis elevam a previsibilidade."
+            },
+            {
+              "id": "svc-4",
+              "from": "receita",
+              "to": "insights",
+              "effect": "reinforces",
+              "description": "Receita consolidada gera indicadores de churn."
+            },
+            {
+              "id": "svc-5",
+              "from": "insights",
+              "to": "agendamento",
+              "effect": "reinforces",
+              "description": "Insights orientam priorização de serviços com maior margem."
+            }
+          ]
+        }
+      ],
+      "insights": [
+        {
+          "id": "insight-totvs-1",
+          "label": "Mobile-first",
+          "description": "Registro mobile reduz falhas de digitação."
+        },
+        {
+          "id": "insight-totvs-2",
+          "label": "KPIs integrados",
+          "description": "Financeiro e operação compartilham a mesma base de indicadores."
+        }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Vídeos indicados",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/totvs-servicos-demo",
+          "title": "Demonstração TOTVS Serviços",
+          "caption": "Fluxo completo do atendimento ao faturamento."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/case-servicos-erp",
+          "title": "Case cliente TOTVS",
+          "caption": "Relato de CFO sobre ganhos em previsibilidade."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 25 — Relatório executivo",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Elabore um relatório executivo (máx. 6 slides) com diagnóstico e três recomendações para evolução do caso TOTVS. Entregue no AVA até às 23h do dia seguinte."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-25-estudo-de-caso-totvs-em-servicos",
+  "summary": "Analisa estudo de caso TOTVS em serviços, conectando execução operacional, faturamento e inteligência financeira.",
+  "objectives": [
+    "Interpretar resultados pós-implantação TOTVS.",
+    "Relacionar módulos de serviços a indicadores financeiros.",
+    "Gerar recomendações executivas baseadas em dados."
+  ],
+  "competencies": [
+    "Análise de desempenho",
+    "Integração financeiro-operacional",
+    "Comunicação executiva"
+  ],
+  "outcomes": [
+    "Entrega relatório com recomendações.",
+    "Argumenta sobre sinergia serviço-finanças.",
+    "Identifica oportunidades de evolução analítica."
+  ],
+  "prerequisites": [
+    "Completar diário de campo da aula 24.",
+    "Revisar conceitos de CRM da aula 18."
+  ],
+  "tags": ["aula-25-totvs"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Relatório TOTVS Serviços",
+      "url": "https://example.edu/tgs/cases/totvs-servicos",
+      "type": "dataset"
+    },
+    {
+      "label": "Template de slides executivos",
+      "url": "https://example.edu/tgs/templates/slides-executivos",
+      "type": "template"
+    }
+  ],
+  "bibliography": [
+    "TOTVS. Guia de Boas Práticas para Serviços. TOTVS, 2024.",
+    "HARVARD BUSINESS REVIEW. Why Service Businesses Need ERP. HBR, 2022."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Relatório executivo entregue com recomendações."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-02-15T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Case TOTVS Serviços 2024"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-25.vue
+++ b/src/content/courses/tgs/lessons/lesson-25.vue
@@ -1,0 +1,18 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-25',
+  title: 'Aula 25: Estudo de Caso TOTVS em Serviços',
+  objective:
+    'Analisar implantação de TOTVS em uma empresa de serviços e identificar lições de integração financeira e operacional.',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-25.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-26.json
+++ b/src/content/courses/tgs/lessons/lesson-26.json
@@ -1,0 +1,250 @@
+{
+  "id": "lesson-26",
+  "title": "Aula 26: ERP, E-commerce e Plataformas Digitais",
+  "objective": "Discutir estratégias de integração do ERP com canais digitais e marketplaces, garantindo consistência de estoque, preços e atendimento.",
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Plano da aula",
+      "cards": [
+        {
+          "icon": "monitor",
+          "title": "CONTEÚDO",
+          "content": "Integração ERP ↔ e-commerce, OMS, marketplaces, política de preços e experiência do cliente."
+        },
+        {
+          "icon": "bullseye",
+          "title": "OBJETIVOS",
+          "content": "- Identificar dados críticos compartilhados.\n- Avaliar modelos de sincronização (batch vs. near real-time).\n- Planejar monitoramento de SLA e atendimento."
+        },
+        {
+          "icon": "users",
+          "title": "METODOLOGIA",
+          "content": "Estudo de arquitetura de referência, construção de tabela comparativa e simulação de incidentes."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Dados que circulam entre ERP e canais digitais",
+      "headers": ["Categoria", "Origem", "Frequência", "Risco se falhar"],
+      "rows": [
+        ["Estoque", "ERP/WMS", "Quase real-time", "Venda de item indisponível"],
+        ["Preço", "ERP/Financeiro", "Diária ou sob evento", "Margens incorretas"],
+        ["Pedidos", "E-commerce/OMS", "Imediata", "Não faturamento"],
+        ["Clientes", "E-commerce/CRM", "Sob evento", "Entrega inviabilizada"],
+        ["Promoções", "Marketing", "Agendada", "Campanha inválida"]
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Incidentes simulados",
+      "cards": [
+        {
+          "title": "Duplicidade de pedidos",
+          "content": "Marketplace envia pedido duas vezes. Como o ERP evita faturamento duplicado?"
+        },
+        {
+          "title": "Divergência de preço",
+          "content": "Tabela no ERP não sincroniza. Que monitoria detecta?"
+        },
+        {
+          "title": "Estoque negativo",
+          "content": "Reserva online excede disponibilidade. Qual política aplicar?"
+        },
+        {
+          "title": "Cancelamento tardio",
+          "content": "Cliente cancela após faturamento. Quais integrações tratam devolução?"
+        }
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Arquitetura integrada",
+      "summary": "Componentes que sustentam a jornada digital.",
+      "factors": [
+        {
+          "id": "erp",
+          "name": "ERP",
+          "summary": "Fonte de estoque, preços e faturamento.",
+          "kind": "driver",
+          "indicators": ["atualizacao_precos", "acuracia_estoque"]
+        },
+        {
+          "id": "oms",
+          "name": "Order Management",
+          "summary": "Orquestra pedidos multicanal.",
+          "kind": "flow",
+          "indicators": ["sla_roteamento"]
+        },
+        {
+          "id": "marketplaces",
+          "name": "Marketplaces",
+          "summary": "Canais externos com regras próprias.",
+          "kind": "flow",
+          "indicators": ["penalidades"]
+        },
+        {
+          "id": "ecommerce",
+          "name": "E-commerce próprio",
+          "summary": "Vitrine digital e carrinho.",
+          "kind": "flow",
+          "indicators": ["taxa_conversao"]
+        },
+        {
+          "id": "cliente",
+          "name": "Cliente final",
+          "summary": "Experiência e fidelização.",
+          "kind": "outcome",
+          "indicators": ["nps_digital", "recompra"]
+        }
+      ],
+      "loops": [
+        {
+          "id": "experiencia-omnicanal",
+          "name": "Experiência omnicanal",
+          "polarity": "reinforcing",
+          "summary": "Sincronização eficiente aumenta satisfação e gera novas vendas.",
+          "steps": [
+            {
+              "id": "omni-1",
+              "from": "erp",
+              "to": "oms",
+              "effect": "reinforces",
+              "description": "Dados atualizados permitem roteamento correto."
+            },
+            {
+              "id": "omni-2",
+              "from": "oms",
+              "to": "marketplaces",
+              "effect": "reinforces",
+              "description": "OMS publica status confiáveis nos canais."
+            },
+            {
+              "id": "omni-3",
+              "from": "marketplaces",
+              "to": "ecommerce",
+              "effect": "reinforces",
+              "description": "Experiência consistente fortalece marca própria."
+            },
+            {
+              "id": "omni-4",
+              "from": "ecommerce",
+              "to": "cliente",
+              "effect": "reinforces",
+              "description": "Compra fluida melhora satisfação."
+            },
+            {
+              "id": "omni-5",
+              "from": "cliente",
+              "to": "erp",
+              "effect": "reinforces",
+              "description": "Feedback influencia planejamento de estoque e preços."
+            }
+          ]
+        }
+      ],
+      "insights": [
+        {
+          "id": "insight-omni-1",
+          "label": "Monitoria unificada",
+          "description": "Dashboard único com SLAs por canal evita visão fragmentada."
+        },
+        {
+          "id": "insight-omni-2",
+          "label": "Governança tributária",
+          "description": "Regras fiscais variam por marketplace e exigem parametrização específica."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Checklist de go-live digital",
+      "steps": [
+        { "title": "H-48", "content": "Congelar catálogo e validar preços." },
+        { "title": "H-24", "content": "Executar sincronização completa de estoque." },
+        { "title": "H-12", "content": "Rodar pedidos de teste end-to-end." },
+        { "title": "H", "content": "Abrir canais com monitoria dedicada." },
+        { "title": "H+24", "content": "Revisar SLAs, incidentes e ajustar regras." }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Demonstrações sugeridas",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/sap-commerce-integration",
+          "title": "SAP Commerce + S/4HANA",
+          "caption": "Fluxo de sincronização de catálogo, preços e pedidos."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/totvs-omnicanal",
+          "title": "TOTVS Omnichannel",
+          "caption": "Integração Protheus com marketplaces brasileiros."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 26 — Plano de monitoramento",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Monte um plano de monitoramento com indicadores, ferramentas e rotinas para integrações digitais. Entregue no AVA até às 22h de dois dias após a aula."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-26-erp-ecommerce-e-plataformas-digitais",
+  "summary": "Explora integrações entre ERP, e-commerce, OMS e marketplaces para garantir experiência omnicanal consistente.",
+  "objectives": [
+    "Mapear dados críticos compartilhados entre ERP e canais digitais.",
+    "Planejar sincronização e monitoramento de integrações.",
+    "Propor plano de monitoramento com indicadores e rotinas."
+  ],
+  "competencies": [
+    "Arquitetura de integrações digitais",
+    "Gestão de SLAs",
+    "Planejamento orientado ao cliente"
+  ],
+  "outcomes": [
+    "Entrega plano de monitoramento com indicadores coerentes.",
+    "Identifica riscos de sincronização por categoria de dado.",
+    "Participa da simulação de incidentes propondo respostas."
+  ],
+  "prerequisites": [
+    "Ler relatório executivo da aula 25.",
+    "Revisar integrações estudadas na aula 21."
+  ],
+  "tags": ["aula-26-erp-ecommerce"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Arquitetura de referência omnicanal",
+      "url": "https://example.edu/tgs/guias/arquitetura-omnicanal",
+      "type": "guide"
+    },
+    {
+      "label": "Planilha de monitoramento",
+      "url": "https://example.edu/tgs/templates/monitoramento-erp-digital",
+      "type": "template"
+    }
+  ],
+  "bibliography": [
+    "DION, Chris. Omnichannel Retail: How to Build Winning Stores in a Digital World. Wiley, 2023.",
+    "GARTNER. Market Guide for Digital Commerce Integrations. Gartner, 2024."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Plano de monitoramento das integrações digitais."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-02-15T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Referência Omnicanal 2024"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-26.vue
+++ b/src/content/courses/tgs/lessons/lesson-26.vue
@@ -1,0 +1,18 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-26',
+  title: 'Aula 26: ERP, E-commerce e Plataformas Digitais',
+  objective:
+    'Discutir estratégias de integração do ERP com canais digitais e marketplaces, garantindo consistência de estoque, preços e atendimento.',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-26.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-27.json
+++ b/src/content/courses/tgs/lessons/lesson-27.json
@@ -1,0 +1,276 @@
+{
+  "id": "lesson-27",
+  "title": "Aula 27: Fatores Críticos de Sucesso em Projetos ERP",
+  "objective": "Consolidar aprendizados sobre ERP destacando fatores críticos de sucesso, indicadores e mecanismos de melhoria contínua.",
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Plano da aula",
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "CONTEÚDO",
+          "content": "Fatores críticos de sucesso (FCS), indicadores de maturidade, governança pós-implantação e roadmap evolutivo."
+        },
+        {
+          "icon": "bullseye",
+          "title": "OBJETIVOS",
+          "content": "- Sintetizar aprendizados das aulas 19-26.\n- Classificar FCS por dimensão (processos, pessoas, tecnologia, dados).\n- Construir plano de ação incremental."
+        },
+        {
+          "icon": "users",
+          "title": "METODOLOGIA",
+          "content": "World café, construção colaborativa de tabela de FCS e priorização via matriz impacto × esforço."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Fatores críticos por dimensão",
+      "headers": ["Dimensão", "Fator", "Indicadores de sucesso", "Riscos se negligenciado"],
+      "rows": [
+        [
+          "Processos",
+          "Mapeamento e padronização",
+          "Tempo de ciclo, % automação",
+          "Retrabalho, desvios fiscais"
+        ],
+        [
+          "Pessoas",
+          "Patrocínio executivo e change management",
+          "Participação em treinamentos, NPS interno",
+          "Resistência, baixa adoção"
+        ],
+        [
+          "Tecnologia",
+          "Arquitetura integrada e monitorada",
+          "Disponibilidade, incidentes críticos",
+          "Paradas não planejadas"
+        ],
+        [
+          "Dados",
+          "Governança de dados mestres",
+          "Score de qualidade, conformidade LGPD",
+          "Dados inconsistentes"
+        ],
+        ["Valor", "KPIs de negócio acompanhados", "Margem, OTIF, churn", "Perda de credibilidade"]
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Indicadores para o dashboard de governança",
+      "cards": [
+        {
+          "title": "People",
+          "content": "Adesão a treinamentos, engajamento no AVA e taxa de uso de funcionalidades."
+        },
+        {
+          "title": "Process",
+          "content": "Tempo médio de processos críticos e % de tarefas automatizadas."
+        },
+        { "title": "Data", "content": "Score de qualidade de dados, incidentes de LGPD." },
+        {
+          "title": "Tech",
+          "content": "Disponibilidade do ERP, tempo médio de resposta a incidentes."
+        },
+        { "title": "Value", "content": "KPIs de negócio (margem, OTIF, NPS) vinculados ao ERP." }
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Ciclo de maturidade ERP",
+      "summary": "Como ações contínuas sustentam benefícios do ERP.",
+      "factors": [
+        {
+          "id": "estrategia",
+          "name": "Estratégia",
+          "summary": "Visão de longo prazo alinhada ao negócio.",
+          "kind": "driver",
+          "indicators": ["roadmap_atualizado"]
+        },
+        {
+          "id": "capacitacao",
+          "name": "Capacitação",
+          "summary": "Programas de treinamento e comunidade de prática.",
+          "kind": "flow",
+          "indicators": ["horas_treinamento"]
+        },
+        {
+          "id": "operacao",
+          "name": "Operação",
+          "summary": "Execução diária e suporte.",
+          "kind": "flow",
+          "indicators": ["tickets_resolvidos", "sla_suporte"]
+        },
+        {
+          "id": "dados",
+          "name": "Dados",
+          "summary": "Qualidade e governança contínua.",
+          "kind": "flow",
+          "indicators": ["score_dados"]
+        },
+        {
+          "id": "valor",
+          "name": "Valor de negócio",
+          "summary": "Resultados tangíveis.",
+          "kind": "outcome",
+          "indicators": ["roi_erp", "margem"]
+        }
+      ],
+      "loops": [
+        {
+          "id": "melhoria",
+          "name": "Melhoria contínua",
+          "polarity": "reinforcing",
+          "summary": "Capacitação e monitoramento sustentam geração de valor.",
+          "steps": [
+            {
+              "id": "mat-1",
+              "from": "estrategia",
+              "to": "capacitacao",
+              "effect": "reinforces",
+              "description": "Roadmap define trilhas de capacitação."
+            },
+            {
+              "id": "mat-2",
+              "from": "capacitacao",
+              "to": "operacao",
+              "effect": "reinforces",
+              "description": "Usuários treinados executam processos com precisão."
+            },
+            {
+              "id": "mat-3",
+              "from": "operacao",
+              "to": "dados",
+              "effect": "reinforces",
+              "description": "Execução correta gera dados confiáveis."
+            },
+            {
+              "id": "mat-4",
+              "from": "dados",
+              "to": "valor",
+              "effect": "reinforces",
+              "description": "Dados de qualidade suportam decisões e medição de benefícios."
+            },
+            {
+              "id": "mat-5",
+              "from": "valor",
+              "to": "estrategia",
+              "effect": "reinforces",
+              "description": "Resultados alimentam revisão de metas e investimentos."
+            }
+          ]
+        }
+      ],
+      "insights": [
+        {
+          "id": "insight-maturidade-1",
+          "label": "Comitê de governança",
+          "description": "Reuniões mensais mantêm alinhamento entre TI e negócio."
+        },
+        {
+          "id": "insight-maturidade-2",
+          "label": "Academia ERP",
+          "description": "Plano contínuo de capacitação evita perda de conhecimento."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Roadmap de evolução (12 meses)",
+      "steps": [
+        { "title": "Mês 1-2", "content": "Consolidar KPIs e instalar dashboard de governança." },
+        {
+          "title": "Mês 3-5",
+          "content": "Executar sprints de melhoria de dados e automações prioritárias."
+        },
+        {
+          "title": "Mês 6-8",
+          "content": "Expandir integrações digitais e revisar processos críticos."
+        },
+        {
+          "title": "Mês 9-10",
+          "content": "Rodar avaliação de maturidade e ajustar trilhas de capacitação."
+        },
+        {
+          "title": "Mês 11-12",
+          "content": "Planejar nova onda de projetos (analytics avançado, IA aplicada)."
+        }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Inspirações",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/case-sap-maturidade",
+          "title": "Case SAP: governança contínua",
+          "caption": "Empresa de varejo apresenta roadmap evolutivo."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/case-totvs-melhoria",
+          "title": "Case TOTVS: programa de melhoria",
+          "caption": "Companhia de serviços mostra academia ERP e indicadores."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 27 — Plano 30-60-90",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Crie um plano 30-60-90 dias com ações, responsáveis e indicadores para elevar a maturidade ERP do estudo de caso escolhido (SAP ou TOTVS). Entregue no AVA até às 23h de três dias após a aula."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-27-fatores-criticos-de-sucesso-em-projetos-erp",
+  "summary": "Sintetiza fatores críticos de sucesso em projetos ERP e propõe roadmap de evolução contínua com indicadores de maturidade.",
+  "objectives": [
+    "Consolidar fatores críticos de sucesso observados nos estudos de caso.",
+    "Planejar roadmap evolutivo alinhado a indicadores.",
+    "Produzir plano 30-60-90 orientado à maturidade."
+  ],
+  "competencies": ["Pensamento estratégico", "Gestão de desempenho", "Facilitação colaborativa"],
+  "outcomes": [
+    "Entrega plano 30-60-90 estruturado.",
+    "Curadoria de indicadores para dashboard de governança.",
+    "Participação ativa no world café."
+  ],
+  "prerequisites": [
+    "Ter concluído as entregas das aulas 24 a 26.",
+    "Revisar notas das apresentações de casos."
+  ],
+  "tags": ["aula-27-fcs-erp"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Template plano 30-60-90",
+      "url": "https://example.edu/tgs/templates/plano-30-60-90",
+      "type": "template"
+    },
+    {
+      "label": "Dashboard de governança exemplo",
+      "url": "https://example.edu/tgs/guias/dashboard-governanca-erp",
+      "type": "guide"
+    }
+  ],
+  "bibliography": [
+    "GARTNER. Critical Capabilities for ERP for Product-Centric Enterprises. Gartner, 2024.",
+    "MOTWANI, J. et al. Critical Factors for Successful ERP Implementation. Journal of Business Process Management, 2005."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Plano 30-60-90 com indicadores de maturidade."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-02-15T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Sumário executivo dos casos SAP/TOTVS"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-27.vue
+++ b/src/content/courses/tgs/lessons/lesson-27.vue
@@ -1,0 +1,18 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-27',
+  title: 'Aula 27: Fatores Críticos de Sucesso em Projetos ERP',
+  objective:
+    'Consolidar aprendizados sobre ERP destacando fatores críticos de sucesso, indicadores e mecanismos de melhoria contínua.',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-27.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>


### PR DESCRIPTION
## Summary
- add lessons 19-27 for TGS covering ERP fundamentos, módulos, integração logística, governança de dados, implantação e roadmap de maturidade, com diagramas (systemMapper, timeline, md3Table, cardGrid) e TEDs alinhados ao plano
- registrar vídeos sugeridos (SAP e TOTVS) e estudos de caso, incluindo o sábado letivo imersivo, além de atualizar o manifesto de aulas para tornar os conteúdos disponíveis
## Testing
- npm run validate:content

------
https://chatgpt.com/codex/tasks/task_e_68da88b7641c832cacec71c2cbaea7d3