### PR TITLE
Add struct-focused lessons and gamified revision resources

### DIFF
--- a/public/courses/algi/crud-lab-rubrica.md
+++ b/public/courses/algi/crud-lab-rubrica.md
@@ -1,0 +1,9 @@
+# Rubrica de Avaliação - Laboratório CRUD em Memória
+
+| Critério | Peso | Descrição |
+| --- | --- | --- |
+| Modelagem de `struct` | 20% | Campos apropriados, tipos corretos e comentários que descrevem o domínio. |
+| Operações CRUD | 35% | Implementa criar, ler, atualizar e remover com validações de entrada e mensagens claras. |
+| Busca e Ordenação | 20% | Disponibiliza buscas por diferentes campos e integra com ordenação crescente/decrescente. |
+| Qualidade de Código | 15% | Estrutura modular (funções e headers), nomes significativos e ausência de duplicação. |
+| Testes e Demonstração | 10% | Inclui casos de teste básicos e demonstração escrita ou gravada dos cenários principais. |

--- a/public/courses/algi/crud-ordenacao-lab.md
+++ b/public/courses/algi/crud-ordenacao-lab.md
@@ -1,0 +1,12 @@
+# Laboratório Integrado: CRUD e Ordenação
+
+1. **Modelagem:** defina uma `struct Produto` com campos `codigo`, `descricao`, `categoria` e `preco`.
+2. **Carga inicial:** leia os dados de um arquivo CSV (pode ser gerado manualmente) para um vetor de `Produto`.
+3. **Operações CRUD:**
+   - Inserir novo produto validando unicidade do `codigo`.
+   - Atualizar preço ou categoria a partir do `codigo` informado.
+   - Remover registro deslocando elementos subsequentes.
+4. **Busca:** implemente busca linear por `codigo` e por prefixo da `descricao`.
+5. **Ordenação:** disponibilize ordenação crescente/decrescente por preço utilizando Bubble Sort ou Insertion Sort reutilizável.
+6. **Menu interativo:** ofereça um menu textual com opções numeradas para manipular o vetor em memória.
+7. **Relatórios:** gere um resumo com ticket médio por categoria e exporte para CSV.

--- a/public/courses/algi/gamificacao-jeopardy-kit.md
+++ b/public/courses/algi/gamificacao-jeopardy-kit.md
@@ -1,0 +1,8 @@
+# Kit de Gamificação - Revisão Jeopardy
+
+- **Categorias sugeridas:** Sintaxe C, Structs & Vetores, Funções, Controle de Fluxo, Desafios Mistos.
+- **Pontuações:** 100, 200, 300, 400 e 500 pontos por categoria.
+- **Formato:** squads escolhem categoria + pontuação; se acertarem, ganham pontos; se errarem, outra equipe pode roubar.
+- **Materiais necessários:** slides com perguntas/indícios, cronômetro, quadro de pontuação visível.
+- **Ranking final:** converta pontuação em medalhas (ouro/prata/bronze) para registrar no mural da turma.
+- **Bônus:** inclua cartões "Daily Double" para permitir apostas e perguntas-relâmpago de algoritmos curtos.

--- a/public/courses/algi/gamificacao-ranking-template.csv
+++ b/public/courses/algi/gamificacao-ranking-template.csv
@@ -1,0 +1,4 @@
+Equipe,Pontuacao,Medalha,Feedback
+Squad A,0,,
+Squad B,0,,
+Squad C,0,,

--- a/public/courses/algi/struct-cadastro-template.c
+++ b/public/courses/algi/struct-cadastro-template.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include <string.h>
+
+#define MAX_NOME 64
+
+typedef struct {
+    int id;
+    char nome[MAX_NOME];
+    char setor[32];
+    float faturamentoMensal;
+} Empresa;
+
+void imprimirEmpresa(const Empresa *empresa) {
+    printf("[%d] %s | Setor: %s | Faturamento: R$ %.2f\n",
+           empresa->id, empresa->nome, empresa->setor, empresa->faturamentoMensal);
+}
+
+int main(void) {
+    Empresa exemplo = {1, "Cooperativa Horizonte", "Serviços", 18500.0f};
+
+    imprimirEmpresa(&exemplo);
+
+    return 0;
+}

--- a/src/content/courses/algi/lessons.json
+++ b/src/content/courses/algi/lessons.json
@@ -376,25 +376,45 @@
       "id": "lesson-35",
       "title": "Aula 35: Introdução a Structs (Registros)",
       "file": "lesson-35.json",
-      "available": false
+      "available": true,
+      "description": "Apresenta structs em C como registros compostos e organiza um CRUD inicial para consolidar o modelo de dados.",
+      "summary": "Declaração de structs, acesso a campos e mini-CRUD em memória inspirado em dados do SEBRAE.",
+      "tags": ["structs", "crud", "revisao"],
+      "duration": 115,
+      "formatVersion": "md3.lesson.v1"
     },
     {
       "id": "lesson-36",
       "title": "Aula 36: Vetores de Structs",
       "file": "lesson-36.json",
-      "available": false
+      "available": true,
+      "description": "Organiza coleções de registros com structs em vetor, adicionando ordenação e relatórios.",
+      "summary": "Vetores de structs com contagem ativa, integração do CRUD e ordenação baseada em dados do SEBRAE.",
+      "tags": ["structs", "crud", "revisao"],
+      "duration": 120,
+      "formatVersion": "md3.lesson.v1"
     },
     {
       "id": "lesson-37",
       "title": "Aula 37: Busca e Atualização em Vetores de Structs",
       "file": "lesson-37.json",
-      "available": false
+      "available": true,
+      "description": "Aprofunda operações de busca, atualização e remoção em vetores de structs com foco em integridade.",
+      "summary": "Busca por múltiplos critérios, atualização validada e remoção com logs usando dados IBGE/SEBRAE.",
+      "tags": ["structs", "crud", "revisao"],
+      "duration": 125,
+      "formatVersion": "md3.lesson.v1"
     },
     {
       "id": "lesson-38",
       "title": "Aula 38: Revisão Geral do Semestre",
       "file": "lesson-38.json",
-      "available": false
+      "available": true,
+      "description": "Revisa o semestre com dinâmica gamificada envolvendo Jeopardy, ranking colaborativo e feedbacks.",
+      "summary": "Revisão gamificada com quizzes de structs/CRUD, desafios relâmpago e mural de aprendizados.",
+      "tags": ["structs", "crud", "revisao"],
+      "duration": 130,
+      "formatVersion": "md3.lesson.v1"
     },
     {
       "id": "lesson-39",

--- a/src/content/courses/algi/lessons/lesson-35.json
+++ b/src/content/courses/algi/lessons/lesson-35.json
@@ -1,0 +1,174 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-35",
+  "title": "Aula 35: Introdução a Structs (Registros)",
+  "summary": "Apresenta structs em C como registros compostos e conduz um CRUD básico em memória para consolidar o modelo de dados.",
+  "objective": "Compreender a declaração, instância e manipulação inicial de structs em C, preparando-se para coleções de registros.",
+  "objectives": [
+    "Declarar structs com campos adequados ao domínio proposto.",
+    "Inicializar e acessar membros por ponto e ponteiros.",
+    "Construir um mini-CRUD em memória com ênfase em criação e leitura."
+  ],
+  "competencies": ["Pensamento algorítmico", "Modelagem de dados"],
+  "skills": [
+    "Mapear requisitos simples para campos de registros.",
+    "Encapsular operações básicas em funções.",
+    "Documentar structs com comentários significativos."
+  ],
+  "outcomes": [
+    "Define struct Empresa alinhada ao laboratório do semestre.",
+    "Implementa funções create e list utilizando vetor fixo.",
+    "Entrega relatório curto descrevendo decisões de modelagem."
+  ],
+  "prerequisites": [
+    "Conhecimento de vetores simples (Aula 30).",
+    "Noções de funções e passagem de parâmetros."
+  ],
+  "tags": ["structs", "crud", "revisao"],
+  "duration": 115,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Template inicial de struct e impressão",
+      "type": "template",
+      "file": "courses/algi/struct-cadastro-template.c",
+      "url": "https://static.md3.education/courses/algi/struct-cadastro-template.c"
+    },
+    {
+      "label": "Artigo Microsoft Learn - Estruturas em C",
+      "type": "article",
+      "url": "https://learn.microsoft.com/pt-br/cpp/c-language/c-structures"
+    },
+    {
+      "label": "Rubrica CRUD em memória",
+      "type": "rubric",
+      "file": "courses/algi/crud-lab-rubrica.md",
+      "url": "https://static.md3.education/courses/algi/crud-lab-rubrica.md"
+    }
+  ],
+  "bibliography": [
+    "KERNIGHAN, B.; RITCHIE, D. Linguagem de Programação C. 2. ed. Pearson, 2021.",
+    "PRESSMAN, R. Engenharia de Software. McGraw Hill, 2023."
+  ],
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Roteiro detalhado",
+      "cards": [
+        {
+          "icon": "clock",
+          "title": "Aquecimento",
+          "content": "Quiz com cinco cenários para identificar campos de dados (10 min)."
+        },
+        {
+          "icon": "database",
+          "title": "Sintaxe de struct",
+          "content": "Declaração, typedef e alinhamento na memória (25 min)."
+        },
+        {
+          "icon": "code",
+          "title": "Manipulação",
+          "content": "Atribuições, acesso por ponto/seta e funções auxiliares (20 min)."
+        },
+        {
+          "icon": "gears",
+          "title": "Mini-CRUD",
+          "content": "Criar e listar registros de Empresas em vetor fixo (35 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Retrospectiva",
+          "content": "Mapa mental com principais boas práticas (15 min)."
+        }
+      ]
+    },
+    {
+      "type": "flightPlan",
+      "title": "Plano de voo (1h55)",
+      "items": [
+        "(10 min) Icebreaker com cartões de atributos empresariais.",
+        "(20 min) Live coding: declaração e inicialização de Empresa.",
+        "(15 min) Exercício individual: função para imprimir struct formatada.",
+        "(30 min) Laboratório guiado: operações create/list com vetor local.",
+        "(20 min) Debriefing: decisões de modelagem e validação de dados.",
+        "(20 min) Check-out com quiz interativo (Kahoot) sobre sintaxe de structs."
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Componentes essenciais de um registro",
+      "headers": ["Elemento", "Descrição", "Exemplo", "Boas práticas"],
+      "rows": [
+        [
+          "Campos",
+          "Definem as informações necessárias do domínio.",
+          "int id; char nome[64];",
+          "Escolha tipos apropriados e limites realistas."
+        ],
+        [
+          "Typedef",
+          "Simplifica a declaração de variáveis do registro.",
+          "typedef struct { ... } Empresa;",
+          "Use nomes no singular representando a entidade."
+        ],
+        [
+          "Funções auxiliares",
+          "Centralizam operações comuns sobre o registro.",
+          "void imprimir(const Empresa *e);",
+          "Evite duplicar prints/formatos no código."
+        ],
+        [
+          "Constantes",
+          "Guardam limites e tamanhos máximos.",
+          "#define MAX_EMPRESAS 50",
+          "Documente o motivo do limite em comentários."
+        ],
+        [
+          "Documentação",
+          "Explica finalidade e origem dos campos.",
+          "// Faturamento médio mensal (R$)",
+          "Padronize comentários para revisão coletiva."
+        ]
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Prática de laboratório: CRUD em memória",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Os squads implementam um CRUD mínimo (Create/Read) apenas em memória usando um vetor de structs Empresa. Cada equipe documenta o fluxo em um quadro Kanban simplificado para registrar progresso."
+        },
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Modelar struct Empresa alinhada aos dados do SEBRAE/IBGE trabalhados no semestre."
+            },
+            { "text": "Codificar funções create/list, validando tamanhos e duplicidade de id." },
+            {
+              "text": "Preparar checklist de testes exploratórios baseado na rubrica compartilhada."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "good-practice",
+      "title": "Integração com dados oficiais",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Utilize dados de perfil do Microempreendedor Individual disponíveis no portal do SEBRAE para sugerir campos realistas e discutir ética no uso de dados."
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-10-01T10:00:00.000Z",
+    "owners": ["Equipe Algoritmos I"],
+    "sources": ["Plano de ensino Algoritmos I 2025.2", "Relatórios SEBRAE 2024"]
+  }
+}

--- a/src/content/courses/algi/lessons/lesson-36.json
+++ b/src/content/courses/algi/lessons/lesson-36.json
@@ -1,0 +1,175 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-36",
+  "title": "Aula 36: Vetores de Structs",
+  "summary": "Constrói coleções de registros com structs em vetor e prepara o terreno para operações CRUD completas.",
+  "objective": "Estruturar vetores de structs para representar catálogos de dados e aplicar operações coletivas de ordenação e agregação.",
+  "objectives": [
+    "Armazenar múltiplos registros em vetores de structs com limites configuráveis.",
+    "Aplicar ordenação simples para organizar a coleção.",
+    "Documentar o estado da coleção com relatórios resumidos."
+  ],
+  "competencies": ["Pensamento algorítmico", "Organização da informação"],
+  "skills": [
+    "Gerenciar contagem de elementos ativos em vetores de structs.",
+    "Reutilizar funções de comparação para ordenar registros.",
+    "Gerar estatísticas básicas a partir de coleções."
+  ],
+  "outcomes": [
+    "Produz vetor de Empresas carregado com dados iniciais.",
+    "Integra funções de ordenação com o menu CRUD do laboratório.",
+    "Entrega relatório com ranking por faturamento e categoria."
+  ],
+  "prerequisites": [
+    "Domínio da declaração e uso de structs (Aula 35).",
+    "Conhecimento prévio de ordenação básica."
+  ],
+  "tags": ["structs", "crud", "revisao"],
+  "duration": 120,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Laboratório Integrado CRUD + Ordenação",
+      "type": "guide",
+      "file": "courses/algi/crud-ordenacao-lab.md",
+      "url": "https://static.md3.education/courses/algi/crud-ordenacao-lab.md"
+    },
+    {
+      "label": "Dataset SEBRAE - Perfil dos Pequenos Negócios",
+      "type": "dataset",
+      "url": "https://dados.sebrae.com.br/dataset/perfil-dos-pequenos-negocios"
+    },
+    {
+      "label": "Artigo DevDocs - qsort em C",
+      "type": "article",
+      "url": "https://devdocs.io/c/program/qsort"
+    }
+  ],
+  "bibliography": [
+    "ZIVIANI, N. Projetos de Algoritmos. Cengage, 2020.",
+    "DEITEL, P.; DEITEL, H. C Como Programar. 9. ed. Pearson, 2022."
+  ],
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Roteiro detalhado",
+      "cards": [
+        {
+          "icon": "clock",
+          "title": "Check-in",
+          "content": "Revisão relâmpago sobre structs individuais (10 min)."
+        },
+        {
+          "icon": "database",
+          "title": "Coleções",
+          "content": "Configuração de vetores de structs e contadores de uso (25 min)."
+        },
+        {
+          "icon": "settings",
+          "title": "Ordenação",
+          "content": "Comparadores personalizados com Bubble/Insertion Sort (30 min)."
+        },
+        {
+          "icon": "database",
+          "title": "Relatórios",
+          "content": "Geração de ranking de faturamento e segmentação por setor (25 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Wrap-up",
+          "content": "Debate sobre limitações de armazenamento estático (20 min)."
+        }
+      ]
+    },
+    {
+      "type": "flightPlan",
+      "title": "Plano de voo (2h00)",
+      "items": [
+        "(15 min) Icebreaker com cards de dados reais SEBRAE.",
+        "(20 min) Live coding: carga inicial do vetor com dados fictícios.",
+        "(25 min) Oficina: implementar função de ordenação crescente por faturamento.",
+        "(30 min) Laboratório orientado: integrar ordenação ao menu CRUD.",
+        "(20 min) Relato rápido por squads: métricas derivadas do vetor.",
+        "(10 min) Quiz interativo sobre complexidade e estabilidade de ordenações."
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Estratégias de ordenação para vetores de structs",
+      "headers": ["Algoritmo", "Quando usar", "Custo", "Observações"],
+      "rows": [
+        [
+          "Bubble Sort",
+          "Listas pequenas e necessidade de implementação rápida",
+          "O(n^2)",
+          "Fácil de adaptar para ordenação decrescente."
+        ],
+        [
+          "Insertion Sort",
+          "Coleções quase ordenadas",
+          "O(n^2)",
+          "Bom para inserir novos registros mantendo a ordem."
+        ],
+        [
+          "qsort (stdlib)",
+          "Quando o custo de implementação importa",
+          "O(n log n)",
+          "Exige comparador consistente e inclui ponteiros void."
+        ],
+        [
+          "Selection Sort",
+          "Situações de memória crítica",
+          "O(n^2)",
+          "Poucas trocas, útil para dados estáticos."
+        ],
+        [
+          "Counting Sort",
+          "Campos inteiros com domínio pequeno",
+          "O(n + k)",
+          "Requer estrutura auxiliar e limites bem definidos."
+        ]
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Laboratório: integração CRUD com ordenação",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "A turma evolui o CRUD iniciado na aula anterior adicionando ordenação configurável e relatórios baseados em estatísticas do vetor."
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Implementar menu com opções de ordenação por faturamento e por ordem alfabética de setor."
+            },
+            {
+              "text": "Registrar no relatório do squad como a ordenação impacta a busca e as atualizações."
+            },
+            {
+              "text": "Comparar desempenho das abordagens Bubble vs Insertion para 200 registros simulados."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "warning",
+      "title": "Cuidados com dados reais",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Os datasets do SEBRAE podem conter campos sensíveis. Redija um plano de anonimização quando necessário e registre as decisões na ata do laboratório."
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-10-02T09:30:00.000Z",
+    "owners": ["Equipe Algoritmos I"],
+    "sources": ["Plano de ensino Algoritmos I 2025.2", "Workshops SEBRAE de Dados 2024"]
+  }
+}

--- a/src/content/courses/algi/lessons/lesson-37.json
+++ b/src/content/courses/algi/lessons/lesson-37.json
@@ -1,0 +1,175 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-37",
+  "title": "Aula 37: Busca e Atualização em Vetores de Structs",
+  "summary": "Refina o CRUD em memória adicionando buscas flexíveis, atualização de campos e estratégias de auditoria.",
+  "objective": "Desenvolver habilidades para localizar, atualizar e remover registros em vetores de structs, garantindo integridade dos dados.",
+  "objectives": [
+    "Implementar buscas lineares e por chave composta.",
+    "Atualizar campos selecionados mantendo histórico mínimo.",
+    "Realizar remoção lógica e física comparando abordagens."
+  ],
+  "competencies": ["Pensamento crítico", "Confiabilidade de software"],
+  "skills": [
+    "Projetar funções de busca reutilizáveis.",
+    "Definir protocolos de atualização com validação.",
+    "Gerenciar remoção com deslocamento de elementos e logs."
+  ],
+  "outcomes": [
+    "Entrega funções searchById e searchByPrefix documentadas.",
+    "Atualiza registros com validação de domínios e feedback ao usuário.",
+    "Implementa remoção com compactação e ajuste do contador de elementos ativos."
+  ],
+  "prerequisites": [
+    "Vetores de structs com ordenação básica (Aula 36).",
+    "Entendimento de CRUD sequencial."
+  ],
+  "tags": ["structs", "crud", "revisao"],
+  "duration": 125,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Dataset IBGE - Cadastro Central de Empresas (Tabela 6463)",
+      "type": "dataset",
+      "url": "https://sidra.ibge.gov.br/tabela/6463"
+    },
+    {
+      "label": "Rubrica CRUD em memória",
+      "type": "rubric",
+      "file": "courses/algi/crud-lab-rubrica.md",
+      "url": "https://static.md3.education/courses/algi/crud-lab-rubrica.md"
+    },
+    {
+      "label": "Guia SEBRAE - Boas práticas de atendimento",
+      "type": "article",
+      "url": "https://www.sebrae.com.br/sites/PortalSebrae/artigos/boas-praticas-de-atendimento"
+    }
+  ],
+  "bibliography": [
+    "LAFORE, R. Estruturas de Dados e Algoritmos em C++. Pearson, 2019.",
+    "SOMMERVILLE, I. Engenharia de Software. 11. ed. Pearson, 2020."
+  ],
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Roteiro detalhado",
+      "cards": [
+        {
+          "icon": "clock",
+          "title": "Kick-off",
+          "content": "Desafio relâmpago com buscas sobre vetor já ordenado (10 min)."
+        },
+        {
+          "icon": "target",
+          "title": "Estratégias de busca",
+          "content": "Busca linear, sentinela e comparação com busca binária (30 min)."
+        },
+        {
+          "icon": "code",
+          "title": "Atualizações seguras",
+          "content": "Validação de domínio e campos derivados (30 min)."
+        },
+        {
+          "icon": "tasks",
+          "title": "Remoções",
+          "content": "Remoção lógica vs física e implicações no ranking (25 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Debriefing",
+          "content": "Retro coletiva com métricas de cobertura das operações (20 min)."
+        }
+      ]
+    },
+    {
+      "type": "flightPlan",
+      "title": "Plano de voo (2h05)",
+      "items": [
+        "(15 min) Estudo de caso: empresas que cresceram segundo IBGE.",
+        "(25 min) Live coding: busca por id com retorno de ponteiro.",
+        "(30 min) Oficina: atualização de faturamento com logs de alterações.",
+        "(25 min) Laboratório: remoção e compactação do vetor com relatório automático.",
+        "(20 min) Testes cruzados entre squads (pair review).",
+        "(10 min) Reflexão escrita sobre integridade e auditoria."
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Boas práticas para atualização e busca",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Conecte as operações CRUD às métricas de atendimento SEBRAE, justificando por que determinados campos precisam de validação adicional e feedback claro ao usuário."
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Implemente busca por múltiplos critérios (id, setor, faixa de faturamento)."
+            },
+            { "text": "Mantenha log textual das alterações relevantes para auditoria." },
+            { "text": "Crie testes unitários simples para funções de atualização e remoção." }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Padrões de retorno para operações CRUD",
+      "headers": ["Operação", "Retorno sugerido", "Descrição", "Quando aplicar"],
+      "rows": [
+        [
+          "create",
+          "int (novo tamanho)",
+          "Incrementa contador e retorna total de registros.",
+          "Ao inserir no fim do vetor."
+        ],
+        [
+          "read",
+          "int (índice) ou ponteiro",
+          "Localiza registro e permite inspeção.",
+          "Quando busca por id ou prefixo."
+        ],
+        [
+          "update",
+          "bool",
+          "Indica sucesso/falha após validações.",
+          "Atualização de campos sensíveis."
+        ],
+        [
+          "delete",
+          "bool",
+          "Retorna sucesso após compactação.",
+          "Remoção física movendo elementos."
+        ],
+        [
+          "auditLog",
+          "void",
+          "Gera linha de log com contexto da alteração.",
+          "Chamar após operações críticas."
+        ]
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Checklist de testes",
+      "content": [
+        {
+          "type": "list",
+          "items": [
+            "Busca inexistente retorna NULL/índice -1?",
+            "Atualização rejeita valores negativos?",
+            "Remoção mantém coleção ordenada após compactação?"
+          ]
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-10-03T08:45:00.000Z",
+    "owners": ["Equipe Algoritmos I"],
+    "sources": ["Plano de ensino Algoritmos I 2025.2", "Relatórios IBGE 2024"]
+  }
+}

--- a/src/content/courses/algi/lessons/lesson-38.json
+++ b/src/content/courses/algi/lessons/lesson-38.json
@@ -1,0 +1,180 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-38",
+  "title": "Aula 38: Revisão Gamificada do Semestre",
+  "summary": "Consolida conteúdos com dinâmica Jeopardy, ranking colaborativo e síntese dos aprendizados em squads.",
+  "objective": "Promover revisão abrangente dos conceitos-chave da disciplina por meio de atividades gamificadas e colaborativas.",
+  "objectives": [
+    "Relembrar tópicos centrais (fluxo sequencial, controle, funções, structs).",
+    "Aplicar conhecimento em desafios práticos e quizzes competitivos.",
+    "Mapear pontos de melhoria individuais a partir do ranking e feedbacks."
+  ],
+  "competencies": ["Trabalho em equipe", "Pensamento crítico", "Comunicação"],
+  "skills": [
+    "Resolver desafios de código em tempo limitado.",
+    "Registrar resultados e feedbacks em planilha de ranking.",
+    "Refletir sobre evolução pessoal e do squad."
+  ],
+  "outcomes": [
+    "Completa tabuleiro Jeopardy com perguntas de múltiplos níveis.",
+    "Entrega ranking final com medalhas e feedback qualitativo.",
+    "Publica mural digital com síntese dos aprendizados do semestre."
+  ],
+  "prerequisites": [
+    "Participação nas aulas anteriores do semestre.",
+    "Projeto CRUD em memória iniciado."
+  ],
+  "tags": ["structs", "crud", "revisao"],
+  "duration": 130,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Kit Jeopardy para revisão",
+      "type": "guide",
+      "file": "courses/algi/gamificacao-jeopardy-kit.md",
+      "url": "https://static.md3.education/courses/algi/gamificacao-jeopardy-kit.md"
+    },
+    {
+      "label": "Template de ranking gamificado",
+      "type": "template",
+      "file": "courses/algi/gamificacao-ranking-template.csv",
+      "url": "https://static.md3.education/courses/algi/gamificacao-ranking-template.csv"
+    },
+    {
+      "label": "Artigo Harvard Business Review - Gamification in Education",
+      "type": "article",
+      "url": "https://hbr.org/2020/03/how-gamification-can-boost-learner-engagement"
+    }
+  ],
+  "bibliography": [
+    "KAPP, K. The Gamification of Learning and Instruction. Wiley, 2020.",
+    "GEE, J. P. What Video Games Have to Teach Us About Learning and Literacy. Palgrave, 2019."
+  ],
+  "content": [
+    {
+      "type": "lessonPlan",
+      "title": "Roteiro detalhado",
+      "cards": [
+        {
+          "icon": "clock",
+          "title": "Boas-vindas",
+          "content": "Aquecimento com quiz flash revisando structs e CRUD (10 min)."
+        },
+        {
+          "icon": "tasks",
+          "title": "Jeopardy",
+          "content": "Tabuleiro com cinco categorias (Structs, Vetores, Funções, Controle, Desafios) (45 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Ranking dinâmico",
+          "content": "Atualização em tempo real da planilha de pontuação (20 min)."
+        },
+        {
+          "icon": "users",
+          "title": "Oficina de retrospectiva",
+          "content": "Canvas de lições aprendidas e próximos passos (30 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Encerramento",
+          "content": "Entrega de medalhas e feedbacks individuais (25 min)."
+        }
+      ]
+    },
+    {
+      "type": "flightPlan",
+      "title": "Plano de voo (2h10)",
+      "items": [
+        "(15 min) Icebreaker: bingo de conceitos-chave.",
+        "(45 min) Rodadas Jeopardy com perguntas de código e interpretação.",
+        "(20 min) Desafio relâmpago: refatorar função CRUD indicada pelo ranking.",
+        "(25 min) Sessão de feedback 360° entre squads.",
+        "(20 min) Construção do mural digital com insights.",
+        "(5 min) Anúncio dos destaques e próximos passos para NP3."
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Estratégias de gamificação",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Combine Jeopardy, ranking visível e badges digitais para manter engajamento alto durante a revisão. Cada squad assume papéis (porta-voz, programador, analista) e alterna a cada rodada."
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Use perguntas que envolvam leitura de código, correção de bugs e estimativa de complexidade."
+            },
+            {
+              "text": "Atribua badges extras para squads que colaborarem com outras equipes durante a revisão."
+            },
+            {
+              "text": "Publique ranking parcial a cada rodada para incentivar planejamento estratégico."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Categorias e exemplos de perguntas",
+      "headers": ["Categoria", "Exemplo", "Resolução esperada", "Pontuação"],
+      "rows": [
+        [
+          "Structs",
+          "Identificar erro em typedef e sugerir correção.",
+          "Mostrar typedef completo e motivo da falha.",
+          "200"
+        ],
+        [
+          "Vetores",
+          "Reordenar vetor de registros após remoção.",
+          "Apresentar código com deslocamento correto.",
+          "300"
+        ],
+        [
+          "CRUD",
+          "Escolher retorno adequado para função delete.",
+          "Explicar bool e mensagens ao usuário.",
+          "100"
+        ],
+        [
+          "Controle",
+          "Converter laço while em for mantendo lógica.",
+          "Código equivalente com justificativa.",
+          "400"
+        ],
+        [
+          "Desafios",
+          "Aplicar busca por prefixo em lista ordenada.",
+          "Implementar varredura até mismatch.",
+          "500"
+        ]
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "good-practice",
+      "title": "Checklist para ranking saudável",
+      "content": [
+        {
+          "type": "list",
+          "items": [
+            "Atualize a planilha ao final de cada rodada.",
+            "Garanta feedback construtivo para todas as posições.",
+            "Documente insights coletivos na ata compartilhada."
+          ]
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2025-10-04T11:20:00.000Z",
+    "owners": ["Equipe Algoritmos I"],
+    "sources": ["Plano de ensino Algoritmos I 2025.2", "HBR Gamification Strategies 2020"]
+  }
+}


### PR DESCRIPTION
## Summary
- add lessons 35-38 detailing structs, CRUD workflows, dataset usage, and gamified review plans
- publish supporting templates and rubrics for struct CRUD labs and gamification assets
- mark lessons 35-38 as available in the course manifest with summaries, tags, and durations

## Testing
- `npm run validate:content`


------
https://chatgpt.com/codex/tasks/task_e_68dac3aa5c94832caeb6a10faa3e2005