### PR TITLE
Add supplemental materials to ALG I lessons 06-11

### DIFF
--- a/src/content/courses/algi/lessons/lesson-06.json
+++ b/src/content/courses/algi/lessons/lesson-06.json
@@ -130,7 +130,7 @@
     },
     {
       "type": "md3Table",
-      "headers": ["Tipo", "Intervalo aproximado", "Especificador", "Uso comum"],
+      "headers": ["Tipo", "Intervalo aproximado", "printf", "scanf", "Uso comum"],
       "rows": [
         [
           {
@@ -140,10 +140,34 @@
             "value": "-2.147.483.648 a 2.147.483.647"
           },
           {
-            "value": "%d"
+            "value": "%d",
+            "mono": true
+          },
+          {
+            "value": "%d",
+            "mono": true
           },
           {
             "value": "Contagens, idades, quantidades"
+          }
+        ],
+        [
+          {
+            "value": "unsigned int"
+          },
+          {
+            "value": "0 a 4.294.967.295"
+          },
+          {
+            "value": "%u",
+            "mono": true
+          },
+          {
+            "value": "%u",
+            "mono": true
+          },
+          {
+            "value": "Contadores que nunca ficam negativos"
           }
         ],
         [
@@ -154,7 +178,12 @@
             "value": "±3.4e38 (7 casas)"
           },
           {
-            "value": "%f"
+            "value": "%0.2f",
+            "mono": true
+          },
+          {
+            "value": "%f",
+            "mono": true
           },
           {
             "value": "Médias, preços, sensores"
@@ -168,7 +197,12 @@
             "value": "±1.7e308 (15 casas)"
           },
           {
-            "value": "%lf"
+            "value": "%0.4lf",
+            "mono": true
+          },
+          {
+            "value": "%lf",
+            "mono": true
           },
           {
             "value": "Cálculos científicos, finanças"
@@ -182,12 +216,60 @@
             "value": "0 a 255"
           },
           {
-            "value": "%c"
+            "value": "%c",
+            "mono": true
           },
           {
-            "value": "Caracteres isolados"
+            "value": " %c",
+            "mono": true
+          },
+          {
+            "value": "Caracteres isolados, respostas de menu"
+          }
+        ],
+        [
+          {
+            "value": "char[]"
+          },
+          {
+            "value": "Strings terminadas com caractere nulo"
+          },
+          {
+            "value": "%s",
+            "mono": true
+          },
+          {
+            "value": " %29s",
+            "mono": true
+          },
+          {
+            "value": "Nomes, descrições curtas"
           }
         ]
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Cheat sheet C para consulta rápida",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Salve o resumo oficial com sintaxe de tipos, operadores e formatação para tirar dúvidas durante o laboratório: https://example.edu/algi/guias/c-cheatsheet.pdf"
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Destacar na folha os especificadores de printf/scanf mais usados nesta aula."
+            },
+            {
+              "text": "Registrar exemplos adicionais de constantes e intervalos com base nos exercícios."
+            },
+            {
+              "text": "Anotar perguntas para trazer ao plantão ou fórum do Moodle."
+            }
+          ]
+        }
       ]
     },
     {
@@ -239,6 +321,31 @@
         "Declarei variáveis e constantes usando tipos corretos.",
         "Testei entradas válidas e inválidas.",
         "Atualizei minha tabela de especificadores printf/scanf."
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "Teste no OnlineGDB antes de entregar",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Execute o código no projeto pré-configurado e registre evidências."
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Valide pelo menos três cenários (padrão, limite e inválido)."
+            },
+            {
+              "text": "Faça captura de tela do console com os testes principais."
+            },
+            {
+              "text": "Anexe o link da execução compartilhável quando enviar a TED."
+            }
+          ]
+        }
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-07.json
+++ b/src/content/courses/algi/lessons/lesson-07.json
@@ -413,6 +413,96 @@
       ]
     },
     {
+      "type": "truthTable",
+      "title": "Operadores relacionais alimentando decisões lógicas",
+      "headers": [
+        "Entrada",
+        "idade >= 18",
+        "cartao == 'S'",
+        "Pode viajar (idade >= 18 && cartao == 'S')"
+      ],
+      "rows": [
+        [
+          {
+            "value": "17 anos, cartão S"
+          },
+          {
+            "state": "false",
+            "display": "Falso"
+          },
+          {
+            "state": "true",
+            "display": "Verdadeiro"
+          },
+          {
+            "state": "false",
+            "display": "Barrado"
+          }
+        ],
+        [
+          {
+            "value": "18 anos, cartão N"
+          },
+          {
+            "state": "true",
+            "display": "Verdadeiro"
+          },
+          {
+            "state": "false",
+            "display": "Falso"
+          },
+          {
+            "state": "false",
+            "display": "Barrado"
+          }
+        ],
+        [
+          {
+            "value": "21 anos, cartão S"
+          },
+          {
+            "state": "true",
+            "display": "Verdadeiro"
+          },
+          {
+            "state": "true",
+            "display": "Verdadeiro"
+          },
+          {
+            "state": "true",
+            "display": "Autorizado"
+          }
+        ],
+        [
+          {
+            "value": "16 anos, cartão N"
+          },
+          {
+            "state": "false",
+            "display": "Falso"
+          },
+          {
+            "state": "false",
+            "display": "Falso"
+          },
+          {
+            "state": "false",
+            "display": "Barrado"
+          }
+        ]
+      ],
+      "legend": [
+        {
+          "label": "Condição satisfeita",
+          "state": "true"
+        },
+        {
+          "label": "Condição não satisfeita",
+          "state": "false"
+        }
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Precedência e agrupamento",
       "content": [
@@ -427,6 +517,21 @@
             "Evite misturar muitos operadores diferentes em uma única linha.",
             "Teste expressões complexas isoladamente antes de inseri-las em decisões.",
             "Documente com comentários quando a intenção não for óbvia."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Worksheet progressiva",
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            "Nível 1 – Resolva cinco expressões simples e marque o operador dominante.",
+            "Nível 2 – Compare pares de valores e complete os resultados esperados em uma tabela.",
+            "Nível 3 – Combine relacionais e lógicos, anotando o passo a passo que levou ao valor final.",
+            "Nível 4 – Reescreva as expressões usando parênteses para deixar a intenção explícita e valide no OnlineGDB."
           ]
         }
       ]
@@ -464,6 +569,16 @@
           "type": "code",
           "language": "c",
           "code": "float n1, n2, n3;\nfloat media;\n\nprintf(\"Digite as tres notas: \");\nscanf(\"%f %f %f\", &n1, &n2, &n3);\nmedia = (n1 * 4 + n2 * 3 + n3 * 3) / 10.0f;\nif (media >= 7.0f && media <= 10.0f) {\n  printf(\"Aprovado com media %.1f\\n\", media);\n} else if (media >= 5.0f) {\n  printf(\"Recuperacao com media %.1f\\n\", media);\n} else {\n  printf(\"Reprovado com media %.1f\\n\", media);\n}\n"
+        }
+      ]
+    },
+    {
+      "type": "videos",
+      "title": "Reforço em precedência",
+      "videos": [
+        {
+          "title": "Ordem de operadores em C",
+          "src": "https://www.youtube.com/embed/JnAmSrg0xgk"
         }
       ]
     },

--- a/src/content/courses/algi/lessons/lesson-08.json
+++ b/src/content/courses/algi/lessons/lesson-08.json
@@ -176,6 +176,26 @@
       ]
     },
     {
+      "type": "contentBlock",
+      "title": "Encadeando leituras e cálculos",
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            "Leia primeiro todos os dados brutos (preço, quantidade, descontos).",
+            "Crie variáveis para armazenar cada subtotal antes de aplicar novos fatores.",
+            "Atualize o recibo a cada etapa, imprimindo valores intermediários para validar.",
+            "Teste sequências alternativas (com ou sem desconto) para garantir consistência."
+          ]
+        },
+        {
+          "type": "code",
+          "language": "c",
+          "code": "float base, descontoPromocional, descontoFidelidade, total;\nscanf(\"%f %f %f\", &base, &descontoPromocional, &descontoFidelidade);\nfloat etapa1 = base - descontoPromocional;\nfloat etapa2 = etapa1 - (etapa1 * descontoFidelidade / 100.0f);\nprintf(\"Subtotal: %.2f\\n\", etapa1);\nprintf(\"Total final: %.2f\\n\", etapa2);"
+        }
+      ]
+    },
+    {
       "type": "callout",
       "variant": "good-practice",
       "title": "Máscaras printf úteis",
@@ -227,6 +247,19 @@
         ],
         [
           {
+            "value": "%010.2f",
+            "mono": true
+          },
+          {
+            "value": "Preenche com zeros até 10 caracteres"
+          },
+          {
+            "value": "0000123.45",
+            "code": true
+          }
+        ],
+        [
+          {
             "value": "%d%%",
             "mono": true
           },
@@ -235,6 +268,19 @@
           },
           {
             "value": "10%",
+            "code": true
+          }
+        ],
+        [
+          {
+            "value": "%#x",
+            "mono": true
+          },
+          {
+            "value": "Inteiro em hexadecimal com prefixo 0x"
+          },
+          {
+            "value": "0x7b",
             "code": true
           }
         ],
@@ -270,6 +316,42 @@
           "type": "code",
           "language": "c",
           "code": "printf(\"--- RECIBO ---\\n\");\nprintf(\"%-12s %3s %10s\\n\", \"Produto\", \"Qtd\", \"Subtotal\");\nprintf(\"%-12s %3d R$ %8.2f\\n\", nome1, qtd1, subtotal1);"
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Template completo de recibo",
+      "content": [
+        {
+          "type": "code",
+          "language": "c",
+          "code": "#include <stdio.h>\n\nint main(void) {\n  char produto1[30], produto2[30];\n  int qtd1, qtd2;\n  float preco1, preco2;\n\n  printf(\"Item, quantidade e preço: \");\n  scanf(\"%29s %d %f\", produto1, &qtd1, &preco1);\n  printf(\"Item, quantidade e preço: \");\n  scanf(\"%29s %d %f\", produto2, &qtd2, &preco2);\n\n  float subtotal1 = qtd1 * preco1;\n  float subtotal2 = qtd2 * preco2;\n  float subtotal = subtotal1 + subtotal2;\n  float desconto = subtotal * 0.10f;\n  float total = subtotal - desconto;\n\n  printf(\"\\n--- RECIBO DIGITAL ---\\n\");\n  printf(\"%-12s %3s %10s\\n\", \"Produto\", \"Qtd\", \"Subtotal\");\n  printf(\"%-12s %3d R$ %8.2f\\n\", produto1, qtd1, subtotal1);\n  printf(\"%-12s %3d R$ %8.2f\\n\", produto2, qtd2, subtotal2);\n  printf(\"---------------------------\\n\");\n  printf(\"Subtotal:      R$ %8.2f\\n\", subtotal);\n  printf(\"Desconto (10%%): R$ %8.2f\\n\", desconto);\n  printf(\"TOTAL:         R$ %8.2f\\n\", total);\n  return 0;\n}\n"
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "error",
+      "title": "Comprovação visual obrigatória",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Capture o console exibindo o recibo final e o código utilizado lado a lado antes de enviar a atividade."
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Mostre pelo menos dois cenários diferentes (com desconto e sem desconto adicional)."
+            },
+            {
+              "text": "Garanta que a máscara printf usada apareça claramente na captura."
+            },
+            {
+              "text": "Nomeie o arquivo da evidência como screenshot_aula08.png e anexe ao Moodle."
+            }
+          ]
         }
       ]
     },

--- a/src/content/courses/algi/lessons/lesson-09.json
+++ b/src/content/courses/algi/lessons/lesson-09.json
@@ -31,6 +31,11 @@
       "url": "https://example.edu/algi/guias/casos-sequenciais.pdf"
     },
     {
+      "label": "Planilha de dados de teste compartilhada",
+      "type": "spreadsheet",
+      "url": "https://docs.google.com/spreadsheets/d/1ALGI_testeSequencial"
+    },
+    {
       "label": "Repositório de exemplos resolvidos",
       "type": "repository",
       "url": "https://example.edu/algi/repos/sequencial-exemplos"
@@ -116,13 +121,13 @@
       "type": "flightPlan",
       "title": "Plano de voo (1h55)",
       "items": [
-        "(10 min) Revisão colaborativa do fluxo sequencial.",
-        "(25 min) Estudo de caso: salário líquido com descontos e gratificações.",
-        "(20 min) Estudo de caso: calculadora de IMC com análise textual.",
-        "(20 min) Debate: padrões em comum e validações.",
-        "(30 min) Oficina em duplas: problema escolhido.",
-        "(10 min) Apresentações rápidas e feedback.",
-        "(10 min) TED e registro dos testes."
+        "(10 min) Check-in colaborativo reforçando Entrada → Processamento → Saída.",
+        "(25 min) Estudo de caso 1 — Salário líquido (usa planilha de dados de teste e valida descontos).",
+        "(20 min) Estudo de caso 2 — IMC comentado (interpretação + mensagens ao usuário).",
+        "(15 min) Estudo de caso 3 — Desconto cumulativo (explora encadeamento de cálculos).",
+        "(15 min) Debate guiado: padrões encontrados e ajustes necessários.",
+        "(30 min) Oficina em duplas: escolher caso da planilha e registrar validações.",
+        "(10 min) Apresentações rápidas, checklist e registro da TED."
       ]
     },
     {
@@ -209,6 +214,30 @@
             "Implementar a solução em C com comentários descrevendo cada etapa.",
             "Testar ao menos três cenários diferentes registrando resultados.",
             "Preparar um pitch de 2 minutos explicando decisões adotadas."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Checklists de validação",
+      "content": [
+        {
+          "type": "subBlock",
+          "title": "Antes de codar",
+          "items": [
+            "Preencher a planilha de dados de teste com entradas típicas, limites e inválidas.",
+            "Definir o formato de saída esperado para cada cenário (valores e mensagens).",
+            "Confirmar quais variáveis precisam de validação extra (negativos, zero, strings vazias)."
+          ]
+        },
+        {
+          "type": "subBlock",
+          "title": "Antes de entregar",
+          "items": [
+            "Executar todos os casos registrados na planilha e registrar resultados.",
+            "Capturar evidências (console ou prints) anexando o link da planilha preenchida.",
+            "Revisar comentários e mensagens exibidas para garantir alinhamento com o enunciado."
           ]
         }
       ]

--- a/src/content/courses/algi/lessons/lesson-10.json
+++ b/src/content/courses/algi/lessons/lesson-10.json
@@ -197,6 +197,69 @@
       ]
     },
     {
+      "type": "truthTable",
+      "title": "Quando usar if-else ou switch-case",
+      "headers": ["Cenário", "if-else", "switch-case", "Observação"],
+      "rows": [
+        [
+          {
+            "value": "Comparar faixas numéricas (ex.: idade)"
+          },
+          {
+            "value": "Permite intervalos complexos"
+          },
+          {
+            "value": "Pouco eficiente"
+          },
+          {
+            "value": "Use if-else para lidar com <, >, >=, <="
+          }
+        ],
+        [
+          {
+            "value": "Verificar estados de string ou boolean"
+          },
+          {
+            "value": "Funciona, mas exige várias comparações"
+          },
+          {
+            "value": "Aceita apenas números/char"
+          },
+          {
+            "value": "Converta para códigos inteiros antes de usar switch"
+          }
+        ],
+        [
+          {
+            "value": "Menu com opções fixas (1,2,3,4)"
+          },
+          {
+            "value": "Funciona, porém repetitivo"
+          },
+          {
+            "value": "Legível e direto"
+          },
+          {
+            "value": "Prefira switch-case para listar alternativas"
+          }
+        ],
+        [
+          {
+            "value": "Verificar combinações de condições"
+          },
+          {
+            "value": "Agrupa com operadores lógicos"
+          },
+          {
+            "value": "Não suporta expressões complexas"
+          },
+          {
+            "value": "if-else permite &&, || e funções auxiliares"
+          }
+        ]
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Estrutura de um if",
       "content": [
@@ -335,6 +398,29 @@
             "Em duplas, modelem um cenário que dependa de uma decisão binária (ex.: desconto fidelidade, envio de alerta).",
             "Identifiquem quais entradas são necessárias e qual mensagem cada ramo deve exibir.",
             "Implementem o programa em C, documentando os casos de teste utilizados."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Rubrica do simulador de aprovação",
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Lógica (40%) – Condições cobrem todos os cenários previstos (aprovado, recuperação, reprovado)."
+            },
+            {
+              "text": "Organização (25%) – Variáveis nomeadas, comentários indicando cada ramo e mensagens claras."
+            },
+            {
+              "text": "Testes (25%) – Evidências de execução com notas limite (6.9, 7.0, 10.0) e casos negativos."
+            },
+            {
+              "text": "Apresentação (10%) – Pitch de 2 minutos explicando a regra e melhorias futuras."
+            }
           ]
         }
       ]

--- a/src/content/courses/algi/lessons/lesson-11.json
+++ b/src/content/courses/algi/lessons/lesson-11.json
@@ -126,6 +126,25 @@
     },
     {
       "type": "contentBlock",
+      "title": "Mini-teste Moodle (15 min)",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Realize individualmente o mini-teste 'Switch Essentials' disponível no Moodle ao final da aula."
+        },
+        {
+          "type": "orderedList",
+          "items": [
+            "Acesse a atividade em Avaliações → Aula 11 → Mini-teste.",
+            "Responda às 5 questões de múltipla escolha (tempo limite: 15 minutos).",
+            "Faça upload do arquivo .c utilizado durante a resolução (mesmo que incompleto).",
+            "Confirme o envio na página de resumo e registre o recibo em PDF."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
       "title": "Quando if-else fica verboso demais",
       "content": [
         {
@@ -135,6 +154,31 @@
         {
           "type": "paragraph",
           "text": "Além de mais legível, a estrutura facilita adicionar ou remover opções sem alterar a lógica principal do programa."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "good-practice",
+      "title": "Revisão individual obrigatória",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Depois da aula, reserve 20 minutos para revisar sozinho o menu implementado, anotando dúvidas para o plantão."
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Refaça os casos de teste sugeridos sem apoio do colega."
+            },
+            {
+              "text": "Registre no caderno quais cases demandaram ajustes."
+            },
+            {
+              "text": "Envie um resumo no fórum #revisao-individual antes da próxima aula."
+            }
+          ]
         }
       ]
     },
@@ -258,6 +302,21 @@
           }
         ]
       }
+    },
+    {
+      "type": "contentBlock",
+      "title": "Template de comentário linha a linha",
+      "content": [
+        {
+          "type": "code",
+          "language": "text",
+          "code": "// Linha 12: valida entrada e evita opções inválidas\n// Linha 18: agrupa cases 2 e 3 para reutilizar mensagem\n// Linha 26: default orienta o usuário a repetir a escolha\n// TODO Linha 30: considerar adicionar confirmação antes de sair"
+        },
+        {
+          "type": "paragraph",
+          "text": "Use o modelo acima para documentar feedback ao colega no Moodle, apontando linha, ação executada e sugestão."
+        }
+      ]
     },
     {
       "type": "contentBlock",


### PR DESCRIPTION
## Summary
- enrich lesson 06 with a detailed MD3 table for primitive types, a cheat sheet reminder, and an OnlineGDB testing callout
- extend lesson 07 with relational logic truth tables, a progressive worksheet, and a precedence reinforcement video
- expand lessons 08-11 with new practice templates, validation resources, assessment guidance, and Moodle-oriented reminders

## Testing
- `npm run lint` *(fails: script not defined in project)*

------
https://chatgpt.com/codex/tasks/task_e_68dba2f61410832c8394c2146b2949c9