### PR TITLE
Add lessons 29-39 for strategic planning unit

### DIFF
--- a/reports/content-observability-history.json
+++ b/reports/content-observability-history.json
@@ -24,5 +24,31 @@
       "withoutMetadata": 0,
       "completeness": 1
     }
+  },
+  {
+    "generatedAt": "2025-09-29T13:56:11.002Z",
+    "lessons": {
+      "total": 117,
+      "available": 97,
+      "unavailable": 20,
+      "md3Blocks": 784,
+      "legacyBlocks": 0,
+      "legacyLessons": 0,
+      "totalBlocks": 807,
+      "md3Coverage": 0.9714993804213135,
+      "legacyCoverage": 0
+    },
+    "exercises": {
+      "total": 10,
+      "withMetadata": 10,
+      "withoutMetadata": 0,
+      "completeness": 1
+    },
+    "supplements": {
+      "total": 5,
+      "withMetadata": 5,
+      "withoutMetadata": 0,
+      "completeness": 1
+    }
   }
 ]

--- a/reports/content-observability-trends.json
+++ b/reports/content-observability-trends.json
@@ -1,6 +1,32 @@
 {
-  "generatedAt": "2025-09-29T01:32:38.214Z",
+  "generatedAt": "2025-09-29T13:56:11.002Z",
   "snapshot": {
+    "generatedAt": "2025-09-29T13:56:11.002Z",
+    "lessons": {
+      "total": 117,
+      "available": 97,
+      "unavailable": 20,
+      "md3Blocks": 784,
+      "legacyBlocks": 0,
+      "legacyLessons": 0,
+      "totalBlocks": 807,
+      "md3Coverage": 0.9714993804213135,
+      "legacyCoverage": 0
+    },
+    "exercises": {
+      "total": 10,
+      "withMetadata": 10,
+      "withoutMetadata": 0,
+      "completeness": 1
+    },
+    "supplements": {
+      "total": 5,
+      "withMetadata": 5,
+      "withoutMetadata": 0,
+      "completeness": 1
+    }
+  },
+  "previous": {
     "generatedAt": "2025-09-29T01:32:38.214Z",
     "lessons": {
       "total": 92,
@@ -26,24 +52,101 @@
       "completeness": 1
     }
   },
-  "previous": null,
-  "trend": null,
+  "trend": {
+    "lessons": {
+      "md3Blocks": {
+        "current": 784,
+        "previous": 637,
+        "delta": 147,
+        "percentChange": 23.076923076923077,
+        "format": "absolute"
+      },
+      "legacyBlocks": {
+        "current": 0,
+        "previous": 0,
+        "delta": 0,
+        "percentChange": 0,
+        "format": "absolute"
+      },
+      "legacyLessons": {
+        "current": 0,
+        "previous": 0,
+        "delta": 0,
+        "percentChange": 0,
+        "format": "absolute"
+      },
+      "md3Coverage": {
+        "current": 97.14993804213134,
+        "previous": 99.37597503900156,
+        "delta": -2.2260369968702207,
+        "percentChange": -2.240015251167679,
+        "format": "points"
+      },
+      "legacyCoverage": {
+        "current": 0,
+        "previous": 0,
+        "delta": 0,
+        "percentChange": 0,
+        "format": "points"
+      }
+    },
+    "exercises": {
+      "withoutMetadata": {
+        "current": 0,
+        "previous": 0,
+        "delta": 0,
+        "percentChange": 0,
+        "format": "absolute"
+      },
+      "completeness": {
+        "current": 100,
+        "previous": 100,
+        "delta": 0,
+        "percentChange": 0,
+        "format": "points"
+      }
+    },
+    "supplements": {
+      "withoutMetadata": {
+        "current": 0,
+        "previous": 0,
+        "delta": 0,
+        "percentChange": 0,
+        "format": "absolute"
+      },
+      "completeness": {
+        "current": 100,
+        "previous": 100,
+        "delta": 0,
+        "percentChange": 0,
+        "format": "points"
+      }
+    }
+  },
   "sparklines": {
-    "md3Coverage": "▅",
-    "legacyBlocks": "▅",
-    "exercisesCompleteness": "▅",
-    "supplementsCompleteness": "▅"
+    "md3Coverage": "█▁",
+    "legacyBlocks": "▅▅",
+    "exercisesCompleteness": "▅▅",
+    "supplementsCompleteness": "▅▅"
   },
   "series": {
     "md3Coverage": [
       {
         "generatedAt": "2025-09-29T01:32:38.214Z",
         "value": 99.38
+      },
+      {
+        "generatedAt": "2025-09-29T13:56:11.002Z",
+        "value": 97.15
       }
     ],
     "legacyBlocks": [
       {
         "generatedAt": "2025-09-29T01:32:38.214Z",
+        "value": 0
+      },
+      {
+        "generatedAt": "2025-09-29T13:56:11.002Z",
         "value": 0
       }
     ],
@@ -51,11 +154,19 @@
       {
         "generatedAt": "2025-09-29T01:32:38.214Z",
         "value": 100
+      },
+      {
+        "generatedAt": "2025-09-29T13:56:11.002Z",
+        "value": 100
       }
     ],
     "supplementsCompleteness": [
       {
         "generatedAt": "2025-09-29T01:32:38.214Z",
+        "value": 100
+      },
+      {
+        "generatedAt": "2025-09-29T13:56:11.002Z",
         "value": 100
       }
     ]

--- a/reports/content-observability.json
+++ b/reports/content-observability.json
@@ -1,15 +1,15 @@
 {
-  "generatedAt": "2025-09-29T01:32:38.214Z",
+  "generatedAt": "2025-09-29T13:56:11.002Z",
   "totals": {
     "courses": 5,
     "lessons": {
-      "total": 92,
-      "available": 72,
+      "total": 117,
+      "available": 97,
       "unavailable": 20,
       "legacyLessons": 0,
-      "md3Blocks": 637,
+      "md3Blocks": 784,
       "legacyBlocks": 0,
-      "totalBlocks": 641
+      "totalBlocks": 807
     },
     "exercises": {
       "total": 10,
@@ -192,25 +192,27 @@
       "title": "Teoria Geral de Sistemas",
       "institution": "Unichristus",
       "lessons": {
-        "total": 15,
-        "available": 15,
+        "total": 40,
+        "available": 40,
         "unavailable": 0,
-        "totalBlocks": 153,
-        "md3Blocks": 153,
+        "totalBlocks": 319,
+        "md3Blocks": 300,
         "legacyBlocks": 0,
         "legacyLessons": 0,
         "legacyLessonIds": [],
         "blocksByType": {
           "accordion": 11,
           "bibliographyBlock": 9,
-          "callout": 28,
-          "cardGrid": 20,
-          "checklist": 4,
-          "contentBlock": 54,
-          "flightPlan": 6,
-          "lessonPlan": 9,
-          "md3Table": 7,
-          "timeline": 1,
+          "callout": 57,
+          "cardGrid": 45,
+          "checklist": 8,
+          "contentBlock": 63,
+          "flightPlan": 8,
+          "lessonPlan": 23,
+          "md3Table": 27,
+          "systemMapper": 19,
+          "timeline": 24,
+          "videos": 21,
           "videosBlock": 4
         },
         "legacyBlocksByType": {}

--- a/reports/content-validation-report.json
+++ b/reports/content-validation-report.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2025-09-29T13:36:06.296Z",
+  "generatedAt": "2025-09-29T13:56:01.260Z",
   "status": "passed",
   "totals": {
     "courses": 5,
-    "lessons": 86,
+    "lessons": 97,
     "lessonsWithIssues": 0,
     "problems": 0,
     "warnings": 0

--- a/src/content/courses/tgs/lessons.json
+++ b/src/content/courses/tgs/lessons.json
@@ -1,6 +1,6 @@
 {
   "version": "edu.manifest.v1",
-  "generatedAt": "2025-09-29T01:29:26.438Z",
+  "generatedAt": "2025-03-10T00:00:00.000Z",
   "entries": [
     {
       "id": "lesson-01",
@@ -307,6 +307,127 @@
       "description": "Aplica avaliação NP2 integrando sistemas abertos, fluxos e homeostase em estudos de caso.",
       "summary": "Avaliação NP2 voltada à síntese de sistemas abertos, fluxos e homeostase, articulando teoria e estudos de caso.",
       "tags": ["avaliacao", "np2", "pensamento-sistemico"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-29",
+      "title": "Aula 29: Fundamentos do Planejamento Estratégico de SI",
+      "file": "lesson-29.json",
+      "available": true,
+      "description": "Apresenta drivers, macroetapas e governança do planejamento estratégico de sistemas de informação.",
+      "summary": "Introduz fundamentos, atores e macroetapas do planejamento estratégico de sistemas de informação.",
+      "tags": ["planejamento-estrategico", "pesi", "governanca"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-30",
+      "title": "Aula 30: Diagnóstico e Análise SWOT do Ambiente de SI",
+      "file": "lesson-30.json",
+      "available": true,
+      "description": "Estrutura diagnóstico interno e externo com aplicação de matriz SWOT para sistemas de informação.",
+      "summary": "Explora ferramentas de diagnóstico e consolidação da análise SWOT aplicada a sistemas de informação.",
+      "tags": ["diagnostico", "swot", "pesi"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-31",
+      "title": "Aula 31: Capabilidades Digitais e Portfólio de Processos",
+      "file": "lesson-31.json",
+      "available": true,
+      "description": "Avalia capacidades internas e portfólio de processos para orientar prioridades do PESI.",
+      "summary": "Aprofunda a avaliação das capacidades digitais internas e seu impacto no portfólio estratégico de SI.",
+      "tags": ["capacidades-digitais", "portfolio", "planejamento"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-32",
+      "title": "Aula 32: Objetivos Estratégicos e Balanced Scorecard de SI",
+      "file": "lesson-32.json",
+      "available": true,
+      "description": "Converte diagnóstico em objetivos, indicadores e mapa estratégico no formato Balanced Scorecard.",
+      "summary": "Traduz a análise estratégica em objetivos, indicadores e iniciativas no formato Balanced Scorecard.",
+      "tags": ["balanced-scorecard", "objetivos", "planejamento"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-33",
+      "title": "Aula 33: Priorização e Roadmap do Plano Estratégico de SI",
+      "file": "lesson-33.json",
+      "available": true,
+      "description": "Define critérios de priorização e elabora roadmap plurianual das iniciativas estratégicas de SI.",
+      "summary": "Converte objetivos estratégicos em um roadmap priorizado com visão integrada do portfólio de SI.",
+      "tags": ["roadmap", "priorizacao", "pesi"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-34",
+      "title": "Aula 34: Governança e Alinhamento Estratégico SI-Negócio",
+      "file": "lesson-34.json",
+      "available": true,
+      "description": "Estabelece fóruns, cadências e indicadores para manter SI alinhado à estratégia corporativa.",
+      "summary": "Define estruturas e ritos de governança que mantêm SI alinhado ao negócio e asseguram geração de valor contínua.",
+      "tags": ["governanca", "alinhamento", "planejamento"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-35",
+      "title": "Aula 35: Indicadores, OKRs e Monitoramento do PESI",
+      "file": "lesson-35.json",
+      "available": true,
+      "description": "Seleciona indicadores e ritos de monitoramento para garantir execução do PESI.",
+      "summary": "Estabelece métricas, OKRs e ritos de monitoramento para garantir execução e aprendizado contínuo do PESI.",
+      "tags": ["indicadores", "okr", "monitoramento"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-36",
+      "title": "Aula 36: Transformação Digital e Tendências Emergentes",
+      "file": "lesson-36.json",
+      "available": true,
+      "description": "Analisa tendências tecnológicas e mecanismos para incorporá-las ao planejamento estratégico de SI.",
+      "summary": "Discute tendências emergentes e como incorporá-las ao planejamento estratégico de SI via ecossistemas de inovação.",
+      "tags": ["tendencias", "transformacao-digital", "inovacao"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-37",
+      "title": "Aula 37: Planejamento por Cenários e Futuros de SI",
+      "file": "lesson-37.json",
+      "available": true,
+      "description": "Aplica foresight e construção de cenários para orientar respostas estratégicas de SI.",
+      "summary": "Aplica foresight ao planejamento estratégico de SI, criando cenários e planos de resposta adaptativos.",
+      "tags": ["cenarios", "foresight", "planejamento"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-38",
+      "title": "Aula 38: Oficina Integrada – Roadmap, Mudança e Comunicação",
+      "file": "lesson-38.json",
+      "available": true,
+      "description": "Integra roadmap, gestão de mudança e comunicação para engajar stakeholders do PESI.",
+      "summary": "Integra roadmap estratégico com gestão de mudança, comunicação e engajamento de stakeholders.",
+      "tags": ["mudanca", "comunicacao", "roadmap"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-39",
+      "title": "Aula 39: Síntese Estratégica e Painel Futuro de SI",
+      "file": "lesson-39.json",
+      "available": true,
+      "description": "Consolida entregáveis do PESI e prepara painel futuro com próximos passos estratégicos.",
+      "summary": "Consolida entregáveis do PESI, prepara painel futuro e alinha próximos passos estratégicos.",
+      "tags": ["sintese", "painel-futuro", "planejamento"],
       "duration": 110,
       "formatVersion": "md3.lesson.v1"
     },

--- a/src/content/courses/tgs/lessons/lesson-29.json
+++ b/src/content/courses/tgs/lessons/lesson-29.json
@@ -1,0 +1,174 @@
+{
+  "id": "lesson-29",
+  "title": "Aula 29: Fundamentos do Planejamento Estratégico de SI",
+  "objective": "Estabelecer visão sistêmica sobre o ciclo de planejamento estratégico de sistemas de informação.",
+  "content": [
+    {
+      "type": "flightPlan",
+      "title": "Itinerário da aula",
+      "items": [
+        "Panorama das pressões externas e internas que demandam planejamento de SI.",
+        "Modelo de governança para condução do Plano Diretor de Tecnologia (PDTI/PESI).",
+        "Exercício colaborativo de definição de perguntas norteadoras para a etapa de diagnóstico."
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Motores do planejamento",
+      "cards": [
+        {
+          "title": "Estratégia do negócio",
+          "content": "Metas corporativas, proposta de valor e diferenciais competitivos definem prioridades de SI."
+        },
+        {
+          "title": "Regulação e compliance",
+          "content": "Normas como LGPD, Bacen e Susep exigem controles, trilhas de auditoria e planos de continuidade."
+        },
+        {
+          "title": "Transformação digital",
+          "content": "Inovação em produtos, canais e operações demanda investimentos coordenados em tecnologia."
+        },
+        {
+          "title": "Capacidades internas",
+          "content": "Processos, pessoas e arquitetura existentes condicionam ritmo e abrangência das iniciativas."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Evolução do planejamento de TI",
+      "steps": [
+        {
+          "title": "Anos 1980",
+          "content": "Planos de processamento de dados focados em infraestrutura e automação departamental."
+        },
+        {
+          "title": "Anos 1990",
+          "content": "Integração com reengenharia de processos e surgimento de ERPs corporativos."
+        },
+        {
+          "title": "Anos 2000",
+          "content": "PDTI alinhado à governança corporativa, frameworks como COBIT e ITIL."
+        },
+        {
+          "title": "Anos 2010",
+          "content": "Digitalização de jornadas, analytics e integração omnicanal."
+        },
+        {
+          "title": "Anos 2020+",
+          "content": "Estratégias data-driven, plataformas, ecossistemas e sustentabilidade digital."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Macroetapas do PESI",
+      "headers": ["Fase", "Perguntas-guia", "Principais entregáveis"],
+      "rows": [
+        [
+          "Preparação",
+          "Quem patrocina? Quais fronteiras do plano?",
+          "Termo de abertura, comitê, matriz de stakeholders"
+        ],
+        [
+          "Diagnóstico",
+          "Onde estamos em processos, dados e tecnologia?",
+          "Inventário de ativos, análise de maturidade, mapa de riscos"
+        ],
+        [
+          "Formulação",
+          "Que objetivos e indicadores conectam SI à estratégia?",
+          "Mapa estratégico de SI, metas plurianuais, carteira preliminar"
+        ],
+        [
+          "Execução",
+          "Como priorizar, financiar e governar o portfólio?",
+          "Roadmap, modelo de governança, plano de comunicação"
+        ],
+        [
+          "Monitoramento",
+          "Como medir valor e ajustar continuamente?",
+          "Painéis de indicadores, ritos de revisão, lições aprendidas"
+        ]
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Casos recomendados",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/pesi-banco-inovador",
+          "title": "Planejamento de SI no Banco Horizonte",
+          "caption": "Case sobre alinhamento entre diretoria de estratégia e TI para expansão digital."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/pdti-setor-publico",
+          "title": "PDTI em órgão regulador",
+          "caption": "Relato de implantação do ciclo PDTI com governança compartilhada."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 29 — Linha do tempo comentada",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Elabore uma linha do tempo executiva destacando três marcos que influenciaram o planejamento de TI da sua organização ou de um caso pesquisado. Entregue no AVA até 72h após a aula com comentários sobre impactos estratégicos."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-29-fundamentos-planejamento-estrategico-si",
+  "summary": "Introduz fundamentos, atores e macroetapas do planejamento estratégico de sistemas de informação.",
+  "objectives": [
+    "Reconhecer fatores que impulsionam o planejamento estratégico de SI.",
+    "Distinguir macroetapas do PESI e seus produtos principais.",
+    "Preparar perguntas norteadoras para o diagnóstico situacional."
+  ],
+  "competencies": [
+    "Pensamento sistêmico aplicado a estratégia",
+    "Governança de TI",
+    "Análise organizacional"
+  ],
+  "outcomes": [
+    "Mapeia atores e pressões que justificam o PESI.",
+    "Explica o encadeamento das macroetapas do plano.",
+    "Seleciona evidências necessárias para iniciar o diagnóstico."
+  ],
+  "prerequisites": [
+    "Revisar conceitos de alinhamento estratégico estudados na aula 12.",
+    "Trazer organogramas e indicadores atuais da organização analisada."
+  ],
+  "tags": ["planejamento-estrategico", "pesi", "governanca"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Template de termo de abertura de PESI",
+      "url": "https://example.edu/tgs/templates/termo-abertura-pesi",
+      "type": "template"
+    },
+    {
+      "label": "Guia COBIT Design para PESI",
+      "url": "https://example.edu/tgs/guides/cobit-design",
+      "type": "guide"
+    }
+  ],
+  "bibliography": [
+    "WEILL, Peter; ROSS, Jeanne. IT Governance. Harvard Business Review Press, 2017.",
+    "ALMEIDA, T. Planejamento Estratégico de Sistemas de Informação. Atlas, 2022."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Linha do tempo comentada conectando marcos históricos a impactos estratégicos."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-03-10T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Benchmark PESI 2024"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-29.vue
+++ b/src/content/courses/tgs/lessons/lesson-29.vue
@@ -1,0 +1,16 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-29',
+  title: 'Aula 29: Fundamentos do Planejamento Estratégico de SI',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-29.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-30.json
+++ b/src/content/courses/tgs/lessons/lesson-30.json
@@ -1,0 +1,207 @@
+{
+  "id": "lesson-30",
+  "title": "Aula 30: Diagnóstico e Análise SWOT do Ambiente de SI",
+  "objective": "Aplicar ferramentas de diagnóstico para mapear forças, fraquezas, oportunidades e ameaças do ambiente de SI.",
+  "content": [
+    {
+      "type": "flightPlan",
+      "title": "Agenda",
+      "items": [
+        "Revisão de fontes de dados para diagnóstico interno e externo.",
+        "Construção colaborativa da matriz SWOT específica para SI.",
+        "Priorização de riscos e vantagens competitivas."
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Fontes essenciais do diagnóstico",
+      "cards": [
+        {
+          "title": "Inventário de ativos",
+          "content": "Lista de sistemas, contratos, integrações e custos associados."
+        },
+        {
+          "title": "Mapa de processos",
+          "content": "Fluxos ponta a ponta com indicadores de desempenho e gargalos."
+        },
+        {
+          "title": "Pesquisa com stakeholders",
+          "content": "Entrevistas, workshops e NPS de áreas usuárias para captar expectativas."
+        },
+        {
+          "title": "Análise de tendências",
+          "content": "Relatórios de mercado, concorrentes e benchmarks regulatórios."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Matriz SWOT orientada a SI",
+      "headers": ["Quadrante", "Perguntas de apoio", "Exemplos de achados"],
+      "rows": [
+        [
+          "Forças",
+          "Quais capacidades tecnológicas já diferenciam o negócio?",
+          "Time ágil maduro, arquitetura em microserviços, governança de dados consolidada"
+        ],
+        [
+          "Fraquezas",
+          "Onde estão os principais gargalos internos?",
+          "Backlog represado, dependência de fornecedor único, automação limitada"
+        ],
+        [
+          "Oportunidades",
+          "Que movimentos de mercado podem ser acelerados com SI?",
+          "Open finance, parcerias com startups, analytics avançado"
+        ],
+        [
+          "Ameaças",
+          "Que riscos externos podem comprometer resultados?",
+          "Novos entrantes digitais, ataques cibernéticos, mudanças regulatórias"
+        ]
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Conexões do diagnóstico",
+      "summary": "Relaciona fatores internos e externos que influenciam decisões do PESI.",
+      "factors": [
+        {
+          "id": "capabilidades",
+          "name": "Capacidades de TI",
+          "summary": "Competências e ativos internos",
+          "kind": "resource",
+          "indicators": ["maturidade_devops", "cobertura_automacoes"]
+        },
+        {
+          "id": "demandas",
+          "name": "Demandas do negócio",
+          "summary": "Iniciativas estratégicas e OKRs",
+          "kind": "flow",
+          "indicators": ["okr_entregues", "nps_stakeholders"]
+        },
+        {
+          "id": "mercado",
+          "name": "Movimentos de mercado",
+          "summary": "Tendências e benchmark",
+          "kind": "external",
+          "indicators": ["participacao_digital", "indice_inovacao"]
+        },
+        {
+          "id": "riscos",
+          "name": "Riscos críticos",
+          "summary": "Ameaças regulatórias e cibernéticas",
+          "kind": "constraint",
+          "indicators": ["incidentes_criticos", "pendencias_auditoria"]
+        }
+      ],
+      "connections": [
+        {
+          "from": "capabilidades",
+          "to": "demandas",
+          "description": "Capacidades existentes viabilizam entregas prioritárias."
+        },
+        {
+          "from": "mercado",
+          "to": "demandas",
+          "description": "Movimentos externos redefinem prioridades de produto."
+        },
+        {
+          "from": "riscos",
+          "to": "capabilidades",
+          "description": "Fragilidades de segurança exigem investimentos estruturantes."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Roteiro de diagnóstico em 4 semanas",
+      "steps": [
+        {
+          "title": "Semana 1",
+          "content": "Coleta dados internos: inventários, custos e indicadores."
+        },
+        { "title": "Semana 2", "content": "Realiza entrevistas e jornadas com áreas de negócio." },
+        { "title": "Semana 3", "content": "Analisa tendências, concorrentes e riscos externos." },
+        {
+          "title": "Semana 4",
+          "content": "Consolida SWOT, prioriza achados e prepara workshop de validação."
+        }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Estudos recomendados",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/case-diagnostico-pesi",
+          "title": "Diagnóstico PESI em varejo",
+          "caption": "Como um varejista redesenhou seu portfólio após análise SWOT de TI."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/trends-ti-2025",
+          "title": "Tendências de tecnologia 2025",
+          "caption": "Painel Gartner sobre ameaças e oportunidades para CIOs."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 30 — SWOT individual",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Produza uma SWOT da área de SI da sua empresa ou de um estudo de caso, classificando ao menos três itens por quadrante e justificando cada evidência com dados coletados. Submeta até 48h após a aula."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-30-diagnostico-e-analise-swot-si",
+  "summary": "Explora ferramentas de diagnóstico e consolidação da análise SWOT aplicada a sistemas de informação.",
+  "objectives": [
+    "Identificar fontes e dados necessários para o diagnóstico do PESI.",
+    "Construir matriz SWOT alinhada à realidade de SI.",
+    "Priorizar achados críticos para a etapa de formulação."
+  ],
+  "competencies": ["Análise estratégica", "Gestão de riscos", "Comunicação executiva"],
+  "outcomes": [
+    "Entrega SWOT individual com evidências quantitativas e qualitativas.",
+    "Relaciona tendências externas às demandas de tecnologia.",
+    "Propõe prioridades para validação em workshop de diagnóstico."
+  ],
+  "prerequisites": [
+    "Concluir coleta inicial de dados iniciada na aula 29.",
+    "Rever indicadores de desempenho das áreas de negócio."
+  ],
+  "tags": ["diagnostico", "swot", "pesi"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Checklist de diagnóstico PESI",
+      "url": "https://example.edu/tgs/checklists/diagnostico-pesi",
+      "type": "checklist"
+    },
+    {
+      "label": "Template SWOT de SI",
+      "url": "https://example.edu/tgs/templates/swot-si",
+      "type": "template"
+    }
+  ],
+  "bibliography": [
+    "WARD, John; PEPPARD, Joe. Strategic Planning for Information Systems. Wiley, 2016.",
+    "GARTNER. IT Score for CIOs — Strategy & Execution. Gartner, 2024."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "SWOT individual fundamentada em dados reais ou simulados."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-03-10T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Toolkit Diagnóstico 2024"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-30.vue
+++ b/src/content/courses/tgs/lessons/lesson-30.vue
@@ -1,0 +1,16 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-30',
+  title: 'Aula 30: Diagnóstico e Análise SWOT do Ambiente de SI',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-30.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-31.json
+++ b/src/content/courses/tgs/lessons/lesson-31.json
@@ -1,0 +1,196 @@
+{
+  "id": "lesson-31",
+  "title": "Aula 31: Capabilidades Digitais e Portfólio de Processos",
+  "objective": "Avaliar capacidades internas de SI para orientar decisões do portfólio estratégico.",
+  "content": [
+    {
+      "type": "cardGrid",
+      "title": "Dimensões da capacidade digital",
+      "cards": [
+        {
+          "title": "Arquitetura",
+          "content": "Sistemas, integrações, dados e padrões que sustentam entregas."
+        },
+        {
+          "title": "Talentos",
+          "content": "Competências técnicas, soft skills e estruturas de squads."
+        },
+        {
+          "title": "Processos",
+          "content": "Ritos, governança de mudanças e automação de fluxos."
+        },
+        {
+          "title": "Cultura",
+          "content": "Abertura à experimentação, colaboração e aprendizado contínuo."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Matriz de criticidade dos processos",
+      "headers": ["Processo", "Impacto no negócio", "Saúde atual", "Observações"],
+      "rows": [
+        ["Onboarding de clientes", "Alta", "Baixa", "Integrações manuais geram atrasos de 48h"],
+        ["Fechamento financeiro", "Alta", "Média", "Dependência de planilhas fora do ERP"],
+        ["Gestão de estoque", "Média", "Alta", "Automação consolidada com IoT e WMS"],
+        [
+          "Suporte ao cliente",
+          "Alta",
+          "Baixa",
+          "Falta visão 360° e base de conhecimento unificada"
+        ],
+        ["Gestão de campanhas", "Média", "Média", "Ferramentas diversas sem governança comum"]
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Mapa de valor da SI",
+      "summary": "Relaciona capacidades internas com benefícios percebidos pelo negócio.",
+      "factors": [
+        {
+          "id": "dados",
+          "name": "Dados confiáveis",
+          "summary": "Governança e qualidade de dados",
+          "kind": "resource",
+          "indicators": ["qualidade_dados", "tempo_disponibilidade"]
+        },
+        {
+          "id": "experiencia",
+          "name": "Experiência do cliente",
+          "summary": "Omnicanalidade e personalização",
+          "kind": "outcome",
+          "indicators": ["nps", "taxa_conversao"]
+        },
+        {
+          "id": "eficiencia",
+          "name": "Eficiência operacional",
+          "summary": "Automação e redução de retrabalho",
+          "kind": "outcome",
+          "indicators": ["custo_operacional", "tempo_ciclo"]
+        },
+        {
+          "id": "inovacao",
+          "name": "Inovação contínua",
+          "summary": "Capacidade de experimentar e escalar",
+          "kind": "capability",
+          "indicators": ["experimentos_trimestre", "time_to_market"]
+        }
+      ],
+      "connections": [
+        {
+          "from": "dados",
+          "to": "experiencia",
+          "description": "Dados confiáveis habilitam personalização em escala."
+        },
+        {
+          "from": "dados",
+          "to": "eficiencia",
+          "description": "Padronização de dados reduz retrabalho e auditorias."
+        },
+        {
+          "from": "inovacao",
+          "to": "experiencia",
+          "description": "Experimentação gera novas jornadas digitais."
+        },
+        {
+          "from": "inovacao",
+          "to": "eficiencia",
+          "description": "Pilotos de automação são escalados para backoffice."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Sprint de imersão nas capacidades",
+      "steps": [
+        {
+          "title": "Dia 1",
+          "content": "Workshop com líderes de negócio para mapear processos críticos."
+        },
+        {
+          "title": "Dia 2",
+          "content": "Avaliação técnica de sistemas e integrações prioritárias."
+        },
+        { "title": "Dia 3", "content": "Análise de competências e dimensionamento de equipes." },
+        {
+          "title": "Dia 4",
+          "content": "Consolidação dos gaps e oportunidades em relatório executivo."
+        }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Casos para estudo",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/capacidades-digitais-industria",
+          "title": "Capacidades digitais em manufatura",
+          "caption": "Diagnóstico de TI que priorizou automação e analytics na linha de produção."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/portfolio-processos-servicos",
+          "title": "Rebalanceamento de portfólio em serviços",
+          "caption": "Como uma empresa de saúde digital reposicionou investimentos de TI."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 31 — Inventário comentado",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Atualize o inventário de processos e sistemas priorizados, incluindo nível de criticidade e riscos associados. Publique no fórum até 72h e comente em pelo menos um trabalho de colega."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-31-capacidades-digitais-e-portfolio",
+  "summary": "Aprofunda a avaliação das capacidades digitais internas e seu impacto no portfólio estratégico de SI.",
+  "objectives": [
+    "Mensurar criticidade de processos e sistemas sob a ótica de valor.",
+    "Relacionar capacidades digitais com benefícios esperados pelo negócio.",
+    "Preparar insumos para priorização de iniciativas do PESI."
+  ],
+  "competencies": ["Gestão de portfólio", "Arquitetura empresarial", "Colaboração interfuncional"],
+  "outcomes": [
+    "Classifica processos críticos com base em impacto e saúde atual.",
+    "Articula como capacidades digitais sustentam valor para clientes e operação.",
+    "Compartilha inventário atualizado em fórum de prática."
+  ],
+  "prerequisites": [
+    "Trazer resultados preliminares da SWOT (aula 30).",
+    "Disponibilizar indicadores de desempenho dos processos avaliados."
+  ],
+  "tags": ["capacidades-digitais", "portfolio", "planejamento"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Template de matriz de criticidade",
+      "url": "https://example.edu/tgs/templates/matriz-criticidade",
+      "type": "template"
+    },
+    {
+      "label": "Guia de entrevistas com stakeholders",
+      "url": "https://example.edu/tgs/guides/entrevistas-stakeholders",
+      "type": "guide"
+    }
+  ],
+  "bibliography": [
+    "ROSS, Jeanne et al. Designed for Digital. MIT Press, 2019.",
+    "BCG. Digital Acceleration Index 2024. Boston Consulting Group, 2024."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Inventário comentado com criticidade e riscos dos processos prioritários."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-03-10T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Playbook Capacidades Digitais 2024"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-31.vue
+++ b/src/content/courses/tgs/lessons/lesson-31.vue
@@ -1,0 +1,16 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-31',
+  title: 'Aula 31: Capabilidades Digitais e Portfólio de Processos',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-31.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-32.json
+++ b/src/content/courses/tgs/lessons/lesson-32.json
@@ -1,0 +1,199 @@
+{
+  "id": "lesson-32",
+  "title": "Aula 32: Objetivos Estratégicos e Balanced Scorecard de SI",
+  "objective": "Construir objetivos, indicadores e iniciativas do Balanced Scorecard aplicado a SI.",
+  "content": [
+    {
+      "type": "cardGrid",
+      "title": "Perspectivas do BSC de SI",
+      "cards": [
+        {
+          "title": "Financeira",
+          "content": "Valor entregue por TI, otimização de custos e retorno de investimentos."
+        },
+        {
+          "title": "Clientes",
+          "content": "Experiência dos usuários finais e satisfação das áreas de negócio."
+        },
+        {
+          "title": "Processos internos",
+          "content": "Eficiência, confiabilidade e segurança dos serviços de TI."
+        },
+        {
+          "title": "Aprendizado e inovação",
+          "content": "Capacitação, cultura ágil e adoção de novas tecnologias."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Exemplo de mapa de objetivos",
+      "headers": ["Perspectiva", "Objetivo", "Indicador", "Meta 2025"],
+      "rows": [
+        ["Financeira", "Reduzir custo por transação digital", "Custo médio por transação", "-15%"],
+        ["Clientes", "Elevar NPS das soluções digitais", "NPS digital", ">= 65"],
+        [
+          "Processos internos",
+          "Aumentar disponibilidade crítica",
+          "Disponibilidade 24x7",
+          ">= 99,8%"
+        ],
+        ["Processos internos", "Reduzir tempo de entrega", "Lead time de squads", "-25%"],
+        [
+          "Aprendizado e inovação",
+          "Escalar competências em analytics",
+          "% equipes certificadas",
+          ">= 70%"
+        ],
+        ["Aprendizado e inovação", "Fomentar inovação aberta", "Provas de conceito/ano", ">= 6"]
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Mapa estratégico simplificado",
+      "summary": "Ilustra relações de causa e efeito entre objetivos do BSC de SI.",
+      "factors": [
+        {
+          "id": "capacitacao",
+          "name": "Capacitação analítica",
+          "summary": "Treinamentos e comunidades",
+          "kind": "capability",
+          "indicators": ["certificacoes"]
+        },
+        {
+          "id": "automacao",
+          "name": "Automação de processos",
+          "summary": "Plataformas low-code e RPA",
+          "kind": "flow",
+          "indicators": ["processos_automatizados"]
+        },
+        {
+          "id": "experiencia_cliente",
+          "name": "Experiência digital",
+          "summary": "Jornadas omnicanal",
+          "kind": "outcome",
+          "indicators": ["nps_digital"]
+        },
+        {
+          "id": "eficiencia_custo",
+          "name": "Eficiência de custos",
+          "summary": "Uso racional de infraestrutura",
+          "kind": "outcome",
+          "indicators": ["custo_transacao"]
+        }
+      ],
+      "connections": [
+        {
+          "from": "capacitacao",
+          "to": "automacao",
+          "description": "Equipes capacitadas implementam automação com menor retrabalho."
+        },
+        {
+          "from": "automacao",
+          "to": "experiencia_cliente",
+          "description": "Automação reduz fricção e erros em jornadas digitais."
+        },
+        {
+          "from": "automacao",
+          "to": "eficiencia_custo",
+          "description": "Automação otimiza uso de infraestrutura e licenças."
+        },
+        {
+          "from": "capacitacao",
+          "to": "experiencia_cliente",
+          "description": "Competências analíticas melhoram personalização."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Workshop de formulação do BSC",
+      "steps": [
+        { "title": "Pré-work", "content": "Consolide SWOT e matriz de capacidades como insumo." },
+        {
+          "title": "Sessão 1",
+          "content": "Definir objetivos por perspectiva com patrocínio executivo."
+        },
+        { "title": "Sessão 2", "content": "Selecionar indicadores e metas realistas." },
+        {
+          "title": "Sessão 3",
+          "content": "Priorizar iniciativas estratégicas e donos dos objetivos."
+        }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Referências em vídeo",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/bsc-ti-servicos",
+          "title": "Balanced Scorecard em empresa de serviços",
+          "caption": "Case sobre alinhamento entre diretoria de TI e conselho."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/mapa-estrategico-data-driven",
+          "title": "Mapa estratégico para jornada data-driven",
+          "caption": "Discussão sobre indicadores e governança de métricas."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 32 — Mapa estratégico de SI",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Construa um mapa estratégico visual com objetivos, indicadores e relações de causa e efeito para a área de SI. Utilize o template disponibilizado e poste no fórum para feedback cruzado."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-32-objetivos-e-balanced-scorecard-si",
+  "summary": "Traduz a análise estratégica em objetivos, indicadores e iniciativas no formato Balanced Scorecard.",
+  "objectives": [
+    "Transformar achados do diagnóstico em objetivos estratégicos de SI.",
+    "Selecionar indicadores e metas alinhados às perspectivas do BSC.",
+    "Visualizar relações de causa e efeito no mapa estratégico de TI."
+  ],
+  "competencies": ["Gestão estratégica de TI", "Medição de desempenho", "Facilitação executiva"],
+  "outcomes": [
+    "Propõe objetivos de SI alinhados ao negócio.",
+    "Define indicadores e metas realistas para cada perspectiva.",
+    "Publica mapa estratégico visual para discussão coletiva."
+  ],
+  "prerequisites": [
+    "Ter SWOT e inventário de capacidades consolidados (aulas 30 e 31).",
+    "Revisar metas corporativas vigentes."
+  ],
+  "tags": ["balanced-scorecard", "objetivos", "planejamento"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Template de mapa estratégico",
+      "url": "https://example.edu/tgs/templates/mapa-estrategico",
+      "type": "template"
+    },
+    {
+      "label": "Guia de indicadores de TI",
+      "url": "https://example.edu/tgs/guides/indicadores-ti",
+      "type": "guide"
+    }
+  ],
+  "bibliography": [
+    "KAPLAN, Robert; NORTON, David. Mapas Estratégicos. Elsevier, 2004.",
+    "ISACA. COBIT Focus: Aligning BSC with Governance Objectives. ISACA, 2023."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Mapa estratégico de SI publicado em fórum para peer review."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-03-10T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Playbook BSC TI 2024"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-32.vue
+++ b/src/content/courses/tgs/lessons/lesson-32.vue
@@ -1,0 +1,16 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-32',
+  title: 'Aula 32: Objetivos Estratégicos e Balanced Scorecard de SI',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-32.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-33.json
+++ b/src/content/courses/tgs/lessons/lesson-33.json
@@ -1,0 +1,198 @@
+{
+  "id": "lesson-33",
+  "title": "Aula 33: Priorização e Roadmap do Plano Estratégico de SI",
+  "objective": "Transformar objetivos estratégicos em um roadmap priorizado de iniciativas de SI.",
+  "content": [
+    {
+      "type": "cardGrid",
+      "title": "Critérios de priorização",
+      "cards": [
+        {
+          "title": "Valor estratégico",
+          "content": "Contribuição direta aos objetivos do BSC e KPIs corporativos."
+        },
+        {
+          "title": "Urgência regulatória",
+          "content": "Prazos legais ou riscos de continuidade se não executar."
+        },
+        {
+          "title": "Viabilidade",
+          "content": "Disponibilidade de recursos, maturidade tecnológica e complexidade."
+        },
+        {
+          "title": "Dependências",
+          "content": "Sequência lógica entre iniciativas e impactos em programas correlatos."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Matriz de pontuação",
+      "headers": ["Iniciativa", "Valor", "Urgência", "Esforço", "Score ponderado"],
+      "rows": [
+        ["Plataforma de dados corporativos", "5", "4", "3", "4,4"],
+        ["Portal omnicanal", "4", "5", "4", "4,2"],
+        ["Automação de backoffice", "3", "3", "2", "3,2"],
+        ["Programa de cibersegurança", "5", "5", "4", "4,8"],
+        ["ERP financeiro-cloud", "4", "4", "5", "4,0"]
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Roadmap macro (12 trimestres)",
+      "steps": [
+        {
+          "title": "T1-T2",
+          "content": "Quick wins regulatórios e fundação de governança de dados."
+        },
+        {
+          "title": "T3-T4",
+          "content": "Entrega da primeira onda da plataforma de dados e pilotos omnicanal."
+        },
+        {
+          "title": "T5-T6",
+          "content": "Implantação do programa de cibersegurança e automações críticas."
+        },
+        {
+          "title": "T7-T8",
+          "content": "Rollout do ERP financeiro-cloud e expansão dos casos de analytics."
+        },
+        {
+          "title": "T9-T12",
+          "content": "Escala das jornadas digitais e revisão estratégica do portfólio."
+        }
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Carteira integrada",
+      "summary": "Visualiza dependências chave entre iniciativas prioritárias.",
+      "factors": [
+        {
+          "id": "dados_plataforma",
+          "name": "Plataforma de dados",
+          "summary": "Lago corporativo e catálogo",
+          "kind": "resource",
+          "indicators": ["datasets_publicados"]
+        },
+        {
+          "id": "omni",
+          "name": "Omnicanalidade",
+          "summary": "Portal e apps unificados",
+          "kind": "outcome",
+          "indicators": ["clientes_ativos"]
+        },
+        {
+          "id": "seguranca",
+          "name": "Cibersegurança",
+          "summary": "Controles e conformidade",
+          "kind": "constraint",
+          "indicators": ["incidentes_severos"]
+        },
+        {
+          "id": "erp",
+          "name": "ERP Cloud",
+          "summary": "Plataforma financeira e compliance",
+          "kind": "resource",
+          "indicators": ["processos_migrados"]
+        }
+      ],
+      "connections": [
+        {
+          "from": "dados_plataforma",
+          "to": "omni",
+          "description": "Dados consistentes alimentam personalização."
+        },
+        {
+          "from": "seguranca",
+          "to": "dados_plataforma",
+          "description": "Controles definem padrões de acesso e criptografia."
+        },
+        {
+          "from": "erp",
+          "to": "dados_plataforma",
+          "description": "Integrações financeiras alimentam indicadores estratégicos."
+        },
+        {
+          "from": "seguranca",
+          "to": "omni",
+          "description": "Camadas de proteção garantem confiança do cliente."
+        }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Casos de roadmap",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/roadmap-ti-financas",
+          "title": "Roadmap de TI em serviços financeiros",
+          "caption": "Sequenciamento de 12 trimestres em banco digital."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/priorizacao-portfolio-ti",
+          "title": "Priorização com value scoring",
+          "caption": "Aplicação prática da matriz de pontuação."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 33 — Roadmap trimestral",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Produza um roadmap em trimestres para as cinco principais iniciativas de SI, incluindo dependências e quick wins. Publique no mural do curso e comente coerência de pelo menos dois colegas."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-33-priorizacao-e-roadmap-pesi",
+  "summary": "Converte objetivos estratégicos em um roadmap priorizado com visão integrada do portfólio de SI.",
+  "objectives": [
+    "Definir critérios de priorização alinhados a valor e risco.",
+    "Construir roadmap plurianual conectando iniciativas e dependências.",
+    "Preparar comunicação executiva sobre sequenciamento do PESI."
+  ],
+  "competencies": ["Gestão de portfólio", "Planejamento tático", "Gestão de stakeholders"],
+  "outcomes": [
+    "Aplica matriz de pontuação para ordenar iniciativas.",
+    "Elabora roadmap com entregas e marcos trimestrais.",
+    "Comunica dependências críticas para patrocínio executivo."
+  ],
+  "prerequisites": [
+    "Mapa estratégico aprovado na aula 32.",
+    "Disponibilidade de estimativas de esforço e custos."
+  ],
+  "tags": ["roadmap", "priorizacao", "pesi"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Planilha de scoring",
+      "url": "https://example.edu/tgs/templates/matriz-scoring",
+      "type": "template"
+    },
+    {
+      "label": "Canvas de roadmap trimestral",
+      "url": "https://example.edu/tgs/templates/roadmap-trimestral",
+      "type": "template"
+    }
+  ],
+  "bibliography": [
+    "PMI. Standard for Portfolio Management. Project Management Institute, 2023.",
+    "MCKINSEY. Orchestrating Technology Roadmaps. McKinsey, 2024."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Roadmap trimestral publicado com feedback colaborativo."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-03-10T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Toolkit Roadmap 2024"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-33.vue
+++ b/src/content/courses/tgs/lessons/lesson-33.vue
@@ -1,0 +1,16 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-33',
+  title: 'Aula 33: Priorização e Roadmap do Plano Estratégico de SI',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-33.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-34.json
+++ b/src/content/courses/tgs/lessons/lesson-34.json
@@ -1,0 +1,204 @@
+{
+  "id": "lesson-34",
+  "title": "Aula 34: Governança e Alinhamento Estratégico SI-Negócio",
+  "objective": "Estabelecer mecanismos de governança que sustentem o alinhamento contínuo entre SI e estratégia corporativa.",
+  "content": [
+    {
+      "type": "cardGrid",
+      "title": "Pilares de governança",
+      "cards": [
+        { "title": "Estruturas", "content": "Comitês, fóruns e papéis que conectam negócio e TI." },
+        {
+          "title": "Processos",
+          "content": "Ritos de priorização, gestão de demanda e avaliação de benefícios."
+        },
+        {
+          "title": "Pessoas",
+          "content": "Patrocinadores, product owners e gestores de relacionamento."
+        },
+        {
+          "title": "Tecnologia",
+          "content": "Plataformas colaborativas, OKRs e dashboards compartilhados."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Fóruns de decisão",
+      "headers": ["Fórum", "Periodicidade", "Decisões", "Indicadores"],
+      "rows": [
+        [
+          "Conselho Digital",
+          "Mensal",
+          "Direcionadores estratégicos e investimentos",
+          "ROI carteira, risco tecnológico"
+        ],
+        [
+          "Comitê de Portfólio",
+          "Quinzenal",
+          "Priorização e balanceamento da carteira",
+          "Valor entregue, capacidade disponível"
+        ],
+        [
+          "Tribo de Produto",
+          "Semanal",
+          "Status das iniciativas e impedimentos",
+          "Lead time, valor gerado"
+        ],
+        [
+          "Fórum de Operações",
+          "Diário",
+          "Gestão de incidentes e disponibilidade",
+          "SLA, backlog crítico"
+        ]
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Fluxo de alinhamento",
+      "summary": "Mostra como demandas chegam, são avaliadas e transformadas em valor.",
+      "factors": [
+        {
+          "id": "demandas_negocio",
+          "name": "Demandas de negócio",
+          "summary": "OKRs e propostas",
+          "kind": "flow",
+          "indicators": ["demandas_registradas"]
+        },
+        {
+          "id": "avaliacao",
+          "name": "Avaliação de portfólio",
+          "summary": "Modelos de priorização",
+          "kind": "constraint",
+          "indicators": ["tempo_decisao"]
+        },
+        {
+          "id": "entrega",
+          "name": "Entrega de valor",
+          "summary": "Squads e PMOs",
+          "kind": "flow",
+          "indicators": ["valor_entregue"]
+        },
+        {
+          "id": "beneficios",
+          "name": "Realização de benefícios",
+          "summary": "Monitoramento pós-implementação",
+          "kind": "outcome",
+          "indicators": ["beneficios_realizados"]
+        }
+      ],
+      "connections": [
+        {
+          "from": "demandas_negocio",
+          "to": "avaliacao",
+          "description": "Demandas formalizadas são avaliadas com critérios comuns."
+        },
+        {
+          "from": "avaliacao",
+          "to": "entrega",
+          "description": "Itens aprovados entram no backlog priorizado."
+        },
+        {
+          "from": "entrega",
+          "to": "beneficios",
+          "description": "Resultados monitorados fecham o ciclo de alinhamento."
+        },
+        {
+          "from": "beneficios",
+          "to": "demandas_negocio",
+          "description": "Lições aprendidas inspiram novas demandas e ajustes."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Ritos de relacionamento SI-negócio",
+      "steps": [
+        {
+          "title": "Diariamente",
+          "content": "Dailies operacionais com presença de representantes de negócio."
+        },
+        {
+          "title": "Semanalmente",
+          "content": "Revisão de backlog integrado e indicadores de squads."
+        },
+        { "title": "Mensalmente", "content": "Comitê executivo revisa roadmap e aprova ajustes." },
+        { "title": "Trimestralmente", "content": "Planejamento integrado e recalibração dos OKRs." }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Governança na prática",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/governanca-si-negocio",
+          "title": "Modelo de governança em indústria",
+          "caption": "Integração de SI com PMO corporativo."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/okrs-ti-case",
+          "title": "OKRs compartilhados",
+          "caption": "Como TI e negócio co-criam metas e cadências."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 34 — Fórum de alinhamento",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Desenhe a proposta de um fórum de alinhamento SI-negócio para sua realidade, definindo propósito, participantes, cadência e indicadores. Submeta na plataforma e discuta no fórum com o time de governança."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-34-governanca-e-alinhamento-si-negocio",
+  "summary": "Define estruturas e ritos de governança que mantêm SI alinhado ao negócio e asseguram geração de valor contínua.",
+  "objectives": [
+    "Configurar fóruns e papéis que sustentam o alinhamento SI-negócio.",
+    "Estabelecer cadências e indicadores para monitorar execução do PESI.",
+    "Integrar lições aprendidas e benefícios ao ciclo de planejamento."
+  ],
+  "competencies": ["Governança de TI", "Gestão de stakeholders", "Liderança colaborativa"],
+  "outcomes": [
+    "Apresenta proposta de fórum de alinhamento contextualizada.",
+    "Relaciona indicadores de governança aos objetivos estratégicos.",
+    "Implementa cadências de acompanhamento conjunto."
+  ],
+  "prerequisites": [
+    "Roadmap preliminar definido na aula 33.",
+    "Patrocinadores identificados e comprometidos."
+  ],
+  "tags": ["governanca", "alinhamento", "planejamento"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Modelo de charter de comitê",
+      "url": "https://example.edu/tgs/templates/charter-comite",
+      "type": "template"
+    },
+    {
+      "label": "Guia de OKRs compartilhados",
+      "url": "https://example.edu/tgs/guides/okrs-compartilhados",
+      "type": "guide"
+    }
+  ],
+  "bibliography": [
+    "ISACA. COBIT 2019 Framework. ISACA, 2019.",
+    "MIT CISR. Achieving Business Outcomes with IT. MIT, 2023."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Proposta de fórum de alinhamento SI-negócio com indicadores e cadência."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-03-10T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Guia Governança Integrada 2024"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-34.vue
+++ b/src/content/courses/tgs/lessons/lesson-34.vue
@@ -1,0 +1,16 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-34',
+  title: 'Aula 34: Governança e Alinhamento Estratégico SI-Negócio',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-34.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-35.json
+++ b/src/content/courses/tgs/lessons/lesson-35.json
@@ -1,0 +1,198 @@
+{
+  "id": "lesson-35",
+  "title": "Aula 35: Indicadores, OKRs e Monitoramento do PESI",
+  "objective": "Definir métricas e ritos de monitoramento que assegurem a execução do planejamento estratégico de SI.",
+  "content": [
+    {
+      "type": "cardGrid",
+      "title": "Painéis essenciais",
+      "cards": [
+        { "title": "Valor entregue", "content": "Indicadores de benefícios, adoção e satisfação." },
+        { "title": "Saúde operacional", "content": "SLA, disponibilidade, backlog e incidentes." },
+        { "title": "Capacidade", "content": "Velocidade das equipes, alocação e burn-down." },
+        { "title": "Inovação", "content": "Experimentos, pilotos em andamento e taxa de sucesso." }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "OKRs exemplo",
+      "headers": ["Objetivo", "Resultado-chave", "Indicador", "Frequência"],
+      "rows": [
+        [
+          "Maximizar valor das soluções digitais",
+          "Aumentar NPS digital de 58 para 70",
+          "NPS",
+          "Mensal"
+        ],
+        [
+          "Maximizar valor das soluções digitais",
+          "Elevar adoção ativa para 80% dos clientes",
+          "% clientes ativos",
+          "Mensal"
+        ],
+        [
+          "Garantir estabilidade crítica",
+          "Reduzir incidentes severos de 12 para 4",
+          "Incidentes críticos",
+          "Semanal"
+        ],
+        [
+          "Acelerar entregas",
+          "Reduzir lead time médio de 16 para 12 dias",
+          "Lead time",
+          "Quinzenal"
+        ],
+        [
+          "Fortalecer inovação",
+          "Executar 8 pilotos com ROI validado",
+          "Pilotos concluídos",
+          "Trimestral"
+        ]
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Cadeia de dados para monitoramento",
+      "summary": "Fluxo de dados do registro à decisão executiva.",
+      "factors": [
+        {
+          "id": "coleta",
+          "name": "Coleta",
+          "summary": "Eventos e logs operacionais",
+          "kind": "flow",
+          "indicators": ["latencia_dados"]
+        },
+        {
+          "id": "qualidade",
+          "name": "Qualidade",
+          "summary": "Tratamento, deduplicação e catalogação",
+          "kind": "constraint",
+          "indicators": ["dados_conformes"]
+        },
+        {
+          "id": "visualizacao",
+          "name": "Visualização",
+          "summary": "Dashboards e alertas",
+          "kind": "resource",
+          "indicators": ["dashboards_publicados"]
+        },
+        {
+          "id": "decisao",
+          "name": "Decisão",
+          "summary": "Comitês e OKRs",
+          "kind": "outcome",
+          "indicators": ["acoes_derivadas"]
+        }
+      ],
+      "connections": [
+        {
+          "from": "coleta",
+          "to": "qualidade",
+          "description": "Dados coletados passam por esteiras de validação."
+        },
+        {
+          "from": "qualidade",
+          "to": "visualizacao",
+          "description": "Somente dados conformes alimentam painéis oficiais."
+        },
+        {
+          "from": "visualizacao",
+          "to": "decisao",
+          "description": "Painéis atualizados geram decisões e planos de ação."
+        },
+        {
+          "from": "decisao",
+          "to": "coleta",
+          "description": "Novas decisões ajustam eventos monitorados."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Ritos de acompanhamento",
+      "steps": [
+        { "title": "Semanal", "content": "Squads atualizam progresso dos resultados-chave." },
+        { "title": "Quinzenal", "content": "Review de portfólio verifica capacidade e riscos." },
+        {
+          "title": "Mensal",
+          "content": "Comitê executivo avalia desvios e aprova ajustes de roadmap."
+        },
+        { "title": "Trimestral", "content": "Replanejamento de OKRs e lições aprendidas." }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Medição em destaque",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/okr-ti-case",
+          "title": "OKRs em organização pública",
+          "caption": "Como conectar indicadores de TI a metas de governo digital."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/observabilidade-produto",
+          "title": "Observabilidade orientada a produto",
+          "caption": "Uso de telemetria para decisões estratégicas."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 35 — Painel executivo",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Desenhe um painel executivo com três indicadores críticos para acompanhar o PESI. Detalhe fonte de dados, periodicidade e responsável pela atualização."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-35-indicadores-okrs-monitoramento",
+  "summary": "Estabelece métricas, OKRs e ritos de monitoramento para garantir execução e aprendizado contínuo do PESI.",
+  "objectives": [
+    "Selecionar indicadores e OKRs coerentes com o mapa estratégico.",
+    "Estruturar cadeia de dados que suporte monitoramento confiável.",
+    "Definir ritos de acompanhamento e responsabilidade pela atualização."
+  ],
+  "competencies": ["Gestão orientada a dados", "OKR e métricas", "Governança de informação"],
+  "outcomes": [
+    "Apresenta painel executivo com indicadores priorizados.",
+    "Descreve cadeia de dados e responsabilidades de monitoramento.",
+    "Integra ritos de acompanhamento à governança definida."
+  ],
+  "prerequisites": [
+    "Roadmap e fóruns aprovados (aulas 33 e 34).",
+    "Acesso às fontes de dados relevantes."
+  ],
+  "tags": ["indicadores", "okr", "monitoramento"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Template de painel executivo",
+      "url": "https://example.edu/tgs/templates/painel-executivo",
+      "type": "template"
+    },
+    {
+      "label": "Guia de OKRs para TI",
+      "url": "https://example.edu/tgs/guides/okr-ti",
+      "type": "guide"
+    }
+  ],
+  "bibliography": [
+    "DOERR, John. Avalie o Que Importa. Companhia das Letras, 2018.",
+    "FORRESTER. Metrics That Matter for CIOs. Forrester, 2024."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Painel executivo com indicadores, fontes e responsáveis."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-03-10T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Guia Métricas TI 2024"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-35.vue
+++ b/src/content/courses/tgs/lessons/lesson-35.vue
@@ -1,0 +1,16 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-35',
+  title: 'Aula 35: Indicadores, OKRs e Monitoramento do PESI',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-35.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-36.json
+++ b/src/content/courses/tgs/lessons/lesson-36.json
@@ -1,0 +1,216 @@
+{
+  "id": "lesson-36",
+  "title": "Aula 36: Transformação Digital e Tendências Emergentes",
+  "objective": "Explorar tendências tecnológicas e seu impacto no planejamento estratégico de SI.",
+  "content": [
+    {
+      "type": "cardGrid",
+      "title": "Macro tendências 2025-2028",
+      "cards": [
+        {
+          "title": "Plataformas de dados confiáveis",
+          "content": "Zero trust, governança automatizada e mesh de dados."
+        },
+        {
+          "title": "IA generativa aplicada",
+          "content": "Automação de decisões, copilotos e interfaces conversacionais."
+        },
+        {
+          "title": "Experiências imersivas",
+          "content": "Metaverso corporativo, realidade aumentada em operações."
+        },
+        {
+          "title": "Sustentabilidade digital",
+          "content": "Green IT, medição de carbono e circularidade de hardware."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Radar tecnológico",
+      "headers": ["Tendência", "Horizonte", "Oportunidades", "Riscos"],
+      "rows": [
+        [
+          "IA generativa",
+          "0-18 meses",
+          "Automação de atendimento, suporte a desenvolvedores",
+          "Viés algorítmico, segurança de dados"
+        ],
+        [
+          "Digital twin de operações",
+          "18-36 meses",
+          "Otimização de ativos físicos, simulação",
+          "Investimento alto, integração complexa"
+        ],
+        [
+          "Realidade aumentada",
+          "18-36 meses",
+          "Treinamento imersivo, manutenção remota",
+          "Adoção cultural, devices"
+        ],
+        [
+          "Computação quântica",
+          "36-60 meses",
+          "Criptografia pós-quântica, novas capacidades analíticas",
+          "Imaturidade tecnológica, custos"
+        ],
+        [
+          "Green cloud",
+          "0-24 meses",
+          "Redução de carbono, compliance ESG",
+          "Necessidade de métricas confiáveis"
+        ]
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Ecossistema de inovação",
+      "summary": "Relaciona atores e fluxos necessários para incorporar tendências ao PESI.",
+      "factors": [
+        {
+          "id": "labs",
+          "name": "Laboratórios internos",
+          "summary": "Equipes de pesquisa aplicada",
+          "kind": "capability",
+          "indicators": ["provas_conceito"]
+        },
+        {
+          "id": "partners",
+          "name": "Parceiros externos",
+          "summary": "Startups, universidades",
+          "kind": "external",
+          "indicators": ["parcerias_ativas"]
+        },
+        {
+          "id": "governanca",
+          "name": "Governança de inovação",
+          "summary": "Comitês, funding",
+          "kind": "constraint",
+          "indicators": ["budget_inovacao"]
+        },
+        {
+          "id": "negocio",
+          "name": "Áreas de negócio",
+          "summary": "Patrocínio e pilotos",
+          "kind": "flow",
+          "indicators": ["pilotos_negocio"]
+        }
+      ],
+      "connections": [
+        {
+          "from": "labs",
+          "to": "partners",
+          "description": "Labs conectam pesquisas a parceiros especializados."
+        },
+        {
+          "from": "partners",
+          "to": "negocio",
+          "description": "Parcerias aceleram pilotos em áreas de negócio."
+        },
+        {
+          "from": "governanca",
+          "to": "labs",
+          "description": "Governança define critérios e orçamento dos experimentos."
+        },
+        {
+          "from": "negocio",
+          "to": "governanca",
+          "description": "Resultados dos pilotos influenciam priorização futura."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Trilha de maturidade digital",
+      "steps": [
+        {
+          "title": "Fase 1",
+          "content": "Explorar tendências com pilotos controlados e métricas claras."
+        },
+        { "title": "Fase 2", "content": "Escalar soluções com arquitetura modular e governança." },
+        {
+          "title": "Fase 3",
+          "content": "Integrar novas capacidades ao core e às jornadas do cliente."
+        },
+        {
+          "title": "Fase 4",
+          "content": "Realizar revisão estratégica para novas ondas de inovação."
+        }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Panorama de tendências",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/trends-gartner-2025",
+          "title": "Gartner Top Strategic Technology Trends",
+          "caption": "Resumo executivo das principais tendências."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/case-ia-generativa",
+          "title": "Case IA generativa em seguros",
+          "caption": "Como a seguradora Sirius aplicou copilotos a processos de sinistro."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 36 — Radar de tendências",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Monte um radar de tendências personalizado com quatro iniciativas prioritárias e avaliação de impacto, esforço e horizonte. Publique no fórum e compare com colegas de outros setores."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-36-transformacao-digital-e-tendencias",
+  "summary": "Discute tendências emergentes e como incorporá-las ao planejamento estratégico de SI via ecossistemas de inovação.",
+  "objectives": [
+    "Identificar tendências tecnológicas relevantes para o PESI.",
+    "Avaliar impactos e riscos associados a cada tendência.",
+    "Planejar mecanismos de inovação para absorver novas capacidades."
+  ],
+  "competencies": ["Foresight tecnológico", "Gestão de inovação", "Planejamento estratégico"],
+  "outcomes": [
+    "Produz radar de tendências com priorização contextualizada.",
+    "Descreve como parceiros e labs contribuem para adoção tecnológica.",
+    "Integra tendências ao roadmap de maturidade digital."
+  ],
+  "prerequisites": [
+    "Conhecer objetivos e roadmap do PESI (aulas 32 e 33).",
+    "Ter mapeamento de capacidades e gaps atualizado."
+  ],
+  "tags": ["tendencias", "transformacao-digital", "inovacao"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Template de radar de tendências",
+      "url": "https://example.edu/tgs/templates/radar-tendencias",
+      "type": "template"
+    },
+    {
+      "label": "Relatório Gartner 2025",
+      "url": "https://example.edu/tgs/reports/gartner-2025",
+      "type": "report"
+    }
+  ],
+  "bibliography": [
+    "GARTNER. Top Strategic Technology Trends 2025. Gartner, 2025.",
+    "ACCENTURE. Technology Vision 2025. Accenture, 2025."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Radar de tendências com análise de impacto e horizonte."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-03-10T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Radar de Tendências 2025"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-36.vue
+++ b/src/content/courses/tgs/lessons/lesson-36.vue
@@ -1,0 +1,16 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-36',
+  title: 'Aula 36: Transformação Digital e Tendências Emergentes',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-36.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-37.json
+++ b/src/content/courses/tgs/lessons/lesson-37.json
@@ -1,0 +1,201 @@
+{
+  "id": "lesson-37",
+  "title": "Aula 37: Planejamento por Cenários e Futuros de SI",
+  "objective": "Aplicar técnicas de foresight para projetar futuros possíveis e implicações para o PESI.",
+  "content": [
+    {
+      "type": "cardGrid",
+      "title": "Elementos do foresight",
+      "cards": [
+        {
+          "title": "Sinais fracos",
+          "content": "Indícios emergentes que sugerem mudanças futuras."
+        },
+        {
+          "title": "Forças motrizes",
+          "content": "Tendências macroeconômicas, tecnológicas e sociais."
+        },
+        {
+          "title": "Incertezas críticas",
+          "content": "Variáveis de alto impacto e difícil previsão."
+        },
+        {
+          "title": "Narrativas",
+          "content": "Histórias que conectam eventos e guiam decisões estratégicas."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Matriz 2x2 de cenários",
+      "headers": ["Cenário", "Descrição", "Implicações para SI", "Alertas precoces"],
+      "rows": [
+        [
+          "Regulado & Estável",
+          "Mercado com regulação forte e baixa disrupção",
+          "Foco em compliance e eficiência",
+          "Novas normas, auditorias frequentes"
+        ],
+        [
+          "Regulado & Disruptivo",
+          "Regulação rígida e mudanças tecnológicas rápidas",
+          "Necessidade de inovação segura",
+          "Sandbox regulatórios, startups licenciadas"
+        ],
+        [
+          "Livre & Estável",
+          "Ambiente competitivo com poucas barreiras",
+          "Escala de produtos digitais",
+          "Entrada de players globais"
+        ],
+        [
+          "Livre & Disruptivo",
+          "Mercado aberto e alta velocidade de inovação",
+          "Portfólio flexível e parcerias",
+          "Investimentos massivos em IA e dados"
+        ]
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Sequência de construção de cenários",
+      "steps": [
+        { "title": "Etapa 1", "content": "Coleta sinais e tendências com especialistas." },
+        { "title": "Etapa 2", "content": "Define forças motrizes e incertezas críticas." },
+        { "title": "Etapa 3", "content": "Constrói matrizes de cenários e narrativas." },
+        { "title": "Etapa 4", "content": "Extrai implicações para portfólio e riscos." }
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Matriz de respostas estratégicas",
+      "summary": "Mapeia gatilhos de mudança e planos de resposta do PESI.",
+      "factors": [
+        {
+          "id": "gatilhos",
+          "name": "Gatilhos",
+          "summary": "Eventos monitorados",
+          "kind": "constraint",
+          "indicators": ["alertas_ativos"]
+        },
+        {
+          "id": "portfolio",
+          "name": "Portfólio adaptativo",
+          "summary": "Backlog flexível",
+          "kind": "flow",
+          "indicators": ["iniciativas_repriorizadas"]
+        },
+        {
+          "id": "investimentos",
+          "name": "Investimentos",
+          "summary": "Capex e Opex",
+          "kind": "resource",
+          "indicators": ["budget_disponivel"]
+        },
+        {
+          "id": "competencias",
+          "name": "Competências futuras",
+          "summary": "Upskilling e talento",
+          "kind": "capability",
+          "indicators": ["talentos_formados"]
+        }
+      ],
+      "connections": [
+        {
+          "from": "gatilhos",
+          "to": "portfolio",
+          "description": "Gatilhos acionam repriorização do backlog."
+        },
+        {
+          "from": "investimentos",
+          "to": "portfolio",
+          "description": "Realocação de orçamento viabiliza respostas."
+        },
+        {
+          "from": "competencias",
+          "to": "portfolio",
+          "description": "Competências futuras permitem executar novos planos."
+        },
+        {
+          "from": "portfolio",
+          "to": "investimentos",
+          "description": "Novas prioridades demandam redistribuição de budget."
+        }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Futuros de SI",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/foresight-ti",
+          "title": "Foresight em TI",
+          "caption": "Metodologia de construção de cenários em empresas globais."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/cenarios-publico-2030",
+          "title": "Cenários 2030 no setor público",
+          "caption": "Planejamento estratégico de TI para governo digital."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 37 — Narrativa 2030",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Escreva uma narrativa de cenário para 2030 considerando incertezas críticas do seu setor e detalhe três implicações para o PESI. Compartilhe em documento colaborativo para debate síncrono."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-37-planejamento-por-cenarios-e-futuros",
+  "summary": "Aplica foresight ao planejamento estratégico de SI, criando cenários e planos de resposta adaptativos.",
+  "objectives": [
+    "Utilizar ferramentas de foresight para identificar futuros plausíveis.",
+    "Derivar implicações estratégicas para SI a partir de cenários.",
+    "Planejar respostas adaptativas diante de gatilhos e incertezas."
+  ],
+  "competencies": ["Planejamento por cenários", "Gestão de riscos", "Pensamento crítico"],
+  "outcomes": [
+    "Produz matriz de cenários com implicações de SI.",
+    "Define gatilhos e planos de resposta no portfólio.",
+    "Comunica narrativa 2030 alinhada ao negócio."
+  ],
+  "prerequisites": [
+    "Radar de tendências concluído (aula 36).",
+    "Participação prévia em fóruns de governança (aula 34)."
+  ],
+  "tags": ["cenarios", "foresight", "planejamento"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Template de matriz 2x2",
+      "url": "https://example.edu/tgs/templates/matriz-2x2",
+      "type": "template"
+    },
+    {
+      "label": "Guia de narrativas de cenário",
+      "url": "https://example.edu/tgs/guides/narrativas-cenario",
+      "type": "guide"
+    }
+  ],
+  "bibliography": [
+    "SCHOEMAKER, Paul. Scenario Planning in Organizations. Harvard, 2014.",
+    "EUROSTAT. Strategic Foresight Report 2024. European Commission, 2024."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Narrativa de cenário 2030 com implicações estratégicas."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-03-10T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Toolkit Foresight 2024"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-37.vue
+++ b/src/content/courses/tgs/lessons/lesson-37.vue
@@ -1,0 +1,16 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-37',
+  title: 'Aula 37: Planejamento por Cenários e Futuros de SI',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-37.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-38.json
+++ b/src/content/courses/tgs/lessons/lesson-38.json
@@ -1,0 +1,178 @@
+{
+  "id": "lesson-38",
+  "title": "Aula 38: Oficina Integrada – Roadmap, Mudança e Comunicação",
+  "objective": "Conectar roadmap estratégico à gestão de mudança e comunicação executiva do PESI.",
+  "content": [
+    {
+      "type": "cardGrid",
+      "title": "Alavancas de mudança",
+      "cards": [
+        {
+          "title": "Patrocínio visível",
+          "content": "Executivos comunicam visão e desbloqueiam recursos."
+        },
+        {
+          "title": "Gestão de impactos",
+          "content": "Mapeamento de processos, personas e riscos de adoção."
+        },
+        { "title": "Capacitação", "content": "Trilhas de aprendizagem e suporte contínuo." },
+        {
+          "title": "Comunicação segmentada",
+          "content": "Mensagens personalizadas por stakeholder."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Plano de comunicação",
+      "headers": ["Stakeholder", "Mensagem-chave", "Canal", "Frequência"],
+      "rows": [
+        ["Conselho", "Status do roadmap e resultados", "Relatório executivo", "Mensal"],
+        ["Gestores", "Impactos operacionais e decisões", "Reuniões de liderança", "Quinzenal"],
+        ["Colaboradores", "Benefícios e suporte", "Intranet, newsletters", "Semanal"],
+        ["Parceiros", "Integrações e mudanças contratuais", "Workshops dedicados", "Trimestral"]
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Gestão de mudança integrada",
+      "summary": "Mostra como comunicação, capacitação e suporte sustentam a adoção do roadmap.",
+      "factors": [
+        {
+          "id": "comunicacao",
+          "name": "Comunicação",
+          "summary": "Mensagens direcionadas",
+          "kind": "flow",
+          "indicators": ["alcance_mensagens"]
+        },
+        {
+          "id": "capacitacao",
+          "name": "Capacitação",
+          "summary": "Treinamentos e coaching",
+          "kind": "capability",
+          "indicators": ["horas_treinamento"]
+        },
+        {
+          "id": "suporte",
+          "name": "Suporte",
+          "summary": "Canais e help desk",
+          "kind": "resource",
+          "indicators": ["chamados_resolvidos"]
+        },
+        {
+          "id": "adocao",
+          "name": "Adoção",
+          "summary": "Uso efetivo das novas soluções",
+          "kind": "outcome",
+          "indicators": ["usuarios_ativos"]
+        }
+      ],
+      "connections": [
+        {
+          "from": "comunicacao",
+          "to": "capacitacao",
+          "description": "Comunicação convoca públicos para trilhas de aprendizado."
+        },
+        {
+          "from": "capacitacao",
+          "to": "adocao",
+          "description": "Treinamentos aumentam confiança no uso."
+        },
+        {
+          "from": "suporte",
+          "to": "adocao",
+          "description": "Suporte rápido remove barreiras pós-go-live."
+        },
+        {
+          "from": "capacitacao",
+          "to": "suporte",
+          "description": "Insights dos treinamentos orientam base de conhecimento."
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Cronograma da oficina",
+      "steps": [
+        { "title": "Bloco 1", "content": "Atualização do roadmap e dependências críticas." },
+        { "title": "Bloco 2", "content": "Mapeamento de impactos e stakeholders." },
+        { "title": "Bloco 3", "content": "Definição de mensagens e canais por segmento." },
+        { "title": "Bloco 4", "content": "Plano de capacitação e métricas de adoção." }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Gestão de mudança em ação",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/change-management-ti",
+          "title": "Transformação digital orientada à mudança",
+          "caption": "Como comunicar roadmap de TI em escala."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/case-capacitacao-pesi",
+          "title": "Capacitação contínua",
+          "caption": "Case de onboarding digital com academias internas."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 38 — Plano de engajamento",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Produza um plano de engajamento resumido com stakeholders críticos, mensagens-chave e indicadores de adoção. Entregue no fórum e responda à banca de perguntas em aula seguinte."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-38-oficina-integrada-roadmap-mudanca",
+  "summary": "Integra roadmap estratégico com gestão de mudança, comunicação e engajamento de stakeholders.",
+  "objectives": [
+    "Relacionar roadmap do PESI às necessidades de comunicação e mudança.",
+    "Elaborar plano de comunicação segmentado por stakeholder.",
+    "Definir indicadores de adoção e suporte contínuo."
+  ],
+  "competencies": ["Gestão de mudança", "Comunicação executiva", "Engajamento de stakeholders"],
+  "outcomes": [
+    "Entrega plano de engajamento alinhado ao roadmap.",
+    "Mapeia impactos e planos de capacitação por público.",
+    "Define métricas de adoção para monitoramento contínuo."
+  ],
+  "prerequisites": [
+    "Roadmap priorizado (aula 33) e governança definida (aula 34).",
+    "Indicadores de monitoramento estruturados (aula 35)."
+  ],
+  "tags": ["mudanca", "comunicacao", "roadmap"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Template de plano de engajamento",
+      "url": "https://example.edu/tgs/templates/plano-engajamento",
+      "type": "template"
+    },
+    {
+      "label": "Kit de comunicação PESI",
+      "url": "https://example.edu/tgs/kits/comunicacao-pesi",
+      "type": "kit"
+    }
+  ],
+  "bibliography": [
+    "HIATT, Jeff. ADKAR: um modelo de gestão de mudanças. Elsevier, 2014.",
+    "PROSCI. Best Practices in Change Management. Prosci, 2023."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Plano de engajamento com indicadores de adoção."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-03-10T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Playbook Change Management 2024"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-38.vue
+++ b/src/content/courses/tgs/lessons/lesson-38.vue
@@ -1,0 +1,16 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-38',
+  title: 'Aula 38: Oficina Integrada – Roadmap, Mudança e Comunicação',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-38.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>

--- a/src/content/courses/tgs/lessons/lesson-39.json
+++ b/src/content/courses/tgs/lessons/lesson-39.json
@@ -1,0 +1,203 @@
+{
+  "id": "lesson-39",
+  "title": "Aula 39: Síntese Estratégica e Painel Futuro de SI",
+  "objective": "Consolidar aprendizados do ciclo de planejamento estratégico e projetar próximos passos para o PESI.",
+  "content": [
+    {
+      "type": "cardGrid",
+      "title": "Entregáveis consolidados",
+      "cards": [
+        {
+          "title": "Diagnóstico",
+          "content": "SWOT, inventário de capacidades e análise de riscos."
+        },
+        { "title": "Mapa estratégico", "content": "Balanced Scorecard, objetivos e indicadores." },
+        {
+          "title": "Roadmap & governança",
+          "content": "Sequenciamento, fóruns e métricas de acompanhamento."
+        },
+        {
+          "title": "Planos de mudança",
+          "content": "Engajamento, comunicação e monitoramento da adoção."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Checklist final do PESI",
+      "headers": ["Item", "Perguntas de verificação", "Responsável", "Status"],
+      "rows": [
+        [
+          "Diagnóstico validado",
+          "Stakeholders revisaram e aprovaram?",
+          "Equipe de análise",
+          "Em andamento"
+        ],
+        [
+          "Mapa estratégico",
+          "Objetivos conectam-se aos OKRs corporativos?",
+          "Patrocinador executivo",
+          "Concluído"
+        ],
+        ["Roadmap", "Dependências e riscos têm planos mitigadores?", "PMO de TI", "Em revisão"],
+        [
+          "Governança",
+          "Fóruns e cadências estão comunicados?",
+          "Escritório de governança",
+          "Planejado"
+        ],
+        ["Comunicação", "Mensagens e canais foram testados?", "Equipe de mudança", "Em andamento"]
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Preparação para o painel futuro",
+      "steps": [
+        {
+          "title": "Semana -2",
+          "content": "Ajustar entregáveis e coletar feedback dos stakeholders."
+        },
+        {
+          "title": "Semana -1",
+          "content": "Ensaiar pitch executivo e revisar indicadores críticos."
+        },
+        {
+          "title": "Semana 0",
+          "content": "Conduzir painel com banca externa e registrar deliberações."
+        },
+        { "title": "Semana +1", "content": "Documentar decisões e atualizar backlog pós-painel." }
+      ]
+    },
+    {
+      "type": "systemMapper",
+      "title": "Painel futuro de SI",
+      "summary": "Relaciona temas que serão discutidos com a banca avaliadora.",
+      "factors": [
+        {
+          "id": "valor_negocio",
+          "name": "Valor para o negócio",
+          "summary": "Resultados esperados",
+          "kind": "outcome",
+          "indicators": ["roi_estimado"]
+        },
+        {
+          "id": "maturidade",
+          "name": "Maturidade de SI",
+          "summary": "Capacidades atuais",
+          "kind": "capability",
+          "indicators": ["nivel_maturidade"]
+        },
+        {
+          "id": "portfolio_futuro",
+          "name": "Portfólio futuro",
+          "summary": "Iniciativas emergentes",
+          "kind": "flow",
+          "indicators": ["iniciativas_pipeline"]
+        },
+        {
+          "id": "riscos_futuros",
+          "name": "Riscos futuros",
+          "summary": "Ameaças e incertezas",
+          "kind": "constraint",
+          "indicators": ["riscos_prioritarios"]
+        }
+      ],
+      "connections": [
+        {
+          "from": "maturidade",
+          "to": "valor_negocio",
+          "description": "Capacidades sustentam resultados projetados."
+        },
+        {
+          "from": "portfolio_futuro",
+          "to": "valor_negocio",
+          "description": "Novas iniciativas amplificam benefícios esperados."
+        },
+        {
+          "from": "riscos_futuros",
+          "to": "valor_negocio",
+          "description": "Ameaças podem comprometer ROI se não mitigadas."
+        },
+        {
+          "from": "maturidade",
+          "to": "portfolio_futuro",
+          "description": "Nível atual define ritmo de novas ondas."
+        }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Preparação para o painel",
+      "videos": [
+        {
+          "url": "https://example.edu/tgs/videos/painel-estrategico-ti",
+          "title": "Pitch executivo de TI",
+          "caption": "Boas práticas para apresentar roadmap estratégico."
+        },
+        {
+          "url": "https://example.edu/tgs/videos/case-painel-futuro",
+          "title": "Painel futuro em empresa global",
+          "caption": "Como consolidar aprendizados e próximos passos."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 39 — Fórum de síntese",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Prepare um resumo executivo (máx. 2 páginas) com os principais aprendizados, riscos e próximos passos do PESI. Compartilhe no fórum e faça peer review com dois grupos."
+        }
+      ]
+    }
+  ],
+  "formatVersion": "md3.lesson.v1",
+  "slug": "aula-39-sintese-estrategica-e-painel-futuro",
+  "summary": "Consolida entregáveis do PESI, prepara painel futuro e alinha próximos passos estratégicos.",
+  "objectives": [
+    "Revisitar entregáveis críticos do PESI com visão integrada.",
+    "Planejar painel futuro e critérios de avaliação executiva.",
+    "Sintetizar aprendizados e riscos em resumo executivo."
+  ],
+  "competencies": ["Comunicação estratégica", "Gestão de riscos", "Síntese executiva"],
+  "outcomes": [
+    "Apresenta checklist final com status dos entregáveis.",
+    "Organiza painel futuro com atores e temas críticos.",
+    "Produz resumo executivo compartilhado para peer review."
+  ],
+  "prerequisites": [
+    "Planos de mudança e indicadores estruturados (aulas 35 e 38).",
+    "Radar de tendências e cenários (aulas 36 e 37)."
+  ],
+  "tags": ["sintese", "painel-futuro", "planejamento"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Template de resumo executivo",
+      "url": "https://example.edu/tgs/templates/resumo-executivo-pesi",
+      "type": "template"
+    },
+    {
+      "label": "Checklist final do PESI",
+      "url": "https://example.edu/tgs/checklists/final-pesi",
+      "type": "checklist"
+    }
+  ],
+  "bibliography": [
+    "BCS. Strategic Planning for Information Systems Review. BCS, 2024.",
+    "GARTNER. Running Effective Executive Reviews. Gartner, 2023."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Resumo executivo e participação em fórum de síntese."
+  },
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-03-10T00:00:00.000Z",
+    "owners": ["Profa. Marina Duarte"],
+    "sources": ["Plano de ensino TGS 2025.1", "Toolkit Painel Futuro 2024"]
+  }
+}

--- a/src/content/courses/tgs/lessons/lesson-39.vue
+++ b/src/content/courses/tgs/lessons/lesson-39.vue
@@ -1,0 +1,16 @@
+<script lang="ts">
+export const meta = {
+  id: 'lesson-39',
+  title: 'Aula 39: Síntese Estratégica e Painel Futuro de SI',
+  available: true,
+};
+</script>
+
+<script setup lang="ts">
+import LessonRenderer from '@/components/lesson/LessonRenderer.vue';
+import lessonData from './lesson-39.json';
+</script>
+
+<template>
+  <LessonRenderer :data="lessonData" />
+</template>


### PR DESCRIPTION
## Summary
- add lessons 29-39 covering strategic planning foundations, SWOT, capabilities, BSC, roadmap, governance, metrics, trends, foresight, change management, and synthesis for the PESI cycle
- update the lessons manifest and regenerated validation/observability reports

## Testing
- npm run validate:content
- npm run report:observability

------
https://chatgpt.com/codex/tasks/task_e_68da8d46b744832ca216f8b02ac536ca