### PR TITLE
Fix evaluation lesson titles for TGS course index

### DIFF
--- a/src/content/courses/tgs/lessons.json
+++ b/src/content/courses/tgs/lessons.json
@@ -147,23 +147,23 @@
     },
     {
       "id": "lesson-14",
-      "title": "Aula 28: Avaliação – NP2",
+      "title": "Aula 14: Avaliação – NP2",
       "file": "lesson-14.json",
       "available": true,
-      "description": "Aplica avaliação NP2 integrando sistemas abertos, fluxos e homeostase em estudos de caso.",
-      "summary": "Avaliação NP2 voltada à síntese de sistemas abertos, fluxos e homeostase, articulando teoria e estudos de caso.",
-      "tags": ["avaliacao", "np2", "pensamento-sistemico"],
+      "description": "Aplica a avaliação NP2 da aula 14, integrando sistemas abertos, fluxos e homeostase em estudos de caso.",
+      "summary": "Avaliação NP2 da aula 14, sintetizando sistemas abertos, fluxos e homeostase com articulação entre teoria e estudos de caso.",
+      "tags": ["avaliacao", "np2", "aula-14"],
       "duration": 110,
       "formatVersion": "md3.lesson.v1"
     },
     {
       "id": "lesson-15",
-      "title": "Aula 40: Avaliação Final – NP3",
+      "title": "Aula 15: Avaliação Final – NP3",
       "file": "lesson-15.json",
       "available": true,
-      "description": "Conduz avaliação final integradora cobrindo todos os temas da disciplina.",
-      "summary": "Avaliação final NP3 integrando todos os conteúdos da disciplina, com foco na aplicação crítica da Teoria Geral dos Sistemas.",
-      "tags": ["avaliacao", "np3", "integrador"],
+      "description": "Conduz a avaliação final da aula 15, integrando todos os temas abordados na disciplina.",
+      "summary": "Avaliação final NP3 da aula 15, reunindo todos os conteúdos para aplicação crítica da Teoria Geral dos Sistemas.",
+      "tags": ["avaliacao", "np3", "aula-15"],
       "duration": 110,
       "formatVersion": "md3.lesson.v1"
     }


### PR DESCRIPTION
## Summary
- update the TGS course manifest to rename the NP2 and NP3 lessons as Aula 14 and Aula 15
- align the descriptions, summaries, and tags of the evaluation lessons with the corrected numbering to keep the index consistent

## Testing
- npm run build
- node - <<'NODE'
const fs = require('fs');
const data = JSON.parse(fs.readFileSync('src/content/courses/tgs/lessons.json', 'utf8'));
const titles = data.entries.filter(e => /lesson-1[45]/.test(e.id)).map(e => ({id:e.id, title:e.title}));
console.log(titles);
const ids = data.entries.map(e=>e.id).sort();
const missing = [];
for (let i=1;i<=15;i++){const num=String(i).padStart(2,'0');if(!ids.includes(`lesson-${num}`)) missing.push(num);}
console.log('Total aulas:', data.entries.length);
console.log('Ids faltantes:', missing);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68dad6913f1c832ca8ca34a84611b85d