### PR TITLE
Add TGS lesson adjustment plan skeleton

### DIFF
--- a/docs/didactics/tgs-lesson-adjustment-plan.md
+++ b/docs/didactics/tgs-lesson-adjustment-plan.md
@@ -1,0 +1,67 @@
+# Plano de Ajuste das Aulas de Tecnologia e Gestão de Serviços (TGS)
+
+## 1. Propósito do documento
+
+Este plano centraliza os ajustes necessários nas aulas de **Tecnologia e Gestão de Serviços** para garantir aderência ao plano pedagógico vigente e às diretrizes MD3 utilizadas no repositório. Todas as aulas residem em `src/content/courses/tgs/lessons/lesson-XX.json` e são indexadas por `src/content/courses/tgs/lessons.json`.
+
+- [ ] Consolidar objetivos, competências e resultados esperados em cada `lesson-XX.json`.
+- [ ] Mapear dependências com outras frentes curriculares e registrar responsáveis pedagógicos.
+- [ ] Revisar materiais de apoio e pontos de contato com o professor titular de TGS.
+
+## 2. Diretrizes transversais
+
+- [ ] Confirmar metadados obrigatórios em todos os arquivos de lições (resumo, objetivos, competências, habilidades, duração, modalidade e avaliação quando aplicável).
+- [ ] Garantir presença e detalhamento dos blocos MD3 (`lessonPlan`, `flightPlan`, `callouts`, `cardGrid`, entre outros) e registrar orientações de pré e pós-aula.
+- [ ] Revisar alinhamento com Moodle (TEDs, avisos de conduta, bibliografia institucional) e validar a consistência dos recursos externos.
+
+## 3. Ajustes por unidade temática
+
+### Unidade I – Fundamentos e ambientação (Aulas 1–3)
+
+- [ ] Listar objetivos introdutórios, materiais de ambientação e expectativas para integração aos ambientes digitais.
+- [ ] Indicar warm-ups, TEDs e recursos audiovisuais que contextualizem tecnologia aplicada a serviços.
+
+### Unidade II – Processos e ferramentas de apoio (Aulas 4–5)
+
+- [ ] Revisar fluxos operacionais e representar processos com ferramentas MD3 apropriadas.
+- [ ] Selecionar estudos de caso e exercícios guiados para integração com os templates oficiais.
+
+### Unidade III – Planejamento e execução de serviços (Aulas 6–11)
+
+- [ ] Mapear transição da teoria para prática, destacando checklists e planilhas de controle.
+- [ ] Registrar orientações sobre uso de `resources`, `callouts` e avaliações formativas.
+
+### Unidade IV – Monitoramento, métricas e melhoria contínua (Aulas 12–24)
+
+- [ ] Enumerar ajustes para dashboards, indicadores-chave e rotinas de feedback estruturado.
+- [ ] Documentar necessidades de materiais complementares (planilhas, roteiros de laboratório, rubricas).
+
+### Unidade V – Liderança de equipes e relacionamento com clientes (Aulas 25–29)
+
+- [ ] Organizar atividades colaborativas, dinâmicas de role-play e diretrizes de comunicação.
+- [ ] Definir critérios de avaliação para projetos modulares e checkpoints intermediários.
+
+### Unidade VI – Inovação em serviços e transformação digital (Aulas 30–37)
+
+- [ ] Relacionar conteúdos sobre ferramentas digitais, automação e análise de dados aplicadas a serviços.
+- [ ] Especificar datasets, templates de relatório e parâmetros para atividades de investigação.
+
+### Encerramento do semestre (Aulas 38–40)
+
+- [ ] Planejar revisões finais, apresentações, avaliações somativas e coleta de feedback 360°.
+- [ ] Indicar próximos marcos acadêmicos, documentação de encerramento e alinhamentos institucionais.
+
+## 4. Recursos recomendados por categoria
+
+- [ ] Atualizar tabela com vídeos, ferramentas, guias e materiais de avaliação específicos de TGS.
+- [ ] Verificar acessibilidade dos links e organizar evidências em repositórios compartilhados.
+
+## 5. Próximos passos operacionais
+
+- [ ] Auditar cada `lesson-XX.json`, ajustar `metadata.updatedAt`/`owners` e registrar alterações relevantes.
+- [ ] Rodar validações (`npm run validate:content`) e alinhar cronograma de atualização com os stakeholders.
+- [ ] Documentar decisões e pendências em `docs/governance/` ou no canal oficial de acompanhamento.
+
+---
+
+> **Status**: rascunho inicial. Atualizar com detalhes específicos de cada aula conforme o time de TGS consolide evidências e recursos.


### PR DESCRIPTION
## Summary
- add a TGS-focused lesson adjustment plan mirroring the ALGI document structure
- document the lesson JSON locations and provide checklist placeholders per section

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dbe78a6870832ca92e4e59cd1918ca