### PR TITLE
Refine TGS transversal directives

### DIFF
--- a/docs/didactics/tgs-lesson-adjustment-plan.md
+++ b/docs/didactics/tgs-lesson-adjustment-plan.md
@@ -10,9 +10,15 @@ Este plano centraliza os ajustes necessários nas aulas de **Tecnologia e Gestã
 
 ## 2. Diretrizes transversais
 
-- [ ] Confirmar metadados obrigatórios em todos os arquivos de lições (resumo, objetivos, competências, habilidades, duração, modalidade e avaliação quando aplicável).
-- [ ] Garantir presença e detalhamento dos blocos MD3 (`lessonPlan`, `flightPlan`, `callouts`, `cardGrid`, entre outros) e registrar orientações de pré e pós-aula.
-- [ ] Revisar alinhamento com Moodle (TEDs, avisos de conduta, bibliografia institucional) e validar a consistência dos recursos externos.
+1. **Metadados e estrutura mínima** – confirmar em cada `lesson-XX.json` os campos `summary`, `objectives`, `competencies`, `skills`, `outcomes`, `duration`, `modality`, `resources`, `assessment` (quando aplicável) e `metadata.updatedAt`/`metadata.owners`; garantir a sequência mínima por aula definida no plano de aprimoramento (contexto + exemplo aplicado + vídeo + exercício/TED + referências do plano de ensino).
+2. **Blocos MD3 completos** – assegurar `lessonPlan` e `flightPlan` detalhados, `callouts` para orientações pré/pós-aula, `cardGrid` para sínteses e uso de componentes específicos (`contentBlock`, `md3Table`, `callout.warning`) sempre que necessário para operacionalizar os ajustes.
+3. **Substituir "o professor mostrará"** – revisar cada ocorrência e inserir recursos concretos: link ou anexo em `resources`, descrição do passo a passo em `contentBlock` e, se houver demonstração, checklist de observação ou roteiro dentro do `lessonPlan`.
+4. **Exemplos escritos e contextualizados** – incluir parágrafos ou `cardGrid` com casos brasileiros (Magalu, Nubank, SUS Digital, gov.br, etc.) que conectem teoria e prática nas aulas introdutórias e nos conteúdos subsequentes.
+5. **TEDs e exercícios padronizados** – transformar instruções vagas em blocos com objetivo, formato de entrega, tempo estimado, rubrica compacta (em `callout.info` ou `md3Table`) e alinhamento com o Moodle (título, link e prazo); quando a avaliação substituir o TED, registrar isso em `assessment`.
+6. **Recursos em vídeo com propósito** – cada vídeo deve ter fonte, duração e objetivo pedagógico descritos em `resources`, priorizando materiais curtos (≤10 min) e playlists oficiais.
+7. **Ativação de exercícios extras** – atualizar blocos adicionais (`exercises`, `extras`) para `available: true` somente após revisão, incluindo critérios de correção e referência direta ao conteúdo trabalhado em aula.
+8. **Integração com Moodle** – replicar a abordagem do plano de ALGI usando `callout.info` para indicar uploads obrigatórios, `callout.warning` para prazos e conduta e links diretos para TEDs, fóruns ou avaliações hospedados no AVA.
+9. **Referências bibliográficas prioritárias** – garantir que cada aula cite pelo menos uma das obras-chave de TGS (Stair et al., 2021; Meireles & Sordi, 2019; Batista, 2014; Silva et al., 2019; Palmisano & Rosini, 2012; Audy & Brodbeck, 2008; Imoniana, 2016) nas seções de `resources`/`bibliography`, destacando capítulo ou página relevante.
 
 ## 3. Ajustes por unidade temática
 


### PR DESCRIPTION
## Summary
- expand the transversal guidelines in the TGS lesson adjustment plan with actionable items tied to the diagnostic findings
- reinforce mandatory metadata, MD3 block coverage, Moodle alignment, and required bibliographic references across lessons
- restate the minimum lesson structure defined in the TGS content improvement plan

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbe8b7b370832cbbf116533252b63a