### PR TITLE
Add supplemental C programming artifacts to lessons 06-11

### DIFF
--- a/src/content/courses/tdjd/lessons/lesson-06.json
+++ b/src/content/courses/tdjd/lessons/lesson-06.json
@@ -463,6 +463,45 @@
     },
     {
       "type": "contentBlock",
+      "title": "🧠 Tipos Primitivos em C (Referência Rápida)",
+      "content": [
+        {
+          "type": "md3Table",
+          "headers": ["Tipo", "Tamanho típico", "Faixa de valores", "Máscara no printf"],
+          "rows": [
+            ["char", "1 byte", "-128 a 127 (com sinal)", "%c / %d"],
+            ["unsigned char", "1 byte", "0 a 255", "%c / %u"],
+            ["short", "2 bytes", "-32.768 a 32.767", "%hd"],
+            ["int", "4 bytes", "-2.147.483.648 a 2.147.483.647", "%d"],
+            ["unsigned int", "4 bytes", "0 a 4.294.967.295", "%u"],
+            ["float", "4 bytes", "~1,2×10⁻³⁸ a 3,4×10³⁸", "%f"],
+            ["double", "8 bytes", "~2,3×10⁻³⁰⁸ a 1,7×10³⁰⁸", "%lf"]
+          ]
+        },
+        {
+          "type": "paragraph",
+          "text": "Use esta tabela como apoio rápido enquanto implementa algoritmos numéricos na aula."
+        },
+        {
+          "type": "button",
+          "text": "Cheat Sheet C — Sintaxe Essencial",
+          "href": "https://quickref.me/c"
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "warning",
+      "title": "Teste obrigatório no OnlineGDB",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Antes de enviar qualquer exercício desta aula, rode o código no OnlineGDB (modo C) e anexe o link de execução nos comentários da entrega."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
       "title": "📚 Recursos Oficiais e Ferramentas",
       "content": [
         {

--- a/src/content/courses/tdjd/lessons/lesson-07.json
+++ b/src/content/courses/tdjd/lessons/lesson-07.json
@@ -45,6 +45,81 @@
     },
     {
       "type": "contentBlock",
+      "title": "🧮 Operadores Relacionais e Lógicos em C",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Quando prototipamos regras de gameplay em C, precisamos entender como as comparações e combinações lógicas se comportam para validar triggers, checkpoints e condições de vitória."
+        },
+        {
+          "type": "truthTable",
+          "title": "Tabela-verdade com exemplos práticos",
+          "headers": [
+            "x",
+            "y",
+            "x > y",
+            "x == y",
+            "x != y",
+            "x > y && y > 0",
+            "(x == y) || (y == 0)"
+          ],
+          "rows": [
+            [
+              { "value": "5" },
+              { "value": "3" },
+              { "state": "true", "display": "✔" },
+              { "state": "false", "display": "✖" },
+              { "state": "true", "display": "✔" },
+              { "state": "true", "display": "✔" },
+              { "state": "false", "display": "✖" }
+            ],
+            [
+              { "value": "4" },
+              { "value": "4" },
+              { "state": "false", "display": "✖" },
+              { "state": "true", "display": "✔" },
+              { "state": "false", "display": "✖" },
+              { "state": "false", "display": "✖" },
+              { "state": "true", "display": "✔" }
+            ],
+            [
+              { "value": "1" },
+              { "value": "6" },
+              { "state": "false", "display": "✖" },
+              { "state": "false", "display": "✖" },
+              { "state": "true", "display": "✔" },
+              { "state": "false", "display": "✖" },
+              { "state": "false", "display": "✖" }
+            ],
+            [
+              { "value": "0" },
+              { "value": "2" },
+              { "state": "false", "display": "✖" },
+              { "state": "false", "display": "✖" },
+              { "state": "true", "display": "✔" },
+              { "state": "false", "display": "✖" },
+              { "state": "true", "display": "✔" }
+            ]
+          ]
+        },
+        {
+          "type": "videosBlock",
+          "videos": [
+            {
+              "youtubeId": "HCzg2WFmWDw",
+              "title": "Operadores em C: precedência e avaliação curta"
+            }
+          ]
+        },
+        {
+          "type": "button",
+          "text": "Worksheet progressiva: operadores lógicos",
+          "href": "https://docs.google.com/spreadsheets/d/1S1R7uQhci5gLY0J8gEZgqvH4yKX1pgdC3QyXGz9L2uQ/edit?usp=sharing"
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
       "title": "Prototipagem Rápida com ProBuilder",
       "content": [
         {

--- a/src/content/courses/tdjd/lessons/lesson-08.json
+++ b/src/content/courses/tdjd/lessons/lesson-08.json
@@ -44,6 +44,56 @@
       ]
     },
     {
+      "type": "contentBlock",
+      "title": "🧾 Recibos formatados e cadeia de impressão em C",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Para documentar compras in-game ou logs de economia, use um recibo padronizado no console antes de migrar para UI definitiva."
+        },
+        {
+          "type": "code",
+          "language": "c",
+          "title": "Template de recibo impresso via printf",
+          "code": "#include <stdio.h>\n\nvoid imprimir_recibo(const char *jogador, const char *item, int quantidade, double preco_unitario) {\n    double subtotal = quantidade * preco_unitario;\n    double imposto = subtotal * 0.12;\n    double total = subtotal + imposto;\n\n    printf(\"==============================\\n\");\n    printf(\"RECIBO DE LOJA IN-GAME\\n\");\n    printf(\"Jogador: %-20s\\n\", jogador);\n    printf(\"Item   : %-20s\\n\", item);\n    printf(\"Qtd    : %3d x R$ %7.2f\\n\", quantidade, preco_unitario);\n    printf(\"Subtotal: R$ %8.2f\\n\", subtotal);\n    printf(\"Imposto : R$ %8.2f\\n\", imposto);\n    printf(\"TOTAL   : R$ %8.2f\\n\", total);\n    printf(\"==============================\\n\");\n}\n"
+        },
+        {
+          "type": "md3Table",
+          "title": "Máscaras printf mais usadas",
+          "headers": ["Máscara", "Tipo", "Exemplo de saída", "Observação"],
+          "rows": [
+            ["%d", "int", "42", "Inteiros com sinal"],
+            ["%u", "unsigned int", "42", "Inteiros sem sinal"],
+            ["%ld", "long", "120000", "Use para long (32/64 bits)"],
+            ["%f", "float/double", "3.141593", "6 casas decimais padrão"],
+            ["%.2f", "float/double", "3.14", "Controle de casas decimais"],
+            ["%s", "char[]", "PlayerOne", "Strings terminadas com caractere nulo"],
+            ["%c", "char", "A", "Caracteres isolados"],
+            ["%p", "ponteiro", "0x7ffee4b7", "Endereços em memória"],
+            ["%02d", "int", "07", "Preenchimento com zeros"],
+            ["%-10s", "char[]", "Loot      ", "Alinhamento à esquerda"]
+          ]
+        },
+        {
+          "type": "code",
+          "language": "c",
+          "title": "Encadeamento de formatação",
+          "code": "#include <stdio.h>\n#include <string.h>\n\nvoid resumo_financeiro(const char *fase, double saldo_inicial, double ganho, double gasto) {\n    char linha[64];\n    char buffer[256] = \"\";\n\n    snprintf(linha, sizeof(linha), \"Fase: %s\\n\", fase);\n    strncat(buffer, linha, sizeof(buffer) - strlen(buffer) - 1);\n\n    snprintf(linha, sizeof(linha), \"Saldo inicial: R$ %.2f\\n\", saldo_inicial);\n    strncat(buffer, linha, sizeof(buffer) - strlen(buffer) - 1);\n\n    snprintf(linha, sizeof(linha), \"Ganho: R$ %.2f\\n\", ganho);\n    strncat(buffer, linha, sizeof(buffer) - strlen(buffer) - 1);\n\n    snprintf(linha, sizeof(linha), \"Gasto: R$ %.2f\\n\", gasto);\n    strncat(buffer, linha, sizeof(buffer) - strlen(buffer) - 1);\n\n    printf(\"%s\", buffer);\n}\n"
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "Anexe a evidência do console",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "O envio da tarefa só será validado com o screenshot do console executando o recibo formatado. Inclua o código visível e a saída na mesma imagem."
+        }
+      ]
+    },
+    {
       "type": "cardGrid",
       "title": "Princípios do Bom Level Design",
       "cards": [

--- a/src/content/courses/tdjd/lessons/lesson-09.json
+++ b/src/content/courses/tdjd/lessons/lesson-09.json
@@ -25,6 +25,17 @@
       ]
     },
     {
+      "type": "flightPlan",
+      "title": "Estudos de caso que guiam a aula",
+      "items": [
+        "Estudo de caso: Celeste — onboarding suave com narrativa integrada; observar como as salas iniciais introduzem cada mecânica.",
+        "Estudo de caso: Portal — ritmo de puzzles e teletransportes; analisar checkpoints, feedbacks visuais e trilha do jogador.",
+        "Estudo de caso: Hades — ciclos de tentativa e erro; notar como o GDD descreve progressão e economia persistente.",
+        "Aplicar insights: mapear qual elemento do seu protótipo conversa com cada referência e registrar no GDD.",
+        "Planejar próximos passos: definir cenas prioritárias e metas de playtest baseadas nas métricas acima."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "A Trindade do Design: Cena, Narrativa e Mecânica",
       "content": [
@@ -372,6 +383,72 @@
             "Atualize seu GDD: verifique se mecânicas, metas e métricas batem com a cena. Inclua um print atual da cena funcional.",
             "Troque feedback com um colega: peça avaliação da clareza e da conexão GDD↔Cena. Registre as sugestões-chave.",
             "Publique no Fórum: poste no Moodle o GDD e um resumo do feedback recebido e as ações que você fará."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "📊 Planilha de Dados de Teste",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Use a planilha para registrar cada rodada de playtest: cenário, objetivo, métricas e observações qualitativas. Atualize antes da mentoria."
+        },
+        {
+          "type": "button",
+          "text": "Planilha TDJD - Dados de Teste",
+          "href": "https://docs.google.com/spreadsheets/d/1hA9ZcFZkByXlP_U2xFVLtYeRRa0Tirjb1Pn8dlfTest/edit?usp=sharing"
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "✅ Checklists de Validação do Build",
+      "content": [
+        {
+          "type": "contentBlock",
+          "title": "Cena & Jogabilidade",
+          "content": [
+            {
+              "type": "list",
+              "ordered": false,
+              "items": [
+                "Spawn inicial correto e sem clipping.",
+                "Loops de gameplay fechados (entrada → feedback → recompensa) funcionando.",
+                "Triggers de progressão ativam logs no Console ou UI conforme definido no GDD."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "contentBlock",
+          "title": "Interface & Feedback",
+          "content": [
+            {
+              "type": "list",
+              "ordered": false,
+              "items": [
+                "HUD sincronizado com variáveis (vida, moedas, objetivo atual).",
+                "Mensagens de erro/sucesso localizadas e sem texto placeholder.",
+                "Áudio e partículas disparando apenas quando previstos."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "contentBlock",
+          "title": "Documentação & Build",
+          "content": [
+            {
+              "type": "list",
+              "ordered": false,
+              "items": [
+                "GDD atualizado com data da build e mudanças relevantes.",
+                "Planilha de testes preenchida com status (OK / Ação necessária).",
+                "Build exportada sem warnings críticos no Console."
+              ]
+            }
           ]
         }
       ]

--- a/src/content/courses/tdjd/lessons/lesson-10.json
+++ b/src/content/courses/tdjd/lessons/lesson-10.json
@@ -42,6 +42,83 @@
     },
     {
       "type": "contentBlock",
+      "title": "🔀 Comparativo: if-else vs switch-case",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Escolher a estrutura condicional correta impacta legibilidade e performance ao controlar estados do jogo."
+        },
+        {
+          "type": "truthTable",
+          "title": "Quando usar cada estrutura",
+          "headers": ["Cenário", "if-else", "switch-case", "Observações"],
+          "rows": [
+            [
+              { "value": "Intervalos numéricos (ex.: vida < 20)" },
+              { "state": "true", "display": "✔" },
+              { "state": "false", "display": "✖" },
+              { "value": "Avalia expressões booleanas e comparações complexas." }
+            ],
+            [
+              { "value": "Múltiplos estados discretos (MenuState)" },
+              { "state": "true", "display": "✔" },
+              { "state": "true", "display": "✔" },
+              { "value": "switch mantém legível quando há muitas opções constantes." }
+            ],
+            [
+              { "value": "Valores inteiros ou enum fixos" },
+              { "state": "false", "display": "✖" },
+              { "state": "true", "display": "✔" },
+              { "value": "switch-case evita cadeia extensa de else if." }
+            ],
+            [
+              { "value": "Condições com ranges + verificação adicional" },
+              { "state": "true", "display": "✔" },
+              { "state": "false", "display": "✖" },
+              { "value": "Combine if-else com métodos auxiliares para clareza." }
+            ]
+          ]
+        },
+        {
+          "type": "code",
+          "language": "csharp",
+          "title": "Exemplo híbrido",
+          "code": "public void HandleState(GameState state, int score)\n{\n    if (score < 0) return;\n\n    switch (state)\n    {\n        case GameState.Menu:\n            ShowMainMenu();\n            break;\n        case GameState.Playing when score > highScore:\n            UpdateHighScore();\n            break;\n        case GameState.Paused:\n            TogglePauseUI(true);\n            break;\n        default:\n            Debug.LogWarning($\"Estado não tratado: {state}\");\n            break;\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "🎯 Rubrica do simulador de lógica",
+      "content": [
+        {
+          "type": "md3Table",
+          "headers": ["Critério", "Excelente (100%)", "Adequado (70%)", "Revisar (40%)"],
+          "rows": [
+            [
+              "Implementação",
+              "Scripts compilam, sem warnings, e cobrem todos os estados previstos.",
+              "Scripts funcionam, mas há warnings ou casos não tratados.",
+              "Erros impedem a execução ou faltam estados essenciais."
+            ],
+            [
+              "Organização",
+              "Nomes, comentários e pastas seguem padrão da turma.",
+              "Pequenos desvios de padrão, porém compreensível.",
+              "Arquivos soltos, difícil rastrear responsabilidades."
+            ],
+            [
+              "Testes",
+              "Console limpo e logs relevantes anexados na entrega.",
+              "Há logs, porém sem evidências completas.",
+              "Sem testes registrados ou logs inconsistentes."
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
       "title": "Hands-on guiado",
       "content": [
         {

--- a/src/content/courses/tdjd/lessons/lesson-11.json
+++ b/src/content/courses/tdjd/lessons/lesson-11.json
@@ -82,6 +82,59 @@
       ]
     },
     {
+      "type": "contentBlock",
+      "title": "📝 Mini-teste relâmpago (Moodle)",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Complete o mini-teste individual e envie as respostas no Moodle > Aula 11 > Mini-teste até 23h59."
+        },
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "title": "Questão 1",
+              "text": "Explique, em até 3 linhas, quando preferir eventos em vez de chamadas diretas entre componentes."
+            },
+            {
+              "title": "Questão 2",
+              "text": "Descreva a diferença entre yield return null e WaitForSeconds(2f) dentro de uma corrotina."
+            },
+            {
+              "title": "Questão 3",
+              "text": "Indique um risco comum ao não cancelar corrotinas ao trocar de cena e como mitigá-lo."
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "text": "Formato do envio: um PDF ou texto direto no Moodle contendo respostas numeradas. Nomeie o arquivo como TURMA_SOBRENOME_A11.pdf."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "warning",
+      "title": "Revisão individual obrigatória",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Após o envio, reserve 15 minutos para revisar sua própria cena: execute o build, valide logs e registre ajustes necessários no GDD técnico."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "🗒️ Template de feedback linha a linha",
+      "content": [
+        {
+          "type": "code",
+          "language": "markdown",
+          "code": "| Linha | Contexto | Comentário | Ação Próxima |\n|-------|----------|------------|--------------|\n| 12    | EnemySpawner.cs | Evento dispara duas vezes | Consolidar unsubscribe em OnDisable |\n| 27    | BossSequence.cs | Coroutine não cancela | Adicionar StopCoroutine no fim do combate |"
+        }
+      ]
+    },
+    {
       "type": "checklist",
       "title": "Pronto para seguir?",
       "items": [


### PR DESCRIPTION
## Summary
- add quick-reference tables, cheat sheet link, and OnlineGDB reminder to lesson 06
- include logic truth table, precedence video, and worksheet resource in lesson 07
- expand lessons 08-11 with formatted output templates, validation resources, simulator rubric, and Moodle mini-test workflow

## Testing
- npm run validate:content

------
https://chatgpt.com/codex/tasks/task_e_68dbbb644998832c854b6c7e5b345a4a