### PR TITLE
Add Algoritmos I study guide supplement

### DIFF
--- a/public/courses/algi/supplements/guia-estudos.pdf
+++ b/public/courses/algi/supplements/guia-estudos.pdf
@@ -1,0 +1,200 @@
+%PDF-1.4
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 8 0 R /F4 10 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 16 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 17 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 18 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 19 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/BaseFont /Symbol /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+9 0 obj
+<<
+/Contents 20 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+11 0 obj
+<<
+/Contents 21 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/Contents 22 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+13 0 obj
+<<
+/PageMode /UseNone /Pages 15 0 R /Type /Catalog
+>>
+endobj
+14 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20250929185105+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20250929185105+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+15 0 obj
+<<
+/Count 7 /Kids [ 4 0 R 5 0 R 6 0 R 7 0 R 9 0 R 11 0 R 12 0 R ] /Type /Pages
+>>
+endobj
+16 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2146
+>>
+stream
+GauHL9lJcG&A@7.nE;J;a-(:"hHQF\(Bk/Q]C>NY$SBcOUm.g@OrNK6mi+m)Ur5t1(H$dIdFXJ-mr@1m"#7Vfi;^fr&FW][nuk:]Tic/"0H8?VlBA_`SUE^1l8PJW*%f'>+;XRf3*8XCI##`Us4D58&0][2`TJZOL*F.eJ76OXJk7Yf"i1ht=,@dm?'5nY'">"l'B@#:(e3LgDiLS;`V%8q@eCjEIu'$^LR?UVpc11;E'AAU=R)\c.aMr'YB"2h6mA1h9nY(*FQXk"1;c4.`S@Iu>'W&t/athZ64"O!1mcn/9N>,\F54$8U[6fY*bI,M%Y#U3DU#'&P3T/hZ_CNe0PS?dpd2?T*f'aY`aFLsP?')5.'WsRDpKf"%"L/qK^$Hd4Gd[t'Gj!PkeD^+4fN2[<#3W>e0=$(ol(R>V)"6\/8euB4VNFQ=I1;WqEYk'"!b(m@RW^7aU':!S-0#7#+S8t6&A:"CXtE6j!UE?_lk\[5(lanGLL6.3*[ro:26d8k*ok#m4an#`ZZ4iF-rcib/1/!\a%%>=XmHd1QbO^YMsJh>iEWq&diq5TaN"E7g;*F:I6\2>Z2uSI$:]^;o3dRr#Dt^or)[8XQD7rb%q?F!JI9G/W4\bqN3A]Q=AET\^pP2-(Ytt&KR$6@Rh2!l2f>'07kF6G@5V((iJ%;pTs4.GS5SZj6/*t/:,4H1!'*%;6DlNV.ICcYO,pi0tLt2:4as4]f4AFlmUm?H>s[#(.R@7O^%$^\qN3D>hWI=qGUWd:_#%t55F@Cb-=-A8?Y+C)hPTnS>sV7`<AoJH4Ee=rfjn7AGp$Xg6S%72dC,3A(/sP`IlBVoY'BmjLeG';V/7@",&C5/q-#`h*I'1.]f$6U,#e]@j0N@GV^*!6$b_FOg6);4?2"58*s(Gfta[HZBb$;2H7,gjMpU*gZ\4UCr**#4*M$l(Giu9D*c`)Deif&n32&dg:E]mi-%Bm_2a8s&PZ%d7l:0%3i3W4?_q=5K:VSD]HFuuA18gsl<f_F&R3F(j\nU+m\aPt=B_'@:WS(B9,b(s<i'<r"a^p*DV8IF2&hGG"UXOJ;lt#%`IZeOhgf8]FUg]%>b1roc6,WN5HE02S1BN:6FoL(eV3Zs7d=h*k*7d;r/ulja'9QY0?,=gokCGdTq2bCL/5M89AN<P\LF!:@f_WEH3YDU>9(N"X:H?3>Ar%'87C9R-Dnu^mq8@VaAGXT?SGoRQ<8K7<B!Vr5-u+iW"!>!P=AcCE6:-VKj5j]'0qe_+Z?1F(?Qef)jf&'77YriQNb/F*0T)h4J&TAOE@s-VS&+$Ak5a4Y14X)U(`o=GEARZLain]LtIlSJ?LX?C.P:iHQX-prNn>!,U4r>p&uaZ/sUV&)_oA:9t<UDQ^P9?K7h[F_!/t:>k)k6WC!kL%mW*:JbaHo3==_6L%%eQ<gaQRVlF2mH<>h=)7h7+HT841>YBLkp*a4*9FQJ.\/2O22#W&aq#1ne'W2PnYh8+4BAA$E7ijN&CK*^K\RoR%kNkJ:&.b*TnCR(N7j3?3po?kGe>ldf(T5@uSA/0Y((2f@CCke"fl)?i?UP-eq21uEEnkZr4m4=2>$Lpp@p7&iA"3:u<T35D-?O@Caji:3KSK:/N4(gh;)BgS)ErEpJ_lH7dd#@Xi&N3U9K^u+i_qUfkYga5/Uc)F4%O.l1+lML_quMeBm9^&%)ZGY9\euER[B#*^j8osUD3s)48?g^ZF[Jprbr/Gjhli=LXPuVX?D$l(0s'9.Rl$^ijR$K(!_ps8u:0LO:2m#&D[Q6'3J^fOJ=K>Smf:2S!h/?+;Lo'3p-<HUY3r>"RVI77_o.j=g"SWS:;P!Yrsg?I:H6ZcIkQMSY*\$KD?H=GVL'@P:0OdI,so8_Vs>a)(Xg4?\A(.BPj%4G0.g&<iWcUYB6\@:1T<,2NqrfZmJLiai@F1\],,fN3Ca(.BBcC*n0D!XA'r*d`"C1Db+AIK>8!n@#3W)N`'uTE*iFAUH/D=5lMDRI7)HVq4*=@mP1>5Fj.`nFM1&ZcNQA]-[*j3?e_PIR]W7f^j>+EkA(!#@I4PF'WcF)q,J0dHMg3[53ptEk=tfR*W<-uE\;`O7=F-7epJCOkb8RJ,[K"-HWZiBX(+=iDS(*HV0pa+ks\VgBE&&uFINF~>endstream
+endobj
+17 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2136
+>>
+stream
+GauI8:N+uI&B4,:'Ki7NX;gtRZF@2TJ-$*8gNmeP:_Kla/!1<5)*pLc^7f4sY+;Xp5_T2hU6(o?a5NLH9Z!t%Q2'fN`Rr3gqf&13ABNJ-QHU^t[f2J=?GCi9Q\:LEl"#&q]h-jkO\Cq-jUL@cHYqK%T4A9IOL1^E-!OI;@[!lon(IPoXad+NJ,NH1kFYecVH"6NlGNRb-!(fY&<U8Reg4tNJo.C6-2Y7eL2U\qeRl6p#g6+.-WXj7Z:n>90:Xr;qS1%"&AQf8+7)Y..n(bKj+aD<`V<)"^lO2JQsdQ\U57BkYWHR*g.?A\?l)od9>&?9kCP]kmBkguqms=7S+i,AO+/39Z5S:7'P%d:AY<j[T`U8M9J_&sAjn0&2lD0j>?C!<bKE3kkpl'JA56mYX>Xt5DA=h$`=Q[(i#`OG/SJQ5:M&ctpAhh<T)Eu>EKEIo=0I7AapR_Efh]E%%1`PFTK_7?AR&Ha7+F'#Fc(!bWg2&!4kJHrVZ!-MCYOX7r+6)O;34)&Y8bJ'l$0O4.KL$2V,EFF(s,S$hX5q&UHh6/)URuDnXMD,!Y9"_KKU1?TJ+=V#$_D4$1.02V6+KU[/EuHXN=oSXAP'F=Do+Z?PLe&??`s'=iHqo5L.C<S]FEqZ[tKI1Mr()m;Ql5/tp6"H-7M@p3'M`_N84HI8M&*Xn]%8bf05\ALn<H"Qo@AHl8^7HCa2B?#aolh;l_A@L-#bV3?Ja@GZ\9m3%l_n>c+rj/@#FeKZ)TQ?Pa+g/OT!Xir$t@NUS8bXX'fEKEJ&PD8IQXWk(M<Mc8A8$XY4Q)OX7i_8Kh\rSj3<X%0OGt(&%i=8+K@F4]rQ:1ioEZdtue]dK!GhWIG1."!ZK+((0D7DcK.U:Fp5T4TRRBW+9SMLL(]2Fh4i$_fJ\L<F\^-7tLfn_3p_8TAbP-`D%:h3<]:@c(7ARr,"BL/9gHe8J0RB<>WI7Ah$a-JRrA09?hY=>I,EKEJrB;)WQ[$98NEk=E)Ro^$9m1'oAZ+A!O=d)%Z:^q-RZmhXZEJDAf4UN#Z"$-1O19?(["$mOIeV:R20eCpZm1"2"\I\-(#Sf!&1'mV:i7>i7-mu1b0TLs\1M`t@/gq/c."MM\N39Ai!C<;M11?TjDc$Y5#OP1MO/UfPE5AnklEFW_@O:j3?<NhX:^c;+K.r(HmQ8RX.OZ;f,ic$[UNC>,]2R-n_c'l*G0/tf\dVEcO^_s_II=BTia$80;,'.-A=&G-a2\A+P-ua@4)d@XcW2:?b;dQcrh8#W2:&\clVK'NU('+jPXmK4/FkU\5A@Nj7;Y*ZNV9.9j(.0E@7;PM*.UQ(G>"HrGCHnr>EM'h)F^bQ<pp3<5!lZ9K+%f%RQn1#VC#L-`fOK:Q[rnLWM_`=Tc9%YZSH1,q'aU>T[Z`h2n7q-r3M7K4cX?"0\_iiA7e6/Iu90@]3"_c],IA4`^'ep%c-#pd8,:4Y\t\al#OY5E6.gBMYU(h-(`1Nj64fC;;4aNgX,+8cU<C,c<Juq@KKd'#t;5Ek?RSpE;8_2OW:LE>Q5emSutP]NH(%GQpWfW-[)mX3kg[b(QL.Sk8:#Z.Hn3-J_Mu0F>s[QXc#i<)SuI,Boj_)V(R.mn**<:95HGFY`K2P9J%T;*,=9p:aQ!XSrZ\fiug]KcU+COlRsn`BuM7#%QA!4mPnDi!WNc-1AJlKpTG7Y+'F_6eCHK\csG;>2bX16_eq#g(,gr0pHa*_6G8;0$pkm/_f$a":%2Zl"keXMPTB,1\^YJ#%[%A3V)pNm)]B0.TI!J+-s`r-pB#cfMniqYQ2Cf+ku[W&dnXYdj\Tg99<<1f;i#^boq@qX7OWS&O?p7OVmP]grNld#CLGln+FdH7h;Pc?H+7%p&(GoK=.OfuhH*(9>-CPHe2NeT:upUYK:pLN-deI668g*;^[O^$CQeBFODM1aIKA>/G\Ka'ToFUf5'1u3f.m=#o#T/G_t.VrC).$l`,gBD)Q;_lMW[%q#4uqH_MU:!Ca1'cf'C@*<pjmnU]+GlUMPNj@:"+Y)L$3TF%A6l[e$'mMi2GUjB_RjF1q@fs'4i@%"c0;)n'i4Fqi%IoQqTXTiI6#d#-,PH2l:!0dq?m&4PY%JDZL4F)n1XiU\\5,b(=GBKlQ7p?l9]UQhh~>endstream
+endobj
+18 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 844
+>>
+stream
+GauI4;/b/B&BE]('_f\GMW+aOfNT`*:QrA4H/urP&*D/t;qnNoT71E#KT*>X65i1`@%HcGhuA1=##kB&oIC?c`sStf)6aOL26bbE#1[A]</mJ=XG\X88[6L*%*CT"Y[t)8IA=9[:"(GuM#j\2`<rOPN*!)3ha-o@eb^3\oj:.ZNj:3F(7%Quhe'[$Z1u$WN,Q.n6XIPXb6n%(llu]BWXcOY>[#a^X+656nl\QAgd7=`-QOLE)h3BbjBDNE%NMWOD6L_ZAS@dn<6W_l_N&*d+HN`2[XLl!QrDT):HA-kcs'*--\!07oqSka!dk5AcJi':*:ImFI!bPr&_/!9\DC>cK'CR16rg"-E.kW=WYVVnb!X(Cl]BP<M5!Xg7I1s%lG+3mYf;:u4jNR\HE28R5V!q$8qbOS`%%D*"\A_Y5*648StJBSaT'!Z_]i`-Y\5ohesVFU3Y"8uEaVHo0@qk2\7r;_8Hufe@&ucPg38N)+1V(Hb+M]rfEp=nKlu=VLQ+JW*XF1KW0T;tO!H)3'PQMn5h"@a8C*S<+?_,n(?oC'qJND<iCkk0j^klqk'tA22Z[\c<g8L$[p!eiLP9Y#\WPHfS/j5j%OjX_MnDo=4=XSE#jnt#f@Ci+Th@5TQM_GoCjlD^K-KJ4SPAhl)P_3]L.s;ohsF4VKJ2<Pbm:t%eBIQ0(^F.#K6=p1C9?b1,_q8GE5o^[,:WVQF.!0tYo`WI51A%YT7V@&\A1Nm/92M<ed[HG.$<^Tr6<X9JPFT:?Cq?YcJ?"YDl+QuV:$qd;/>g\\u<E[Yf_l@:bbVMpp6\6JbDp5#ATu'9:0:*-;$OiZT4t'9HQ`R!#86lpA~>endstream
+endobj
+19 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1407
+>>
+stream
+GatU4bAQ&o']%q&mP64HRE2]#aYJ8I(ncd\iMAIAFlb<B8;.b;+C@@r;R4bn3fn)"0>Mm1p[Gh[N3;]9V;Jj-qRE4`mkW$$[&GHX?7fm_Q+h([T$O_$bgk]fFgJU"BO.^CZCBARY/B5aFP-'-E/3e);dA2;L'u0'OrH"hEkCp]Y%-K4Pt^qD>NOBn?`rp_45-8VgMrlaOc$R#?<kk>M)HI:+o]=0Y9"t8NXt]1ci<=O>KGiqBCD-'=^Yc</:H>-SL4<X7ZeqA+ZAaB'?Ppa3)<5FAD<Np4@c8hS$*WT;lW*7$.Z[iSs1J.g=Zsd"l;\#Mm"IXP0F)?0a^Nr.Oa2!DZU:t!tSSMc&:qLKT1,MRKipoR.eOD;:XSmVu]l-UchI(8p5c-oH!obkss=^CD4;H`<9:D2tLG!a'e^_J_u+API$P-71WoQ.2gpR$;*fJ9)/s5pTEAB"s8\*rr2iWP-f".;l_ZNMI/EQ@@OG-%b!+7cbj9RMTP^:WWWa2W9)_F7`LITc=#C6fPBGt2Y%HDJq3InMQs#*!$dS*e9OtW.QKq"[`gcPRY"*c&!LH:PN#P8DCoBdmbs!aZcA.ZLZ"C79Ok;om5Z^bZOr0BDZOjL!/#'GKrKT2[F3I>C&kDL36WWEBl(oRgA^:!`<!77/KT%^`F>]V8,^,gU"KXKMrqN`lblQ6kpk@!0=%Ab"_2B%OE%!e9)I#8Zn\FecW1P87+8NgG:<P?Cdg'W\>(*PS1NI-1p.,9n"T1PK+L_?\9Q(W%3ciq33Y7IO$V&h%`c.[^kkJPmfead'R`c.BVpe[rOt6oa7m`oN(aTh#Wr[)l0$U"<Y*L!-O9(l;VI9lK<5Y]@!3;bHA\Cd1S$`6PF6i5eF/<ZqpHkBG*7Ah#\ZTE_J5j/W4^!e-N[BpZ.B2?V0oMi9=&]+:`YEj!X;WOnQ71m;u*H*PQs/TAT\Z-Z'\[f7Pg\s\O,+5WaOnq9\5W1@iU_l,A'K]p?-bHU9r)<L/B:s!m;KYO-,gYoX%lLFoQgAZ]N>dK]QggGLZJU-d26Zn<\n'hO:6teLX,l\I`0K4&l/62,uIl_gP-mk<6TIMMds?%daB?g$@IIelfQRT'Ih01K2l"Bs9^&f!gDm$e8]=R2#*SWOIGP+Q'6RERT];:;_^\cOm![U%H)-K>,C.ne]bGpHbfQj6]MlO645ucKgQkZ_NjYJLKP/80dE&<9IYFSS.mL"1tKPh@+Tk021XD:<-sk6[4NFhl@Ccb`4QL$2Mf*eY1!tHUYr4@O7-3fLTN)q:PBN%h^$(J;Y$l.Z;J"k41h&mf@rRI[K>Aq94.BlMp\%p$07lQCfGIYfj_VU`bb6+/fiX>,,Ar[st:ATthb%+?>N#9UV9S4bqg!055)@$!8Si^k.Q%(AH_)UpGOOHJP/d~>endstream
+endobj
+20 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1091
+>>
+stream
+Gau1-hbtFJ&BE],/,#eqfWk't^]F/Ng,e7&&%/6^iak[_7dhs"P!d:)^:OD6"U&oe(s$"NG*C8?IQ&uLoSLJh-igsli9Nf?E<:bI`3!VZ#(?8,31:o-M^Pj,RIu_L%%VR>)>CEX]gpOKR'r2'Z4K5=V:Q)1QpBG<K1WrB)J?o$'pdHRW6uWH$I37NCE04Rc7mMsarSCX"pU^Qo+c[3H&m/rB;`^r5LFjC_>R`EF8_a3_;e)J8->b:[C/o*74:j/]s27%<bKqc*E8>j(4.WHX?^#@EEa;dH3_mFUq'@0%D#RRMpg6)SG=)Va)W72V[=t0k7*UU;h4K'CUU*P=q9#);@6.L--ql$Y8qm^9li7LXIDD*fG;.PGV[:fLnFKFH0DUnGaN@m4QdX"*&oV-6)0Jc,3^PTWR^,;8/`!XrHO\T=[*iHLF'#'eMr8h.OX$CN$&ZS[8e99:Mrkf:1-Q8X^ZkcH:t>F'E2EXGR,K`Wuh'+`s;rWK[^Z&Dg:C-]+<]`X`0K>2VH21gWDG(cBkII79S3<:u/h%q5W!V6ib6H&e-u[DOp"%.@nSgjR!VW^bS"_+XiVAp^Lt.2jKON'Xs_C,rJS8LUuCL#]30d%-MD?<WF@Nh('1Dn"Z9<UtC!aic]:Uer"Ylgne*GM)LK!711%RJH`!(oKq,nDYde,XX?pola69,_IhA^XLj+J06nYJekU&'>I".;2KpF$PUi2%D&q:?74RT8I9OE:V$uTF_GVM7*U+Y<%&-9d%3q]h>s9cg-5d3*[g0EdYC/ZKC'CEhcl+N08M4Nb(((pja+T2mm,>;B^0keViJe=jD!FI()rQ-85]s7]WF3=i=Gl9YL+bP=.q>7Y$<cPHUq%VQ4bZ=4e*$FZ8X@'rq-jQ>dAPsn4qVOZN37&?E#>_7b14$5[7\Z?$XnH>O\YNTOMljS+W%p&k;BRfVY"AOF/+B*0V+\qZG*ajZf[DTjf67c]LX;-]=?e>H$pcp!1FV,662(aWoW"Mc3Bf4ef#*cP;8X?p4F'/N(e,2E#>C/ALF&>ER9Kd]F_q7b6iAiOE3U=%kB7tqPVA9'Btfm'W&%`Fk8YY*;p*U\b"5~>endstream
+endobj
+21 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 916
+>>
+stream
+GatUr?#SFN'Sc)P($DTk;]B0J@J#ScU:-h#=#*dE\?V2!GU,2T*BNo[GK`S#>1t[1#RI\`?CrUKIEWh0M_2]-*8ir6>)r^E&<D?!Jd0/A\;2XG't3NJnK;T<2M5&:'sMl2VK(**/t:+q64qjK:`>p(5S!.e&'29l=1uK`RUNnO<?d-N7&uFief/FcdN1dR$fXrgo/g6iFR/9bpT<]JSdkG#WNq"!8d$2YjMR959ARt\DT&4%eL!e/!c\4,_$T`_+#I$IPAU@:o]/cmd5q+5TML&u@,OkaRYOlaE]uSq?obu*YH\REm:9^DUs$//K,EiR!5bl.`10N>])-(teGsKi@VSDKK6!DX]6,5j(+jOs17[)+05u5=]Z9UkAf72Uonj5pm@n[6E"f?%?Tg:kc_VPP5tAbVE^lrqiZpBB%:,ON$ASfiM+!WeCMH!We26c8iuBeu&<8Z:<BJcHZDtgULpdd>](0LI'PQf,TI'RW?ol:tR7t9r^&@B<64r.ZC\uZ>Z/6h90:C4\L781?JKNK8;b::[]gnRN@NSF+qT#\h-mc9tn=S;'CZsL]<EC!Vik7#O6dDH.FNSt86D`H!gqbZO_D#MRnB#S^k@XFh<n#0#O@pBt>3pg(+,Y.$]4NKdr[,n<IF1D=@Q2.U3mc?08qi%7iK6e=f4$?:M30UJ2)"!ZrfUo<0\F539//m1TkK?A<k?6cd!).:++k>o644<XFt(X?(nYV#r-at.?>jj'B-ju(#*Y=hIeIMGmF$$i>#`h"X5p59-^s=0.S_S4>\#T)"pBbSq%Nh.p?)F2_g76i4VbHQ_G"UlU$8VJ"f\SeY"0sB+YAsEi<kJ8LLSZ64geZPVrDHinTcEdW?`ts-p=I6,;68^DtlX.37h;!8hKnh25E&:BbNM%E8m^<T^im'5t&Z~>endstream
+endobj
+22 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1126
+>>
+stream
+Gau0C9lo&I'YO<E]VCug<.Z3dj\*WcS3s30Ug\2S4HY^6QNS-*<'C'M>u7u(\B[p8`hOE"J-6p;Z.QMu']C?mpSoNc?dN_`"GrM'22QFH;Xl-j()Pj\`8dDHGeR;"90mihcc'q0`&q:bL<Fa]JJH+P;+to5?qfQ0//ZE9\_6/#[@se0A^(\7P5^VKjiSiCbU""u<4iM`^Ync_=YX5@<,6\CU)f=lpK]V:Q?eWGWVDfl2ro61)^ZmZ2ncNXqMhkFC?<*.X'Xb9o&6:@2WSH()-S!&<+A\\n=4B2m_#@<BT0F<bg'n0;N7[oYenIb<IGO04X#`<lCE%BE&/TV]3,'JqlAOuR>!V^0G?[9(b%/EO$E4rq[22%c0s4]=h`b[,$VqHHJXdnaJ=1B$fbPsALr(7hfGR,j5rDL/2/&c^n$b%`qW$3<6gY_>,?Ra>^:T';u(]4`M6,gV_V7C)[JHsb*cil6,eJ`<LIB#V2V1L[f?f$<F"Pt,X>S!<+/Um/`+ZRRS>"Q4-,V:Pa(3Fi#*tNHFA8u8RZn`boJ&1Ds4:5QemgUA2Y36=>E#s]YaL9OAunrZW.s$lel;.;(0P3S>;pM,c>\baEpZGK-40n/t<SH)r#SS0p0cU5p)b14cn(#KR5Zq:t9np=^<A"]S-a('9827O.C*OSKf-P=,->)&'iOsKm`4:pVAumOgc1g+3k=QS8."HYjgUn:$3`_dsr6EHt4TDn0c`ji,7bSfCZmmfEufX;AF:NX,VB4[8^02YOTsKm$MQZb%Og0)!]J*jZOsWf%@CIP7CU$=AFYSl%%c.5k3f.<rY#?\eIh9FK.MK#%ZsK\&H5ddrsj(H,u!rdrqh]=@7BGT/G?<b$#9:Q:=57FFeVf>1ID3^E3J;IcV&`=C>m!ds$P.!+7rmX=FHns6o/u=V:l%JdQ9Ae09W1\[i/5f8Y11Kno6i(g<Y8mW"!cVE1"eUP!2pZuU(P4M(!DLrrkYW9B5+5lBj*)ILC5oFnI,=0LE&%LYtJIY7?!"2EZgq]Q?%$oeLp#mZ=VR9PF`c-7uA%mn=[2k8ZSb9Vo`YAd7/6L+RGY3?J,V6Yj8.*eb*Goi+g14T)j,.=efVH\/;:=AOM^Rq3mMuNbXqc7&~>endstream
+endobj
+xref
+0 23
+0000000000 65535 f 
+0000000073 00000 n 
+0000000135 00000 n 
+0000000242 00000 n 
+0000000354 00000 n 
+0000000559 00000 n 
+0000000764 00000 n 
+0000000969 00000 n 
+0000001174 00000 n 
+0000001251 00000 n 
+0000001456 00000 n 
+0000001572 00000 n 
+0000001778 00000 n 
+0000001984 00000 n 
+0000002054 00000 n 
+0000002338 00000 n 
+0000002436 00000 n 
+0000004674 00000 n 
+0000006902 00000 n 
+0000007837 00000 n 
+0000009336 00000 n 
+0000010519 00000 n 
+0000011526 00000 n 
+trailer
+<<
+/ID 
+[<3f9bb9f0cf4b6f010efd0ce10cfac082><3f9bb9f0cf4b6f010efd0ce10cfac082>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 14 0 R
+/Root 13 0 R
+/Size 23
+>>
+startxref
+12744
+%%EOF

--- a/reports/content-validation-report.json
+++ b/reports/content-validation-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-29T18:45:25.689Z",
+  "generatedAt": "2025-09-29T18:52:25.220Z",
   "status": "passed",
   "totals": {
     "courses": 5,
@@ -197,20 +197,20 @@
         "withMetadata": 1,
         "missingMetadata": 0,
         "byGenerator": {
-          "Equipe EDU": 1
+          "Equipe EDU (conteúdo atualizado)": 1
         },
         "byModel": {
           "manual": 1
         },
-        "earliestTimestamp": "2025-02-20T12:00:00.000Z",
-        "latestTimestamp": "2025-02-20T12:00:00.000Z",
+        "earliestTimestamp": "2025-09-29T18:51:17Z",
+        "latestTimestamp": "2025-09-29T18:51:17Z",
         "entries": [
           {
             "id": "guia-estudos",
             "type": "reference",
-            "generatedBy": "Equipe EDU",
+            "generatedBy": "Equipe EDU (conteúdo atualizado)",
             "model": "manual",
-            "timestamp": "2025-02-20T12:00:00.000Z"
+            "timestamp": "2025-09-29T18:51:17Z"
           }
         ]
       },

--- a/src/content/courses/algi/supplements.json
+++ b/src/content/courses/algi/supplements.json
@@ -8,13 +8,13 @@
       "description": "Resumo dos objetivos de cada aula e exercícios recomendados para revisão semanal.",
       "type": "reference",
       "link": "courses/algi/supplements/guia-estudos.pdf",
-      "available": false,
+      "available": true,
       "file": "guia-estudos.pdf",
-      "estimatedReadingMinutes": 60,
+      "estimatedReadingMinutes": 75,
       "metadata": {
-        "generatedBy": "Equipe EDU",
+        "generatedBy": "Equipe EDU (conteúdo atualizado)",
         "model": "manual",
-        "timestamp": "2025-02-20T12:00:00.000Z"
+        "timestamp": "2025-09-29T18:51:17Z"
       }
     }
   ]

--- a/src/content/courses/algi/supplements/guia-estudos.pdf
+++ b/src/content/courses/algi/supplements/guia-estudos.pdf
@@ -1,0 +1,200 @@
+%PDF-1.4
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 8 0 R /F4 10 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 16 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 17 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 18 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 19 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/BaseFont /Symbol /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+9 0 obj
+<<
+/Contents 20 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+11 0 obj
+<<
+/Contents 21 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/Contents 22 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+13 0 obj
+<<
+/PageMode /UseNone /Pages 15 0 R /Type /Catalog
+>>
+endobj
+14 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20250929185105+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20250929185105+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+15 0 obj
+<<
+/Count 7 /Kids [ 4 0 R 5 0 R 6 0 R 7 0 R 9 0 R 11 0 R 12 0 R ] /Type /Pages
+>>
+endobj
+16 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2146
+>>
+stream
+GauHL9lJcG&A@7.nE;J;a-(:"hHQF\(Bk/Q]C>NY$SBcOUm.g@OrNK6mi+m)Ur5t1(H$dIdFXJ-mr@1m"#7Vfi;^fr&FW][nuk:]Tic/"0H8?VlBA_`SUE^1l8PJW*%f'>+;XRf3*8XCI##`Us4D58&0][2`TJZOL*F.eJ76OXJk7Yf"i1ht=,@dm?'5nY'">"l'B@#:(e3LgDiLS;`V%8q@eCjEIu'$^LR?UVpc11;E'AAU=R)\c.aMr'YB"2h6mA1h9nY(*FQXk"1;c4.`S@Iu>'W&t/athZ64"O!1mcn/9N>,\F54$8U[6fY*bI,M%Y#U3DU#'&P3T/hZ_CNe0PS?dpd2?T*f'aY`aFLsP?')5.'WsRDpKf"%"L/qK^$Hd4Gd[t'Gj!PkeD^+4fN2[<#3W>e0=$(ol(R>V)"6\/8euB4VNFQ=I1;WqEYk'"!b(m@RW^7aU':!S-0#7#+S8t6&A:"CXtE6j!UE?_lk\[5(lanGLL6.3*[ro:26d8k*ok#m4an#`ZZ4iF-rcib/1/!\a%%>=XmHd1QbO^YMsJh>iEWq&diq5TaN"E7g;*F:I6\2>Z2uSI$:]^;o3dRr#Dt^or)[8XQD7rb%q?F!JI9G/W4\bqN3A]Q=AET\^pP2-(Ytt&KR$6@Rh2!l2f>'07kF6G@5V((iJ%;pTs4.GS5SZj6/*t/:,4H1!'*%;6DlNV.ICcYO,pi0tLt2:4as4]f4AFlmUm?H>s[#(.R@7O^%$^\qN3D>hWI=qGUWd:_#%t55F@Cb-=-A8?Y+C)hPTnS>sV7`<AoJH4Ee=rfjn7AGp$Xg6S%72dC,3A(/sP`IlBVoY'BmjLeG';V/7@",&C5/q-#`h*I'1.]f$6U,#e]@j0N@GV^*!6$b_FOg6);4?2"58*s(Gfta[HZBb$;2H7,gjMpU*gZ\4UCr**#4*M$l(Giu9D*c`)Deif&n32&dg:E]mi-%Bm_2a8s&PZ%d7l:0%3i3W4?_q=5K:VSD]HFuuA18gsl<f_F&R3F(j\nU+m\aPt=B_'@:WS(B9,b(s<i'<r"a^p*DV8IF2&hGG"UXOJ;lt#%`IZeOhgf8]FUg]%>b1roc6,WN5HE02S1BN:6FoL(eV3Zs7d=h*k*7d;r/ulja'9QY0?,=gokCGdTq2bCL/5M89AN<P\LF!:@f_WEH3YDU>9(N"X:H?3>Ar%'87C9R-Dnu^mq8@VaAGXT?SGoRQ<8K7<B!Vr5-u+iW"!>!P=AcCE6:-VKj5j]'0qe_+Z?1F(?Qef)jf&'77YriQNb/F*0T)h4J&TAOE@s-VS&+$Ak5a4Y14X)U(`o=GEARZLain]LtIlSJ?LX?C.P:iHQX-prNn>!,U4r>p&uaZ/sUV&)_oA:9t<UDQ^P9?K7h[F_!/t:>k)k6WC!kL%mW*:JbaHo3==_6L%%eQ<gaQRVlF2mH<>h=)7h7+HT841>YBLkp*a4*9FQJ.\/2O22#W&aq#1ne'W2PnYh8+4BAA$E7ijN&CK*^K\RoR%kNkJ:&.b*TnCR(N7j3?3po?kGe>ldf(T5@uSA/0Y((2f@CCke"fl)?i?UP-eq21uEEnkZr4m4=2>$Lpp@p7&iA"3:u<T35D-?O@Caji:3KSK:/N4(gh;)BgS)ErEpJ_lH7dd#@Xi&N3U9K^u+i_qUfkYga5/Uc)F4%O.l1+lML_quMeBm9^&%)ZGY9\euER[B#*^j8osUD3s)48?g^ZF[Jprbr/Gjhli=LXPuVX?D$l(0s'9.Rl$^ijR$K(!_ps8u:0LO:2m#&D[Q6'3J^fOJ=K>Smf:2S!h/?+;Lo'3p-<HUY3r>"RVI77_o.j=g"SWS:;P!Yrsg?I:H6ZcIkQMSY*\$KD?H=GVL'@P:0OdI,so8_Vs>a)(Xg4?\A(.BPj%4G0.g&<iWcUYB6\@:1T<,2NqrfZmJLiai@F1\],,fN3Ca(.BBcC*n0D!XA'r*d`"C1Db+AIK>8!n@#3W)N`'uTE*iFAUH/D=5lMDRI7)HVq4*=@mP1>5Fj.`nFM1&ZcNQA]-[*j3?e_PIR]W7f^j>+EkA(!#@I4PF'WcF)q,J0dHMg3[53ptEk=tfR*W<-uE\;`O7=F-7epJCOkb8RJ,[K"-HWZiBX(+=iDS(*HV0pa+ks\VgBE&&uFINF~>endstream
+endobj
+17 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2136
+>>
+stream
+GauI8:N+uI&B4,:'Ki7NX;gtRZF@2TJ-$*8gNmeP:_Kla/!1<5)*pLc^7f4sY+;Xp5_T2hU6(o?a5NLH9Z!t%Q2'fN`Rr3gqf&13ABNJ-QHU^t[f2J=?GCi9Q\:LEl"#&q]h-jkO\Cq-jUL@cHYqK%T4A9IOL1^E-!OI;@[!lon(IPoXad+NJ,NH1kFYecVH"6NlGNRb-!(fY&<U8Reg4tNJo.C6-2Y7eL2U\qeRl6p#g6+.-WXj7Z:n>90:Xr;qS1%"&AQf8+7)Y..n(bKj+aD<`V<)"^lO2JQsdQ\U57BkYWHR*g.?A\?l)od9>&?9kCP]kmBkguqms=7S+i,AO+/39Z5S:7'P%d:AY<j[T`U8M9J_&sAjn0&2lD0j>?C!<bKE3kkpl'JA56mYX>Xt5DA=h$`=Q[(i#`OG/SJQ5:M&ctpAhh<T)Eu>EKEIo=0I7AapR_Efh]E%%1`PFTK_7?AR&Ha7+F'#Fc(!bWg2&!4kJHrVZ!-MCYOX7r+6)O;34)&Y8bJ'l$0O4.KL$2V,EFF(s,S$hX5q&UHh6/)URuDnXMD,!Y9"_KKU1?TJ+=V#$_D4$1.02V6+KU[/EuHXN=oSXAP'F=Do+Z?PLe&??`s'=iHqo5L.C<S]FEqZ[tKI1Mr()m;Ql5/tp6"H-7M@p3'M`_N84HI8M&*Xn]%8bf05\ALn<H"Qo@AHl8^7HCa2B?#aolh;l_A@L-#bV3?Ja@GZ\9m3%l_n>c+rj/@#FeKZ)TQ?Pa+g/OT!Xir$t@NUS8bXX'fEKEJ&PD8IQXWk(M<Mc8A8$XY4Q)OX7i_8Kh\rSj3<X%0OGt(&%i=8+K@F4]rQ:1ioEZdtue]dK!GhWIG1."!ZK+((0D7DcK.U:Fp5T4TRRBW+9SMLL(]2Fh4i$_fJ\L<F\^-7tLfn_3p_8TAbP-`D%:h3<]:@c(7ARr,"BL/9gHe8J0RB<>WI7Ah$a-JRrA09?hY=>I,EKEJrB;)WQ[$98NEk=E)Ro^$9m1'oAZ+A!O=d)%Z:^q-RZmhXZEJDAf4UN#Z"$-1O19?(["$mOIeV:R20eCpZm1"2"\I\-(#Sf!&1'mV:i7>i7-mu1b0TLs\1M`t@/gq/c."MM\N39Ai!C<;M11?TjDc$Y5#OP1MO/UfPE5AnklEFW_@O:j3?<NhX:^c;+K.r(HmQ8RX.OZ;f,ic$[UNC>,]2R-n_c'l*G0/tf\dVEcO^_s_II=BTia$80;,'.-A=&G-a2\A+P-ua@4)d@XcW2:?b;dQcrh8#W2:&\clVK'NU('+jPXmK4/FkU\5A@Nj7;Y*ZNV9.9j(.0E@7;PM*.UQ(G>"HrGCHnr>EM'h)F^bQ<pp3<5!lZ9K+%f%RQn1#VC#L-`fOK:Q[rnLWM_`=Tc9%YZSH1,q'aU>T[Z`h2n7q-r3M7K4cX?"0\_iiA7e6/Iu90@]3"_c],IA4`^'ep%c-#pd8,:4Y\t\al#OY5E6.gBMYU(h-(`1Nj64fC;;4aNgX,+8cU<C,c<Juq@KKd'#t;5Ek?RSpE;8_2OW:LE>Q5emSutP]NH(%GQpWfW-[)mX3kg[b(QL.Sk8:#Z.Hn3-J_Mu0F>s[QXc#i<)SuI,Boj_)V(R.mn**<:95HGFY`K2P9J%T;*,=9p:aQ!XSrZ\fiug]KcU+COlRsn`BuM7#%QA!4mPnDi!WNc-1AJlKpTG7Y+'F_6eCHK\csG;>2bX16_eq#g(,gr0pHa*_6G8;0$pkm/_f$a":%2Zl"keXMPTB,1\^YJ#%[%A3V)pNm)]B0.TI!J+-s`r-pB#cfMniqYQ2Cf+ku[W&dnXYdj\Tg99<<1f;i#^boq@qX7OWS&O?p7OVmP]grNld#CLGln+FdH7h;Pc?H+7%p&(GoK=.OfuhH*(9>-CPHe2NeT:upUYK:pLN-deI668g*;^[O^$CQeBFODM1aIKA>/G\Ka'ToFUf5'1u3f.m=#o#T/G_t.VrC).$l`,gBD)Q;_lMW[%q#4uqH_MU:!Ca1'cf'C@*<pjmnU]+GlUMPNj@:"+Y)L$3TF%A6l[e$'mMi2GUjB_RjF1q@fs'4i@%"c0;)n'i4Fqi%IoQqTXTiI6#d#-,PH2l:!0dq?m&4PY%JDZL4F)n1XiU\\5,b(=GBKlQ7p?l9]UQhh~>endstream
+endobj
+18 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 844
+>>
+stream
+GauI4;/b/B&BE]('_f\GMW+aOfNT`*:QrA4H/urP&*D/t;qnNoT71E#KT*>X65i1`@%HcGhuA1=##kB&oIC?c`sStf)6aOL26bbE#1[A]</mJ=XG\X88[6L*%*CT"Y[t)8IA=9[:"(GuM#j\2`<rOPN*!)3ha-o@eb^3\oj:.ZNj:3F(7%Quhe'[$Z1u$WN,Q.n6XIPXb6n%(llu]BWXcOY>[#a^X+656nl\QAgd7=`-QOLE)h3BbjBDNE%NMWOD6L_ZAS@dn<6W_l_N&*d+HN`2[XLl!QrDT):HA-kcs'*--\!07oqSka!dk5AcJi':*:ImFI!bPr&_/!9\DC>cK'CR16rg"-E.kW=WYVVnb!X(Cl]BP<M5!Xg7I1s%lG+3mYf;:u4jNR\HE28R5V!q$8qbOS`%%D*"\A_Y5*648StJBSaT'!Z_]i`-Y\5ohesVFU3Y"8uEaVHo0@qk2\7r;_8Hufe@&ucPg38N)+1V(Hb+M]rfEp=nKlu=VLQ+JW*XF1KW0T;tO!H)3'PQMn5h"@a8C*S<+?_,n(?oC'qJND<iCkk0j^klqk'tA22Z[\c<g8L$[p!eiLP9Y#\WPHfS/j5j%OjX_MnDo=4=XSE#jnt#f@Ci+Th@5TQM_GoCjlD^K-KJ4SPAhl)P_3]L.s;ohsF4VKJ2<Pbm:t%eBIQ0(^F.#K6=p1C9?b1,_q8GE5o^[,:WVQF.!0tYo`WI51A%YT7V@&\A1Nm/92M<ed[HG.$<^Tr6<X9JPFT:?Cq?YcJ?"YDl+QuV:$qd;/>g\\u<E[Yf_l@:bbVMpp6\6JbDp5#ATu'9:0:*-;$OiZT4t'9HQ`R!#86lpA~>endstream
+endobj
+19 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1407
+>>
+stream
+GatU4bAQ&o']%q&mP64HRE2]#aYJ8I(ncd\iMAIAFlb<B8;.b;+C@@r;R4bn3fn)"0>Mm1p[Gh[N3;]9V;Jj-qRE4`mkW$$[&GHX?7fm_Q+h([T$O_$bgk]fFgJU"BO.^CZCBARY/B5aFP-'-E/3e);dA2;L'u0'OrH"hEkCp]Y%-K4Pt^qD>NOBn?`rp_45-8VgMrlaOc$R#?<kk>M)HI:+o]=0Y9"t8NXt]1ci<=O>KGiqBCD-'=^Yc</:H>-SL4<X7ZeqA+ZAaB'?Ppa3)<5FAD<Np4@c8hS$*WT;lW*7$.Z[iSs1J.g=Zsd"l;\#Mm"IXP0F)?0a^Nr.Oa2!DZU:t!tSSMc&:qLKT1,MRKipoR.eOD;:XSmVu]l-UchI(8p5c-oH!obkss=^CD4;H`<9:D2tLG!a'e^_J_u+API$P-71WoQ.2gpR$;*fJ9)/s5pTEAB"s8\*rr2iWP-f".;l_ZNMI/EQ@@OG-%b!+7cbj9RMTP^:WWWa2W9)_F7`LITc=#C6fPBGt2Y%HDJq3InMQs#*!$dS*e9OtW.QKq"[`gcPRY"*c&!LH:PN#P8DCoBdmbs!aZcA.ZLZ"C79Ok;om5Z^bZOr0BDZOjL!/#'GKrKT2[F3I>C&kDL36WWEBl(oRgA^:!`<!77/KT%^`F>]V8,^,gU"KXKMrqN`lblQ6kpk@!0=%Ab"_2B%OE%!e9)I#8Zn\FecW1P87+8NgG:<P?Cdg'W\>(*PS1NI-1p.,9n"T1PK+L_?\9Q(W%3ciq33Y7IO$V&h%`c.[^kkJPmfead'R`c.BVpe[rOt6oa7m`oN(aTh#Wr[)l0$U"<Y*L!-O9(l;VI9lK<5Y]@!3;bHA\Cd1S$`6PF6i5eF/<ZqpHkBG*7Ah#\ZTE_J5j/W4^!e-N[BpZ.B2?V0oMi9=&]+:`YEj!X;WOnQ71m;u*H*PQs/TAT\Z-Z'\[f7Pg\s\O,+5WaOnq9\5W1@iU_l,A'K]p?-bHU9r)<L/B:s!m;KYO-,gYoX%lLFoQgAZ]N>dK]QggGLZJU-d26Zn<\n'hO:6teLX,l\I`0K4&l/62,uIl_gP-mk<6TIMMds?%daB?g$@IIelfQRT'Ih01K2l"Bs9^&f!gDm$e8]=R2#*SWOIGP+Q'6RERT];:;_^\cOm![U%H)-K>,C.ne]bGpHbfQj6]MlO645ucKgQkZ_NjYJLKP/80dE&<9IYFSS.mL"1tKPh@+Tk021XD:<-sk6[4NFhl@Ccb`4QL$2Mf*eY1!tHUYr4@O7-3fLTN)q:PBN%h^$(J;Y$l.Z;J"k41h&mf@rRI[K>Aq94.BlMp\%p$07lQCfGIYfj_VU`bb6+/fiX>,,Ar[st:ATthb%+?>N#9UV9S4bqg!055)@$!8Si^k.Q%(AH_)UpGOOHJP/d~>endstream
+endobj
+20 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1091
+>>
+stream
+Gau1-hbtFJ&BE],/,#eqfWk't^]F/Ng,e7&&%/6^iak[_7dhs"P!d:)^:OD6"U&oe(s$"NG*C8?IQ&uLoSLJh-igsli9Nf?E<:bI`3!VZ#(?8,31:o-M^Pj,RIu_L%%VR>)>CEX]gpOKR'r2'Z4K5=V:Q)1QpBG<K1WrB)J?o$'pdHRW6uWH$I37NCE04Rc7mMsarSCX"pU^Qo+c[3H&m/rB;`^r5LFjC_>R`EF8_a3_;e)J8->b:[C/o*74:j/]s27%<bKqc*E8>j(4.WHX?^#@EEa;dH3_mFUq'@0%D#RRMpg6)SG=)Va)W72V[=t0k7*UU;h4K'CUU*P=q9#);@6.L--ql$Y8qm^9li7LXIDD*fG;.PGV[:fLnFKFH0DUnGaN@m4QdX"*&oV-6)0Jc,3^PTWR^,;8/`!XrHO\T=[*iHLF'#'eMr8h.OX$CN$&ZS[8e99:Mrkf:1-Q8X^ZkcH:t>F'E2EXGR,K`Wuh'+`s;rWK[^Z&Dg:C-]+<]`X`0K>2VH21gWDG(cBkII79S3<:u/h%q5W!V6ib6H&e-u[DOp"%.@nSgjR!VW^bS"_+XiVAp^Lt.2jKON'Xs_C,rJS8LUuCL#]30d%-MD?<WF@Nh('1Dn"Z9<UtC!aic]:Uer"Ylgne*GM)LK!711%RJH`!(oKq,nDYde,XX?pola69,_IhA^XLj+J06nYJekU&'>I".;2KpF$PUi2%D&q:?74RT8I9OE:V$uTF_GVM7*U+Y<%&-9d%3q]h>s9cg-5d3*[g0EdYC/ZKC'CEhcl+N08M4Nb(((pja+T2mm,>;B^0keViJe=jD!FI()rQ-85]s7]WF3=i=Gl9YL+bP=.q>7Y$<cPHUq%VQ4bZ=4e*$FZ8X@'rq-jQ>dAPsn4qVOZN37&?E#>_7b14$5[7\Z?$XnH>O\YNTOMljS+W%p&k;BRfVY"AOF/+B*0V+\qZG*ajZf[DTjf67c]LX;-]=?e>H$pcp!1FV,662(aWoW"Mc3Bf4ef#*cP;8X?p4F'/N(e,2E#>C/ALF&>ER9Kd]F_q7b6iAiOE3U=%kB7tqPVA9'Btfm'W&%`Fk8YY*;p*U\b"5~>endstream
+endobj
+21 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 916
+>>
+stream
+GatUr?#SFN'Sc)P($DTk;]B0J@J#ScU:-h#=#*dE\?V2!GU,2T*BNo[GK`S#>1t[1#RI\`?CrUKIEWh0M_2]-*8ir6>)r^E&<D?!Jd0/A\;2XG't3NJnK;T<2M5&:'sMl2VK(**/t:+q64qjK:`>p(5S!.e&'29l=1uK`RUNnO<?d-N7&uFief/FcdN1dR$fXrgo/g6iFR/9bpT<]JSdkG#WNq"!8d$2YjMR959ARt\DT&4%eL!e/!c\4,_$T`_+#I$IPAU@:o]/cmd5q+5TML&u@,OkaRYOlaE]uSq?obu*YH\REm:9^DUs$//K,EiR!5bl.`10N>])-(teGsKi@VSDKK6!DX]6,5j(+jOs17[)+05u5=]Z9UkAf72Uonj5pm@n[6E"f?%?Tg:kc_VPP5tAbVE^lrqiZpBB%:,ON$ASfiM+!WeCMH!We26c8iuBeu&<8Z:<BJcHZDtgULpdd>](0LI'PQf,TI'RW?ol:tR7t9r^&@B<64r.ZC\uZ>Z/6h90:C4\L781?JKNK8;b::[]gnRN@NSF+qT#\h-mc9tn=S;'CZsL]<EC!Vik7#O6dDH.FNSt86D`H!gqbZO_D#MRnB#S^k@XFh<n#0#O@pBt>3pg(+,Y.$]4NKdr[,n<IF1D=@Q2.U3mc?08qi%7iK6e=f4$?:M30UJ2)"!ZrfUo<0\F539//m1TkK?A<k?6cd!).:++k>o644<XFt(X?(nYV#r-at.?>jj'B-ju(#*Y=hIeIMGmF$$i>#`h"X5p59-^s=0.S_S4>\#T)"pBbSq%Nh.p?)F2_g76i4VbHQ_G"UlU$8VJ"f\SeY"0sB+YAsEi<kJ8LLSZ64geZPVrDHinTcEdW?`ts-p=I6,;68^DtlX.37h;!8hKnh25E&:BbNM%E8m^<T^im'5t&Z~>endstream
+endobj
+22 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1126
+>>
+stream
+Gau0C9lo&I'YO<E]VCug<.Z3dj\*WcS3s30Ug\2S4HY^6QNS-*<'C'M>u7u(\B[p8`hOE"J-6p;Z.QMu']C?mpSoNc?dN_`"GrM'22QFH;Xl-j()Pj\`8dDHGeR;"90mihcc'q0`&q:bL<Fa]JJH+P;+to5?qfQ0//ZE9\_6/#[@se0A^(\7P5^VKjiSiCbU""u<4iM`^Ync_=YX5@<,6\CU)f=lpK]V:Q?eWGWVDfl2ro61)^ZmZ2ncNXqMhkFC?<*.X'Xb9o&6:@2WSH()-S!&<+A\\n=4B2m_#@<BT0F<bg'n0;N7[oYenIb<IGO04X#`<lCE%BE&/TV]3,'JqlAOuR>!V^0G?[9(b%/EO$E4rq[22%c0s4]=h`b[,$VqHHJXdnaJ=1B$fbPsALr(7hfGR,j5rDL/2/&c^n$b%`qW$3<6gY_>,?Ra>^:T';u(]4`M6,gV_V7C)[JHsb*cil6,eJ`<LIB#V2V1L[f?f$<F"Pt,X>S!<+/Um/`+ZRRS>"Q4-,V:Pa(3Fi#*tNHFA8u8RZn`boJ&1Ds4:5QemgUA2Y36=>E#s]YaL9OAunrZW.s$lel;.;(0P3S>;pM,c>\baEpZGK-40n/t<SH)r#SS0p0cU5p)b14cn(#KR5Zq:t9np=^<A"]S-a('9827O.C*OSKf-P=,->)&'iOsKm`4:pVAumOgc1g+3k=QS8."HYjgUn:$3`_dsr6EHt4TDn0c`ji,7bSfCZmmfEufX;AF:NX,VB4[8^02YOTsKm$MQZb%Og0)!]J*jZOsWf%@CIP7CU$=AFYSl%%c.5k3f.<rY#?\eIh9FK.MK#%ZsK\&H5ddrsj(H,u!rdrqh]=@7BGT/G?<b$#9:Q:=57FFeVf>1ID3^E3J;IcV&`=C>m!ds$P.!+7rmX=FHns6o/u=V:l%JdQ9Ae09W1\[i/5f8Y11Kno6i(g<Y8mW"!cVE1"eUP!2pZuU(P4M(!DLrrkYW9B5+5lBj*)ILC5oFnI,=0LE&%LYtJIY7?!"2EZgq]Q?%$oeLp#mZ=VR9PF`c-7uA%mn=[2k8ZSb9Vo`YAd7/6L+RGY3?J,V6Yj8.*eb*Goi+g14T)j,.=efVH\/;:=AOM^Rq3mMuNbXqc7&~>endstream
+endobj
+xref
+0 23
+0000000000 65535 f 
+0000000073 00000 n 
+0000000135 00000 n 
+0000000242 00000 n 
+0000000354 00000 n 
+0000000559 00000 n 
+0000000764 00000 n 
+0000000969 00000 n 
+0000001174 00000 n 
+0000001251 00000 n 
+0000001456 00000 n 
+0000001572 00000 n 
+0000001778 00000 n 
+0000001984 00000 n 
+0000002054 00000 n 
+0000002338 00000 n 
+0000002436 00000 n 
+0000004674 00000 n 
+0000006902 00000 n 
+0000007837 00000 n 
+0000009336 00000 n 
+0000010519 00000 n 
+0000011526 00000 n 
+trailer
+<<
+/ID 
+[<3f9bb9f0cf4b6f010efd0ce10cfac082><3f9bb9f0cf4b6f010efd0ce10cfac082>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 14 0 R
+/Root 13 0 R
+/Size 23
+>>
+startxref
+12744
+%%EOF


### PR DESCRIPTION
## Summary
- add the Algoritmos I study guide PDF covering the 40 aulas, roteiros de estudo e referências
- expose the supplement in the Algoritmos I manifest with refreshed metadata and availability status
- refresh the content validation report capturing the new supplement metadata

## Testing
- npm run validate:content

------
https://chatgpt.com/codex/tasks/task_e_68dad4a65400832c9101e1894e18d0b4