### PR TITLE
Atualiza aulas 38-40 com roteiro de revisão, NP3 e devolutiva

### DIFF
--- a/reports/content-validation-report.json
+++ b/reports/content-validation-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-30T09:01:15.492Z",
+  "generatedAt": "2025-09-30T13:56:24.206Z",
   "status": "passed",
   "totals": {
     "courses": 5,

--- a/src/content/courses/algi/lessons/lesson-38.json
+++ b/src/content/courses/algi/lessons/lesson-38.json
@@ -35,10 +35,21 @@
       "url": "https://static.md3.education/courses/algi/gamificacao-jeopardy-kit.md"
     },
     {
+      "label": "Slides oficiais da dinâmica Jeopardy",
+      "type": "slides",
+      "file": "courses/algi/aula-38-jeopardy-slides.pdf",
+      "url": "https://static.md3.education/courses/algi/aula-38-jeopardy-slides.pdf"
+    },
+    {
       "label": "Template de ranking gamificado",
       "type": "template",
       "file": "courses/algi/gamificacao-ranking-template.csv",
       "url": "https://static.md3.education/courses/algi/gamificacao-ranking-template.csv"
+    },
+    {
+      "label": "Planilha de pontuação em tempo real",
+      "type": "spreadsheet",
+      "url": "https://docs.google.com/spreadsheets/d/1ALGJeopardyPontuacao"
     },
     {
       "label": "Artigo Harvard Business Review - Gamification in Education",
@@ -101,29 +112,61 @@
       "title": "Roteiro detalhado",
       "cards": [
         {
-          "icon": "clock",
-          "title": "Boas-vindas",
-          "content": "Aquecimento com quiz flash revisando structs e CRUD (10 min)."
+          "icon": "bullseye",
+          "title": "Briefing e kits",
+          "content": "(10 min) Apresente os slides oficiais, distribua kits (cartelas, cartas, sineta) e alinhe papéis do squad."
         },
         {
-          "icon": "tasks",
-          "title": "Jeopardy",
-          "content": "Tabuleiro com cinco categorias (Structs, Vetores, Funções, Controle, Desafios) (45 min)."
+          "icon": "code",
+          "title": "Rodadas Jeopardy",
+          "content": "(45 min) Use o tabuleiro projetado; squads escolhem casas, respondem em 90s e validam com o gabarito do kit."
         },
         {
-          "icon": "check-circle",
-          "title": "Ranking dinâmico",
-          "content": "Atualização em tempo real da planilha de pontuação (20 min)."
+          "icon": "monitor",
+          "title": "Ranking em tempo real",
+          "content": "(15 min) Atualize a planilha oficial a cada rodada, sinalizando badges de consistência e colaboração."
         },
         {
           "icon": "users",
-          "title": "Oficina de retrospectiva",
-          "content": "Canvas de lições aprendidas e próximos passos (30 min)."
+          "title": "Laboratório de estratégias",
+          "content": "(20 min) Squads analisam ranking, definem apostas para rodada relâmpago e registram lições no mural."
+        },
+        {
+          "icon": "gears",
+          "title": "Rodada relâmpago",
+          "content": "(20 min) Perguntas bônus com badges especiais (Insight, Apoio Técnico, Fair Play) e atualização final do ranking."
         },
         {
           "icon": "check-circle",
-          "title": "Encerramento",
-          "content": "Entrega de medalhas e feedbacks individuais (25 min)."
+          "title": "Premiação e feedback",
+          "content": "(20 min) Entregue certificados, colete impressões rápidas e sinalize abertura do formulário de feedback 360°."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Kit Jeopardy por squad",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Cada kit deve ser entregue completo em envelope identificado: cartelas de respostas, cartas de categorias, gabarito laminado, contadores de ponto e badge cards."
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            { "text": "Cartelas numeradas de 100 a 500 por categoria para escolha das perguntas." },
+            {
+              "text": "Campainha ou sinalizador para indicar resposta pronta (alternativa: reação no chat)."
+            },
+            {
+              "text": "Cartões de badge (Insight, Fair Play, Mentor Relâmpago) para premiações adicionais."
+            },
+            { "text": "Guia rápido com critérios de desempate e penalidades." }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "text": "Reserve um kit extra para demonstração durante o briefing e mantenha spray sanitizante para revezamento seguro."
         }
       ]
     },
@@ -131,12 +174,12 @@
       "type": "flightPlan",
       "title": "Plano de voo (2h10)",
       "items": [
-        "(15 min) Icebreaker: bingo de conceitos-chave.",
-        "(45 min) Rodadas Jeopardy com perguntas de código e interpretação.",
-        "(20 min) Desafio relâmpago: refatorar função CRUD indicada pelo ranking.",
-        "(25 min) Sessão de feedback 360° entre squads.",
-        "(20 min) Construção do mural digital com insights.",
-        "(5 min) Anúncio dos destaques e próximos passos para NP3."
+        "(10 min) Icebreaker com quiz flash e revisão das regras nos slides.",
+        "(45 min) Rodadas principais: squads escolhem casas, respondem e registram tentativas na planilha.",
+        "(15 min) Painel do ranking: atualização coletiva e registro dos badges conquistados.",
+        "(20 min) Desafio relâmpago com perguntas de alta complexidade e possibilidade de aposta.",
+        "(25 min) Círculo de feedback 360° mediado por roteiro de perguntas.",
+        "(15 min) Construção do mural digital com insights e anúncio dos destaques."
       ]
     },
     {
@@ -154,12 +197,39 @@
               "text": "Use perguntas que envolvam leitura de código, correção de bugs e estimativa de complexidade."
             },
             {
-              "text": "Atribua badges extras para squads que colaborarem com outras equipes durante a revisão."
+              "text": "Atribua badges extras (Fair Play, Mentor Relâmpago, Insight) para squads que colaborarem com outras equipes ou justificarem soluções com profundidade."
             },
             {
-              "text": "Publique ranking parcial a cada rodada para incentivar planejamento estratégico."
+              "text": "Publique ranking parcial a cada rodada usando o dashboard da planilha oficial para incentivar planejamento estratégico."
             }
           ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Feedback 360° orientado",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Reserve 25 minutos para o círculo de feedback 360°. Projete o roteiro no slide 12 e oriente que cada squad forneça percepções sobre comunicação, domínio técnico e colaboração."
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Preencha o formulário https://forms.gle/algi-feedback-360 durante a roda para capturar evidências."
+            },
+            {
+              "text": "Garanta que todos recebam ao menos um elogio (Keep) e uma sugestão de melhoria (Grow)."
+            },
+            { "text": "Colete compromissos no mural digital para acompanhamento na aula 40." }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "text": "Reforce sigilo e respeito mútuo: feedback deve ser específico, gentil e orientado a ações futuras."
         }
       ]
     },
@@ -264,9 +334,13 @@
     }
   ],
   "metadata": {
-    "status": "draft",
-    "updatedAt": "2025-03-07T12:00:00.000Z",
-    "owners": ["Equipe Algoritmos I"],
-    "sources": ["Plano de ensino Algoritmos I 2025.2", "HBR Gamification Strategies 2020"]
+    "status": "published",
+    "updatedAt": "2025-03-11T12:00:00.000Z",
+    "owners": ["Prof. Tiago Sombra"],
+    "sources": [
+      "Plano de ensino Algoritmos I 2025.2",
+      "HBR Gamification Strategies 2020",
+      "Relatório de monitoria gamificada 2024"
+    ]
   }
 }

--- a/src/content/courses/algi/lessons/lesson-39.json
+++ b/src/content/courses/algi/lessons/lesson-39.json
@@ -29,35 +29,87 @@
       ]
     },
     {
+      "type": "contentBlock",
+      "title": "Escopo e formato da avaliação",
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            { "text": "Duração total: 120 minutos, prova presencial com consulta vedada." },
+            {
+              "text": "Estrutura: três blocos (diagnóstico, desenvolvimento, reflexão) com entregas sequenciais."
+            },
+            {
+              "text": "Material permitido: apenas caneta azul ou preta, lápis para rascunho e régua para organização do papel."
+            },
+            {
+              "text": "Entregáveis: caderno de questões, folha de respostas e rascunhos assinados."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "type": "flightPlan",
       "title": "Mapa da avaliação integradora",
       "items": [
-        "Escopo: Prova NP3 presencial abrangendo todos os tópicos do semestre, com duração de 120 minutos.",
-        "Formato: Questões discursivas, resolução de algoritmos completos e análise de código existente.",
-        "Objetivo: Demonstrar domínio de lógica, estruturas de dados lineares e modularização em C.",
-        "Estratégia: Planejar tempo entre leitura, rascunho e revisão, priorizando clareza de raciocínio.",
-        "Entrega: Respostas devem conter pseudocódigo ou C legível, acompanhadas de explicações breves."
+        "(10 min) Orientações iniciais: regras de conduta, checagem de documentos e distribuição dos cadernos.",
+        "(25 min) Bloco 1 — Diagnóstico: questões objetivas e problemas curtos para aquecer raciocínio lógico.",
+        "(45 min) Bloco 2 — Desenvolvimento: resolução de algoritmos completos com vetores, matrizes e structs.",
+        "(30 min) Bloco 3 — Reflexão: análise crítica de código legado, justificativas e estimativas de complexidade.",
+        "(10 min) Revisão final e entrega: conferência de respostas, organização dos materiais e assinatura de recebimento."
+      ]
+    },
+    {
+      "type": "lessonPlan",
+      "title": "Roteiro operacional da NP3",
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "Bloco 0 — Conduta",
+          "content": "Explique normas de sigilo, desligamento de dispositivos e procedimento para dúvidas antes do início da contagem de tempo."
+        },
+        {
+          "icon": "book-open",
+          "title": "Bloco 1 — Diagnóstico",
+          "content": "Liberado após orientações; alunos respondem perguntas de múltipla escolha e pequenos algoritmos (25 min)."
+        },
+        {
+          "icon": "code",
+          "title": "Bloco 2 — Desenvolvimento",
+          "content": "Questões de implementação em C com suporte a rascunho. Professores registram dúvidas frequentes no quadro (45 min)."
+        },
+        {
+          "icon": "target",
+          "title": "Bloco 3 — Revisão crítica",
+          "content": "Análise de código legado e perguntas discursivas orientadas à justificativa de escolhas (30 min)."
+        },
+        {
+          "icon": "tasks",
+          "title": "Bloco 4 — Encerramento",
+          "content": "Colete provas, rascunhos e listas de presença; confirme recibo de entrega e orientações para devolutiva (10 min)."
+        }
       ]
     },
     {
       "type": "cardGrid",
-      "title": "Componentes-chave da prova",
+      "title": "Rubrica oficial NP3",
       "cards": [
         {
-          "title": "Fluxos completos",
-          "content": "Avalia a capacidade de ligar entrada, processamento e saída com estruturas sequenciais, condicionais e iterativas."
+          "title": "Corretude — 40%",
+          "content": "Implementa solução que compila, atende aos requisitos e trata casos de borda (entradas inválidas, limites de loops)."
         },
         {
-          "title": "Coleções",
-          "content": "Questões com vetores, matrizes e structs, explorando percursos, buscas e agregações de dados."
+          "title": "Estrutura e modularização — 25%",
+          "content": "Organiza o código em funções coesas, usa variáveis bem nomeadas e respeita o fluxo proposto no enunciado."
         },
         {
-          "title": "Funções reutilizáveis",
-          "content": "Exige decomposição em funções bem nomeadas, com parâmetros e retorno adequados para reutilização."
+          "title": "Domínio de dados — 20%",
+          "content": "Manipula vetores, matrizes e structs com precisão, mantendo integridade e desempenho aceitável."
         },
         {
-          "title": "Análise crítica",
-          "content": "Inclui identificação de erros lógicos, discussão de complexidade e sugestões de melhoria em códigos fornecidos."
+          "title": "Clareza comunicativa — 15%",
+          "content": "Apresenta comentários breves, justificativas e rascunhos legíveis, apoiando a correção e a rastreabilidade da solução."
         }
       ]
     },
@@ -85,6 +137,10 @@
         {
           "type": "paragraph",
           "text": "Utilize rascunho para mapear as etapas do algoritmo antes de codificar. A clareza na apresentação vale pontos."
+        },
+        {
+          "type": "paragraph",
+          "text": "Sinalize dúvidas levantando a mão; deslocamentos só são autorizados com acompanhamento do fiscal."
         }
       ]
     },
@@ -97,9 +153,9 @@
           "title": "Como a nota é distribuída",
           "items": [
             "Corretude (40%): resultados esperados, tratamento de bordas e validação de entrada.",
-            "Estrutura (30%): uso apropriado de laços, decisões e funções para organizar o algoritmo.",
+            "Estrutura (25%): uso apropriado de laços, decisões e funções para organizar o algoritmo.",
             "Dados (20%): manipulação correta de vetores, matrizes e registros, incluindo índices e inicializações.",
-            "Apresentação (10%): indentação, nomenclatura consistente e explicações concisas quando solicitadas."
+            "Apresentação (15%): indentação, nomenclatura consistente e explicações concisas quando solicitadas."
           ]
         },
         {
@@ -134,6 +190,21 @@
         {
           "type": "paragraph",
           "text": "Prova individual, sem consulta. Entregue todo material de rascunho ao final e mantenha dispositivos desligados."
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Chegue com 15 minutos de antecedência para acomodação e conferência de documentos."
+            },
+            {
+              "text": "Durante os blocos 1 e 2, somente perguntas de compreensão do enunciado serão respondidas."
+            },
+            {
+              "text": "Saídas ao banheiro são registradas e realizadas uma pessoa por vez, com supervisão."
+            },
+            { "text": "Assine a lista de presença e o recibo de entrega antes de deixar a sala." }
+          ]
         }
       ]
     },
@@ -165,9 +236,13 @@
   ],
   "metadata": {
     "status": "published",
-    "updatedAt": "2025-03-07T12:00:00.000Z",
+    "updatedAt": "2025-03-11T12:00:00.000Z",
     "owners": ["Prof. Tiago Sombra"],
-    "sources": ["Plano pedagógico Algoritmos I 2025.1", "Ata pedagógica de revisão 2024-12"]
+    "sources": [
+      "Plano pedagógico Algoritmos I 2025.1",
+      "Ata pedagógica de revisão 2024-12",
+      "Guia operacional de avaliações NP3 2025"
+    ]
   },
   "formatVersion": "md3.lesson.v1",
   "slug": "avaliacao-np3",

--- a/src/content/courses/algi/lessons/lesson-40.json
+++ b/src/content/courses/algi/lessons/lesson-40.json
@@ -47,9 +47,9 @@
       "url": "https://static.md3.education/courses/algi/roadmap-pos-algi.md"
     },
     {
-      "label": "Formulário de feedback contínuo",
+      "label": "Formulário de feedback final",
       "type": "form",
-      "url": "https://forms.gle/algoritmosI-feedback-continuo"
+      "url": "https://forms.gle/algoritmosI-feedback-final"
     },
     {
       "label": "OnlineGDB - Projeto C pré-configurado",
@@ -114,9 +114,9 @@
         "(10 min) Boas-vindas e retomada dos marcos do semestre.",
         "(20 min) Devolutiva coletiva das NPs com análise de indicadores.",
         "(35 min) Showcase de projetos com rodada de perguntas.",
-        "(15 min) Coleta de feedback estruturado via checklist e formulário.",
+        "(15 min) Coleta de feedback estruturado via checklist e formulário final.",
         "(20 min) Painel de próximos passos e definição de compromissos.",
-        "(15 min) Roadmap futuro: Git, estruturas de dados e recursos complementares."
+        "(15 min) Roadmap futuro: Git colaborativo, estruturas de dados avançadas e agenda de monitoria."
       ]
     },
     {
@@ -141,12 +141,24 @@
       ]
     },
     {
+      "type": "checklist",
+      "title": "Checklist de devolutiva (aplicação em sala)",
+      "description": "Preencha em conjunto com a turma logo após a apresentação dos resultados.",
+      "items": [
+        "Compartilhei médias e distribuição das NPs utilizando o dashboard projetado.",
+        "Comuniquei critérios de correção e respondi às principais dúvidas coletivas.",
+        "Entreguei envelopes individuais com notas e feedbacks escritos.",
+        "Registrei compromissos de melhoria de cada squad no mural digital.",
+        "Alertei sobre prazos para recursos ou revisões formais."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Showcase de projetos",
       "content": [
         {
           "type": "paragraph",
-          "text": "Organize os grupos em estações. Cada equipe tem 5 minutos para apresentar problema, solução, impacto e próximos passos desejados."
+          "text": "Organize os grupos em estações. Cada equipe tem 5 minutos para apresentar problema, solução, impacto e próximos passos desejados, seguindo o Guia de showcase final para orientar storytelling e avaliação."
         },
         {
           "type": "unorderedList",
@@ -155,10 +167,10 @@
               "text": "Garanta registro visual (fotos, prints) para o mural digital."
             },
             {
-              "text": "Estimule perguntas usando a matriz Admirei / Sugiro."
+              "text": "Estimule perguntas usando a matriz Admirei / Sugiro e documente no template compartilhado."
             },
             {
-              "text": "Finalize cada rodada com destaque de uma prática replicável."
+              "text": "Convide banca (professor, monitor, convidado) a atribuir badges rápidos (Pitch, UX, Solução Técnica) ao fim de cada rodada."
             }
           ]
         }
@@ -170,8 +182,33 @@
       "items": [
         "Apresentei devolutiva coletiva com dados e narrativas.",
         "Conduzi roda de feedback cruzado usando o checklist oficial.",
-        "Registrei feedbacks individuais no formulário contínuo.",
+        "Registrei feedbacks individuais no formulário de feedback final.",
         "Combinei com a turma como os dados serão revisitados no próximo semestre."
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "Formulário de feedback final",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Reserve 10 minutos ao término do showcase para que cada estudante preencha o formulário oficial: https://forms.gle/algoritmosI-feedback-final."
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Reforce que o envio é obrigatório para consolidar a presença e registrar percepções da disciplina."
+            },
+            {
+              "text": "Solicite que indiquem highlights, pontos de melhoria e interesses para monitoria."
+            },
+            {
+              "text": "Baixe a planilha de respostas ao final da semana para embasar a reunião de planejamento do próximo semestre."
+            }
+          ]
+        }
       ]
     },
     {
@@ -180,11 +217,15 @@
       "steps": [
         {
           "title": "Curto prazo (1-2 semanas)",
-          "description": "Revisar devolutivas das NPs, atualizar portfólio e refatorar itens críticos do projeto."
+          "description": "Revisar devolutivas das NPs, atualizar portfólio, refatorar itens críticos do projeto e agendar conversa individual com monitoria."
         },
         {
           "title": "Médio prazo (1 mês)",
           "description": "Iniciar trilha de Git colaborativo com repositório compartilhado e pull requests semanais."
+        },
+        {
+          "title": "Apoio contínuo (monitoria)",
+          "description": "Participar das sessões semanais de monitoria para revisar conteúdos de C, tirar dúvidas sobre Git e receber desafios extras de estruturas de dados."
         },
         {
           "title": "Longo prazo (3 meses)",
@@ -291,8 +332,12 @@
   ],
   "metadata": {
     "status": "published",
-    "updatedAt": "2025-03-07T12:00:00.000Z",
+    "updatedAt": "2025-03-11T12:00:00.000Z",
     "owners": ["Prof. Tiago Sombra"],
-    "sources": ["Plano pedagógico Algoritmos I 2025.1", "Relatórios de acompanhamento 2024"]
+    "sources": [
+      "Plano pedagógico Algoritmos I 2025.1",
+      "Relatórios de acompanhamento 2024",
+      "Ata de devolutiva final 2024.2"
+    ]
   }
 }


### PR DESCRIPTION
## Resumo
- detalha a dinâmica Jeopardy da aula 38 com recursos atualizados, roteiro ampliado e callout de feedback 360°
- estrutura a aula 39 com metadados revisados, cronograma completo da aplicação da NP3 e rubrica em cardGrid
- documenta na aula 40 o checklist de devolutiva, orientações de showcase, formulário de feedback final e roadmap pós-disciplina

## Testes
- `npm run validate:content`


------
https://chatgpt.com/codex/tasks/task_e_68dbe04aa10c832cb44357b722acc525