### PR TITLE
Add DDM final project lessons 35-40

### DIFF
--- a/src/content/courses/ddm/lessons.json
+++ b/src/content/courses/ddm/lessons.json
@@ -155,6 +155,72 @@
       "tags": ["android", "room", "persistencia"],
       "duration": 120,
       "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-35",
+      "title": "Aula 35: Projeto Integrador – Planejamento Final",
+      "file": "lesson-35.json",
+      "available": true,
+      "description": "Consolida o plano final do projeto integrador, detalhando escopo, riscos e cronograma até a apresentação.",
+      "summary": "Planejamento detalhado do projeto integrador com priorização, matriz de riscos e integração ao Moodle.",
+      "tags": ["projeto-integrador", "planejamento", "agil"],
+      "duration": 120,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-36",
+      "title": "Aula 36: Projeto Integrador – Ciclo de Desenvolvimento 1",
+      "file": "lesson-36.json",
+      "available": true,
+      "description": "Acompanha o primeiro ciclo de desenvolvimento com foco em incremento funcional, integração contínua e registros de progresso.",
+      "summary": "Entrega de incremento priorizado, revisão técnica e atualização de relatórios do projeto integrador.",
+      "tags": ["projeto-integrador", "desenvolvimento", "ciclo-1"],
+      "duration": 120,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-37",
+      "title": "Aula 37: Projeto Integrador – Ciclo de Desenvolvimento 2",
+      "file": "lesson-37.json",
+      "available": true,
+      "description": "Foca no segundo ciclo acompanhado, priorizando testes integrados, refinamentos de UX e preparação de métricas para a banca.",
+      "summary": "Consolidação de estabilidade, usabilidade e indicadores que embasam a apresentação final.",
+      "tags": ["projeto-integrador", "desenvolvimento", "ciclo-2"],
+      "duration": 120,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-38",
+      "title": "Aula 38: Projeto Integrador – Preparação e Ensaio de Apresentação",
+      "file": "lesson-38.json",
+      "available": true,
+      "description": "Apoia a construção do storytelling, materiais e ensaio geral do pitch final da NP3.",
+      "summary": "Roteiro, materiais e documentação final organizados para a apresentação final do projeto.",
+      "tags": ["projeto-integrador", "apresentacao", "pitch"],
+      "duration": 100,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-39",
+      "title": "Aula 39: Projeto Integrador – Avaliação NP3",
+      "file": "lesson-39.json",
+      "available": true,
+      "description": "Realiza a banca avaliadora da NP3, aplicando rubrica oficial e registrando feedbacks para cada equipe.",
+      "summary": "Sessão de apresentação oficial com registro de notas, feedbacks e pendências pós-banca.",
+      "tags": ["projeto-integrador", "avaliacao", "np3"],
+      "duration": 180,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-40",
+      "title": "Aula 40: Projeto Integrador – Encerramento e Feedback 360°",
+      "file": "lesson-40.json",
+      "available": true,
+      "description": "Encaminha o encerramento da disciplina com feedbacks consolidados, retrospectiva e planos de desenvolvimento individual.",
+      "summary": "Encerramento da disciplina com lições aprendidas, PDIs e comunicação final aos stakeholders.",
+      "tags": ["projeto-integrador", "encerramento", "feedback"],
+      "duration": 100,
+      "formatVersion": "md3.lesson.v1"
     }
   ]
 }

--- a/src/content/courses/ddm/lessons/lesson-35.json
+++ b/src/content/courses/ddm/lessons/lesson-35.json
@@ -1,0 +1,160 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-35",
+  "title": "Aula 35: Projeto Integrador – Planejamento Final",
+  "slug": "projeto-integrador-planejamento-final",
+  "summary": "Orienta o planejamento detalhado do projeto integrador, consolidando escopo, cronograma e responsabilidades da equipe para a fase conclusiva.",
+  "objective": "Estruturar o plano final do projeto integrador garantindo clareza de entregas, riscos e estratégias de validação.",
+  "objectives": [
+    "Revisar o escopo do projeto integrador à luz dos requisitos das unidades anteriores.",
+    "Definir backlog final, responsáveis e cronograma de desenvolvimento e testes.",
+    "Elaborar matriz de riscos e estratégias de mitigação alinhadas às entregas avaliativas."
+  ],
+  "competencies": [
+    "Gestão de projetos ágeis",
+    "Planejamento orientado a produtos digitais",
+    "Comunicação e documentação técnica"
+  ],
+  "skills": [
+    "Priorizar histórias de usuário considerando valor e esforço.",
+    "Estimar tarefas utilizando métricas de capacidade da equipe.",
+    "Documentar plano de execução com critérios de aceite verificáveis."
+  ],
+  "outcomes": [
+    "Consolida um plano de projeto integrador claro, sequenciado e com responsáveis definidos.",
+    "Produz artefatos de planejamento compartilháveis com stakeholders e mentores.",
+    "Alinha o time sobre riscos, mitigação e checkpoints até a apresentação final."
+  ],
+  "prerequisites": [
+    "Backlog inicial construído nas aulas 31 a 34.",
+    "Resultados dos testes intermediários do protótipo funcional."
+  ],
+  "tags": ["projeto-integrador", "planejamento", "agil"],
+  "duration": 120,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Google Design Sprints – Checklist de Preparação",
+      "url": "https://designsprintkit.withgoogle.com/methodology/phase1-understand/checklist",
+      "type": "reference"
+    },
+    {
+      "label": "Atlassian – Guia de Backlog para times ágeis",
+      "url": "https://www.atlassian.com/agile/backlog",
+      "type": "article"
+    }
+  ],
+  "bibliography": [
+    "SCHWABER, K.; SUTHERLAND, J. Scrum Guide. 2023.",
+    "PRESSMAN, R.; MAXIM, B. Engenharia de Software. 9. ed. McGraw-Hill, 2022."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Rubrica diagnóstica para avaliar a consistência do plano final do projeto integrador e orientar ajustes antes dos ciclos de desenvolvimento acompanhados."
+  },
+  "content": [
+    {
+      "type": "flightPlan",
+      "title": "Plano de voo da aula",
+      "items": [
+        "Contextualização: objetivos do projeto integrador e critérios de avaliação finais.",
+        "Revisão de backlog e priorização com foco em valor mínimo viável.",
+        "Matriz de riscos e definição de ações mitigadoras.",
+        "Planejamento de sprints de acompanhamento (Aulas 36 e 37).",
+        "Checklist de documentação e integração com Moodle.",
+        "Síntese e definição de próximos passos."
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Rubrica de Planejamento",
+      "content": [
+        {
+          "type": "table",
+          "headers": ["Critério", "Excelente (A)", "Adequado (B)", "Insuficiente (C)"],
+          "rows": [
+            [
+              "Escopo",
+              "Lista de histórias priorizadas com critérios de aceite completos e alinhados à persona.",
+              "Backlog contém histórias principais, mas alguns critérios de aceite estão genéricos.",
+              "Escopo incompleto, histórias vagas ou sem vínculo com requisitos do cliente."
+            ],
+            [
+              "Cronograma",
+              "Sprints detalhadas com marcos, dependências e capacidade ajustada ao calendário.",
+              "Sprints definidas, porém com estimativas aproximadas ou dependências parcialmente mapeadas.",
+              "Ausência de datas claras, estimativas ou identificação de gargalos."
+            ],
+            [
+              "Riscos",
+              "Matriz de riscos com severidade, probabilidade, donos e plano de resposta registrado.",
+              "Riscos mapeados, mas com planos de resposta superficiais ou sem responsáveis.",
+              "Poucos riscos identificados e sem estratégia de mitigação."
+            ],
+            [
+              "Documentação",
+              "Plano anexado ao Moodle com versionamento, histórico de decisões e referências de testes.",
+              "Plano disponível, porém sem histórico de versões ou anexos de apoio.",
+              "Plano disperso em arquivos locais ou sem compartilhamento com a turma."
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "Checklist de Entrega",
+      "content": [
+        {
+          "type": "list",
+          "ordered": false,
+          "items": [
+            "Backlog priorizado (até 10 histórias) com critérios de aceite.",
+            "Cronograma das próximas três semanas no formato sprint ou kanban.",
+            "Matriz de riscos com pelo menos cinco itens.",
+            "Definição do responsável por cada entrega crítica.",
+            "Upload do documento no Moodle em PDF ou link compartilhável até 23h59."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Orientações de Documentação",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Utilize o template de planejamento disponibilizado na pasta compartilhada. Atualize o versionamento no topo do documento (v1.0, v1.1 etc.) e mantenha os quadros de backlog sincronizados com o repositório do time (GitHub ou GitLab)."
+        },
+        {
+          "type": "list",
+          "ordered": true,
+          "items": [
+            "Padronize nomes de histórias: [Persona] quer [funcionalidade] para [valor].",
+            "Inclua critérios de aceite mensuráveis e alinhados à avaliação NP3.",
+            "Registrar decisões estratégicas e mudanças de escopo no changelog do documento."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Aviso Moodle",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Assunto: Entrega do Plano Final do Projeto Integrador. Texto sugerido: \"Equipe, o plano final deve ser anexado até 23h59 de hoje no tópico 'Projeto Integrador – Planejamento Final'. Utilizem o campo de comentários para indicar dúvidas específicas sobre riscos ou cronograma.\""
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2024-09-15T00:00:00.000Z",
+    "owners": ["Equipe DDM"],
+    "sources": ["Plano de Ensino DDM 2024", "Guia do Projeto Integrador 2024"]
+  }
+}

--- a/src/content/courses/ddm/lessons/lesson-36.json
+++ b/src/content/courses/ddm/lessons/lesson-36.json
@@ -1,0 +1,156 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-36",
+  "title": "Aula 36: Projeto Integrador – Ciclo de Desenvolvimento 1",
+  "slug": "projeto-integrador-ciclo-desenvolvimento-1",
+  "summary": "Conduz o primeiro ciclo acompanhando o desenvolvimento do projeto integrador com foco em incrementos priorizados, integração contínua e feedback rápido.",
+  "objective": "Garantir a entrega de incrementos funcionais planejados, validando qualidade técnica e alinhamento ao plano final.",
+  "objectives": [
+    "Sincronizar o andamento das tarefas com o backlog consolidado.",
+    "Validar a qualidade do código e das integrações por meio de revisões rápidas.",
+    "Registrar evidências de progresso em relatórios semanais e no Moodle."
+  ],
+  "competencies": ["Desenvolvimento colaborativo", "Integração contínua", "Gestão de configuração"],
+  "skills": [
+    "Conduzir daily meetings objetivas com apontamentos de bloqueios.",
+    "Aplicar code review guiado por checklist técnico.",
+    "Registrar demonstrações parciais em vídeo ou capturas de tela com narração técnica."
+  ],
+  "outcomes": [
+    "Entrega um incremento funcional integrado ao repositório principal.",
+    "Mantém documentação e quadro de tarefas atualizados com status real.",
+    "Evidencia testes realizados e pendências para o próximo ciclo."
+  ],
+  "prerequisites": [
+    "Plano final aprovado na Aula 35.",
+    "Ambiente de integração contínua configurado (GitHub Actions ou similar)."
+  ],
+  "tags": ["projeto-integrador", "desenvolvimento", "ciclo-1"],
+  "duration": 120,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "GitHub Actions – Getting started",
+      "url": "https://docs.github.com/actions/learn-github-actions/understanding-github-actions",
+      "type": "article"
+    },
+    {
+      "label": "Checklist de Code Review do Android Jetpack",
+      "url": "https://developer.android.com/topic/libraries/architecture/guide#code-reviews",
+      "type": "reference"
+    }
+  ],
+  "bibliography": [
+    "MARTIN, R. C. Código Limpo. 2. ed. Alta Books, 2022.",
+    "GOOGLE. Android Developers – Guia de Testes. 2024."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Rubrica de acompanhamento para avaliar a qualidade do incremento entregue no Ciclo 1 e orientar ajustes imediatos."
+  },
+  "content": [
+    {
+      "type": "flightPlan",
+      "title": "Plano de voo da aula",
+      "items": [
+        "Daily meeting estendida para alinhamento de prioridades.",
+        "Hands-on: implementação dos itens críticos do sprint.",
+        "Mentorias em pares focadas em integração contínua e testes automatizados.",
+        "Revisão de código orientada por checklist técnico.",
+        "Registro de evidências e atualização do relatório semanal.",
+        "Agendamento de pendências para o Ciclo 2 (Aula 37)."
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Rubrica de Incremento (Ciclo 1)",
+      "content": [
+        {
+          "type": "table",
+          "headers": ["Critério", "Excelente (A)", "Adequado (B)", "Insuficiente (C)"],
+          "rows": [
+            [
+              "Funcionalidade",
+              "Incremento entrega valor completo, alinhado aos critérios de aceite, sem bugs críticos.",
+              "Funcionalidade implementada com pequenos ajustes pendentes ou bugs de baixa prioridade.",
+              "Entregável parcial, sem atender critérios essenciais ou com falhas graves."
+            ],
+            [
+              "Qualidade técnica",
+              "Código padronizado, com testes automatizados executados e integração contínua verde.",
+              "Código funcional com pequenos desvios de padrão ou cobertura de testes parcial.",
+              "Código sem revisão, sem testes ou quebrando o pipeline de CI."
+            ],
+            [
+              "Documentação",
+              "Readme e wiki atualizados com instruções do incremento e evidências de teste.",
+              "Documentação atualizada parcialmente, sem evidências completas.",
+              "Sem atualização de documentação ou instruções de execução."
+            ],
+            [
+              "Comunicação",
+              "Daily report enviado em até 2 horas após a aula com status, bloqueios e próximos passos.",
+              "Daily report entregue com atraso ou sem detalhar bloqueios.",
+              "Ausência de report ou informações incompletas."
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "Checklist de Entrega do Ciclo 1",
+      "content": [
+        {
+          "type": "list",
+          "ordered": false,
+          "items": [
+            "Pull request aprovado e mergeado na branch principal.",
+            "Pipeline de CI executado com sucesso e artefato disponível.",
+            "Registro de testes (logs, prints ou vídeos) anexado ao relatório.",
+            "Atualização do quadro Kanban com cartões movidos para \"Concluído\".",
+            "Daily report postado no fórum do Moodle."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Orientações de Documentação",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Utilizem o arquivo RELEASE_NOTES.md para listar incrementos entregues e impactos em módulos. Atualizem a Wiki com instruções de configuração para QA e anexem links das pipelines executadas."
+        },
+        {
+          "type": "list",
+          "ordered": true,
+          "items": [
+            "Adicionar seção \"Incremento Ciclo 1\" no README principal.",
+            "Registrar evidências de testes instrumentados no diretório docs/testes.",
+            "Arquivar gravações de demonstração no drive compartilhado e vincular na Wiki."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Aviso Moodle",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Assunto: Relatório do Ciclo 1 disponível. Texto sugerido: \"Postem no fórum 'Projeto Integrador – Ciclo 1' o link para o relatório semanal, destacando o incremento integrado e eventuais bloqueios que exigem suporte docente. Prazo: até amanhã às 12h.\""
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2024-09-22T00:00:00.000Z",
+    "owners": ["Equipe DDM"],
+    "sources": ["Guia de Mentoria Ágil", "Relatórios de acompanhamento 2023"]
+  }
+}

--- a/src/content/courses/ddm/lessons/lesson-37.json
+++ b/src/content/courses/ddm/lessons/lesson-37.json
@@ -1,0 +1,160 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-37",
+  "title": "Aula 37: Projeto Integrador – Ciclo de Desenvolvimento 2",
+  "slug": "projeto-integrador-ciclo-desenvolvimento-2",
+  "summary": "Acompanha o segundo ciclo de desenvolvimento com foco em testes integrados, refinamento de UX e preparação de métricas para a apresentação final.",
+  "objective": "Consolidar o produto com estabilidade e experiência aprimorada, garantindo material de suporte para a apresentação e avaliação final.",
+  "objectives": [
+    "Validar integrações completas entre módulos e serviços externos.",
+    "Revisar a experiência do usuário e aplicar ajustes finais de usabilidade.",
+    "Preparar métricas de uso e resultados para embasar a apresentação."
+  ],
+  "competencies": [
+    "Qualidade de software",
+    "Design centrado no usuário",
+    "Comunicação de resultados"
+  ],
+  "skills": [
+    "Executar testes exploratórios e registrar incidentes.",
+    "Aplicar heurísticas de Nielsen para identificar ajustes de UX.",
+    "Construir painéis com métricas chave e narrativas orientadas a dados."
+  ],
+  "outcomes": [
+    "Produto estável com bugs críticos resolvidos e UX refinada.",
+    "Documentação de testes e insights de usabilidade anexados ao repositório.",
+    "Dashboard ou relatório com métricas que sustentam a narrativa da apresentação final."
+  ],
+  "prerequisites": [
+    "Incremento do Ciclo 1 mergeado na branch principal.",
+    "Feedbacks de usabilidade coletados com usuários-teste internos."
+  ],
+  "tags": ["projeto-integrador", "desenvolvimento", "ciclo-2"],
+  "duration": 120,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Nielsen Norman Group – 10 heurísticas de usabilidade",
+      "url": "https://www.nngroup.com/articles/ten-usability-heuristics/",
+      "type": "article"
+    },
+    {
+      "label": "Firebase Analytics – Guia de métricas para apps",
+      "url": "https://firebase.google.com/docs/analytics",
+      "type": "reference"
+    }
+  ],
+  "bibliography": [
+    "KRUG, S. Não me faça pensar. Alta Books, 2014.",
+    "ROZENFELD, H. et al. Gestão de Desenvolvimento de Produtos. Saraiva, 2015."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Rubrica de verificação do Ciclo 2, avaliando estabilidade, usabilidade e evidências para a apresentação final."
+  },
+  "content": [
+    {
+      "type": "flightPlan",
+      "title": "Plano de voo da aula",
+      "items": [
+        "Retrospectiva rápida do Ciclo 1 e ajustes incorporados.",
+        "Execução assistida de testes integrados e instrumentados.",
+        "Sessões de UX review com heurísticas e feedback entre pares.",
+        "Construção de métricas e storytelling com dashboards.",
+        "Atualização da documentação e materiais de apresentação.",
+        "Planejamento da Aula 38 (ensaio de pitch e documentação final)."
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Rubrica de Qualidade (Ciclo 2)",
+      "content": [
+        {
+          "type": "table",
+          "headers": ["Critério", "Excelente (A)", "Adequado (B)", "Insuficiente (C)"],
+          "rows": [
+            [
+              "Estabilidade",
+              "Suite de testes (unitários, instrumentados) executada sem falhas e evidências registradas.",
+              "Testes executados parcialmente com pequenos incidentes abertos.",
+              "Sem registros de testes ou falhas críticas pendentes."
+            ],
+            [
+              "Usabilidade",
+              "Heurísticas aplicadas com ações corretivas documentadas e protótipo final atualizado.",
+              "Análise heurística realizada, mas com implementações em andamento.",
+              "Ausência de revisão de UX ou decisões não registradas."
+            ],
+            [
+              "Métricas",
+              "Painel com KPIs definidos, dados coletados e narrativa associada à proposta de valor.",
+              "Métricas listadas sem painel consolidado ou com dados parciais.",
+              "Métricas não definidas ou sem conexão com objetivos do projeto."
+            ],
+            [
+              "Documentação",
+              "Relatório de testes e UX anexado ao Moodle, com links e anexos organizados.",
+              "Relatório entregue mas com anexos dispersos ou sem links funcionais.",
+              "Sem relatório atualizado ou anexos acessíveis."
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "Checklist de Entrega do Ciclo 2",
+      "content": [
+        {
+          "type": "list",
+          "ordered": false,
+          "items": [
+            "Registro de testes no diretório docs/testes com evidências (prints, logs, vídeos).",
+            "Lista de heurísticas aplicadas e respectivas correções implementadas.",
+            "Painel de métricas publicado (Looker Studio, Firebase ou Sheets).",
+            "Atualização do roadmap destacando itens concluídos e pendências mínimas.",
+            "Post no Moodle com resumo do ciclo e anexos organizados."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Orientações de Documentação",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Consolidem os aprendizados em um relatório 'Testes & UX' (docs/testes/relatorio-ciclo2.md) incluindo tabela de incidentes, decisões tomadas e impacto nas métricas."
+        },
+        {
+          "type": "list",
+          "ordered": true,
+          "items": [
+            "Documentar ambiente, dados de teste e scripts utilizados.",
+            "Gerar seção \"Insights de UX\" com antes/depois e justificativas.",
+            "Atualizar o cronograma no documento principal com status após o Ciclo 2."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Aviso Moodle",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Assunto: Relatório de Qualidade – Ciclo 2. Texto sugerido: \"Publiquem até as 18h de amanhã o link para o relatório 'Testes & UX', incluindo o dashboard de métricas. Comentem no tópico caso necessitem de mentoria extra antes do ensaio geral.\""
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2024-09-29T00:00:00.000Z",
+    "owners": ["Equipe DDM"],
+    "sources": ["Manual de Qualidade de Software DDM", "Relatórios de UX 2023"]
+  }
+}

--- a/src/content/courses/ddm/lessons/lesson-38.json
+++ b/src/content/courses/ddm/lessons/lesson-38.json
@@ -1,0 +1,160 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-38",
+  "title": "Aula 38: Projeto Integrador – Preparação e Ensaio de Apresentação",
+  "slug": "projeto-integrador-preparacao-e-ensaio",
+  "summary": "Guia as equipes na construção do storytelling, materiais de apoio e ensaio geral para a apresentação final do projeto integrador.",
+  "objective": "Preparar pitch consistente, alinhado às evidências técnicas, garantindo materiais entregáveis e documentação finalizada.",
+  "objectives": [
+    "Estruturar roteiro da apresentação com narrativa orientada a problema, solução e resultados.",
+    "Finalizar documentação técnica e anexos obrigatórios.",
+    "Realizar ensaios cronometrados com feedback estruturado."
+  ],
+  "competencies": [
+    "Storytelling de produtos digitais",
+    "Comunicação técnica",
+    "Gestão de entregas finais"
+  ],
+  "skills": [
+    "Construir apresentações visuais concisas e alinhadas à identidade do produto.",
+    "Destacar métricas e aprendizados relevantes em discurso técnico.",
+    "Aplicar feedbacks rápidos para ajustar tempo e clareza do pitch."
+  ],
+  "outcomes": [
+    "Roteiro final aprovado e apresentação ajustada ao tempo limite.",
+    "Documentação técnica consolidada e enviada com antecedência.",
+    "Equipe segura quanto à divisão de falas e material de apoio."
+  ],
+  "prerequisites": [
+    "Relatório de Testes & UX entregue na Aula 37.",
+    "Incremento final integrado ao repositório."
+  ],
+  "tags": ["projeto-integrador", "apresentacao", "pitch"],
+  "duration": 100,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Guy Kawasaki – Regra 10/20/30 do pitch",
+      "url": "https://guykawasaki.com/the-102030-rule/",
+      "type": "article"
+    },
+    {
+      "label": "Pitch Canvas – Ferramenta de Storytelling",
+      "url": "https://pitchcanvas.io/",
+      "type": "tool"
+    }
+  ],
+  "bibliography": [
+    "DUARTE, N. Slide:ology. O'Reilly, 2010.",
+    "OSTERWALDER, A.; PIGNEUR, Y. Value Proposition Design. Wiley, 2014."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Rubrica de prontidão para verificar roteiro, materiais e segurança da equipe antes da avaliação NP3."
+  },
+  "content": [
+    {
+      "type": "flightPlan",
+      "title": "Plano de voo da aula",
+      "items": [
+        "Kick-off: alinhamento das regras da banca e critérios NP3.",
+        "Construção colaborativa do roteiro (Pitch Canvas).",
+        "Mentorias sobre slides, demo e materiais de apoio.",
+        "Ensaio cronometrado com registro em vídeo.",
+        "Feedback 360° (colegas, docentes, mentores).",
+        "Checklist final de documentação e submissão Moodle."
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Rubrica de Prontidão para o Pitch",
+      "content": [
+        {
+          "type": "table",
+          "headers": ["Critério", "Excelente (A)", "Adequado (B)", "Insuficiente (C)"],
+          "rows": [
+            [
+              "Narrativa",
+              "Apresentação segue estrutura clara (problema, solução, diferenciais, resultados) dentro do tempo.",
+              "Narrativa compreensível, porém com ajustes de tempo ou aprofundamento necessários.",
+              "História confusa, sem conexão com o problema ou estourando tempo."
+            ],
+            [
+              "Demonstração",
+              "Demo fluida, com roteiro ensaiado e plano B documentado em caso de falhas.",
+              "Demo funcional, mas com dependência de conexão ou pequenos riscos não mitigados.",
+              "Demo inexistente ou não testada previamente."
+            ],
+            [
+              "Material de apoio",
+              "Slides, one-pager e anexos técnicos prontos, padronizados e acessíveis à banca.",
+              "Materiais quase finalizados, demandando ajustes de formatação ou acesso.",
+              "Materiais incompletos ou indisponíveis para a banca."
+            ],
+            [
+              "Documentação",
+              "Relatório final, manual do usuário e repositório com tag de release publicados.",
+              "Documentação publicada parcialmente ou sem versão final marcada.",
+              "Ausência de documentação consolidada ou release final."
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "Checklist Final de Preparação",
+      "content": [
+        {
+          "type": "list",
+          "ordered": false,
+          "items": [
+            "Slides exportados em PDF e enviados à banca.",
+            "One-pager com resumo do projeto (problema, solução, métricas).",
+            "Manual do usuário atualizado com versão do app apresentada.",
+            "Vídeo do ensaio salvo no drive e compartilhado com o time.",
+            "Tag de release (v1.0-NP3) criada no repositório."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Orientações de Documentação",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Consolidem tudo no pacote \"Entrega NP3\": pasta com subpastas 01-Slides, 02-Demo, 03-Documentação, 04-Métricas. Incluam README.txt com instruções de navegação e contatos da equipe."
+        },
+        {
+          "type": "list",
+          "ordered": true,
+          "items": [
+            "Atualizar o arquivo SUMMARY.md indicando os anexos da entrega.",
+            "Inserir link do vídeo de ensaio e timecodes principais.",
+            "Garantir que os documentos sigam o padrão de nomenclatura: equipe_nome-artefato_v1.0.pdf."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Aviso Moodle",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Assunto: Upload da Pasta 'Entrega NP3'. Texto sugerido: \"Realizem o envio da pasta compactada (ZIP) com todos os materiais do pitch no tópico 'Preparação NP3' até às 23h59. Comentem no mesmo tópico com o link do vídeo de ensaio.\""
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2024-10-02T00:00:00.000Z",
+    "owners": ["Equipe DDM"],
+    "sources": ["Guia da Banca NP3", "Manual de Apresentações Acadêmicas"]
+  }
+}

--- a/src/content/courses/ddm/lessons/lesson-39.json
+++ b/src/content/courses/ddm/lessons/lesson-39.json
@@ -1,0 +1,147 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-39",
+  "title": "Aula 39: Projeto Integrador – Avaliação NP3",
+  "slug": "projeto-integrador-avaliacao-np3",
+  "summary": "Realiza a apresentação oficial do projeto integrador perante a banca avaliadora, aplicando os critérios da NP3 e registrando feedbacks formais.",
+  "objective": "Conduzir a sessão de avaliação NP3 garantindo critérios transparentes, registro de notas e devolutivas construtivas para cada equipe.",
+  "objectives": [
+    "Executar as apresentações seguindo o cronograma e protocolo da banca.",
+    "Aplicar a rubrica de avaliação NP3 e registrar notas parciais e gerais.",
+    "Formalizar feedbacks qualitativos e acordar ajustes finais pós-banca."
+  ],
+  "competencies": [
+    "Gestão de avaliações",
+    "Comunicação institucional",
+    "Análise crítica de projetos digitais"
+  ],
+  "skills": [
+    "Conduzir sessões de banca mantendo tempo, ordem e participação equitativa.",
+    "Registrar notas e observações em planilha oficial.",
+    "Comunicar feedbacks objetivos e alinhados aos critérios da NP3."
+  ],
+  "outcomes": [
+    "Avaliação concluída com notas registradas e validadas pela banca.",
+    "Feedbacks entregues às equipes com pontos fortes e oportunidades de melhoria.",
+    "Checklist de pendências pós-NP3 acordado com prazos realistas."
+  ],
+  "prerequisites": [
+    "Entrega da pasta 'Entrega NP3' validada na Aula 38.",
+    "Presença dos integrantes da equipe na sessão de avaliação."
+  ],
+  "tags": ["projeto-integrador", "avaliacao", "np3"],
+  "duration": 180,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Template de Planilha de Avaliação NP3",
+      "url": "https://docs.google.com/spreadsheets/d/template-np3",
+      "type": "template"
+    },
+    {
+      "label": "Guia de condução de bancas avaliativas",
+      "url": "https://educacao.diretrizes/bancas-avaliativas",
+      "type": "article"
+    }
+  ],
+  "bibliography": [
+    "BARBOSA, S. D. J.; SILVA, B. S. Interação Humano-Computador. Elsevier, 2010.",
+    "ISO/IEC 25010. Systems and software engineering — Systems and software Quality Requirements and Evaluation. 2011."
+  ],
+  "assessment": {
+    "type": "summative",
+    "description": "Rubrica oficial NP3 aplicada pela banca para atribuição das notas finais do projeto integrador."
+  },
+  "content": [
+    {
+      "type": "flightPlan",
+      "title": "Protocolo da Sessão",
+      "items": [
+        "Abertura: apresentação da banca, regras e critérios.",
+        "Sequência de pitches conforme cronograma divulgado.",
+        "Rodada de perguntas e respostas (5 minutos por equipe).",
+        "Deliberação da banca e registro de notas.",
+        "Feedback imediato para cada equipe.",
+        "Orientações sobre ajustes finais e prazos pós-banca."
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Rubrica Oficial NP3",
+      "content": [
+        {
+          "type": "table",
+          "headers": ["Dimensão", "Peso", "Descrição"],
+          "rows": [
+            [
+              "Produto (40%)",
+              "0,4",
+              "Avalia completude funcional, estabilidade, performance e aderência aos requisitos do usuário."
+            ],
+            [
+              "Experiência do usuário (20%)",
+              "0,2",
+              "Considera consistência visual, usabilidade, acessibilidade e resultados dos testes com usuários."
+            ],
+            [
+              "Processo e documentação (20%)",
+              "0,2",
+              "Examina coerência do planejamento, registros de sprint, documentação técnica e versionamento."
+            ],
+            [
+              "Apresentação e pitch (20%)",
+              "0,2",
+              "Avalia clareza do storytelling, domínio da equipe, qualidade dos materiais e gestão do tempo."
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Checklist da Banca",
+      "content": [
+        {
+          "type": "list",
+          "ordered": true,
+          "items": [
+            "Validar presença de todos os integrantes e assinaturas da ata.",
+            "Conferir envio prévio dos materiais (slides, demo, documentação).",
+            "Registrar horários de início e término de cada apresentação.",
+            "Preencher planilha de notas em tempo real e coletar assinaturas da banca.",
+            "Salvar feedbacks escritos em PDF e anexar no Moodle.",
+            "Divulgar prazos de ajustes pós-banca e publicação das notas."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Orientações de Documentação",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Ao final da sessão, anexar no repositório da turma (pasta /avaliacoes/np3) a planilha assinada, ata digitalizada e PDFs dos feedbacks individuais. Atualizar o documento principal do projeto com a seção 'Feedback da Banca' e ações previstas."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Aviso Moodle",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Assunto: Publicação das Notas NP3. Texto sugerido: \"As notas e feedbacks da NP3 serão publicados até as 22h de hoje no tópico 'Resultados NP3'. Confiram a planilha anexada e registrem no fórum quaisquer pedidos de reconsideração até 24h após a divulgação.\""
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2024-10-05T00:00:00.000Z",
+    "owners": ["Equipe DDM"],
+    "sources": ["Regulamento de Avaliações Integradas DDM", "Ata de banca NP3 2023"]
+  }
+}

--- a/src/content/courses/ddm/lessons/lesson-40.json
+++ b/src/content/courses/ddm/lessons/lesson-40.json
@@ -1,0 +1,156 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-40",
+  "title": "Aula 40: Projeto Integrador – Encerramento e Feedback 360°",
+  "slug": "projeto-integrador-encerramento-e-feedback",
+  "summary": "Promove o fechamento da disciplina com devolutivas consolidadas, reflexão sobre aprendizados, plano de evolução profissional e atualização de documentação final.",
+  "objective": "Encerrar o ciclo do projeto integrador com feedback estruturado, registro de lições aprendidas e encaminhamento de pendências.",
+  "objectives": [
+    "Compartilhar resultados da NP3 e pontos fortes identificados pela banca.",
+    "Conduzir retrospectiva 360° envolvendo equipe, docentes e parceiros.",
+    "Definir plano de continuidade do produto e desenvolvimento profissional individual."
+  ],
+  "competencies": ["Aprendizagem contínua", "Gestão de carreira", "Colaboração e retroalimentação"],
+  "skills": [
+    "Registrar lições aprendidas em formato estruturado.",
+    "Elaborar planos de desenvolvimento individual (PDI).",
+    "Comunicar agradecimentos e próximos passos aos stakeholders."
+  ],
+  "outcomes": [
+    "Documento de lições aprendidas publicado e compartilhado.",
+    "PDIs individuais alinhados a metas de curto e médio prazo.",
+    "Pendências finais do projeto mapeadas com responsáveis e prazos."
+  ],
+  "prerequisites": [
+    "Conclusão da banca NP3 (Aula 39).",
+    "Disponibilidade das notas e feedbacks oficiais."
+  ],
+  "tags": ["projeto-integrador", "encerramento", "feedback"],
+  "duration": 100,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Retrospective Prime Directive",
+      "url": "https://retrospectivewiki.org/index.php?title=Prime_Directive",
+      "type": "article"
+    },
+    {
+      "label": "Modelo de Plano de Desenvolvimento Individual (PDI)",
+      "url": "https://www.atlassian.com/team-playbook/plays/individual-growth-plan",
+      "type": "template"
+    }
+  ],
+  "bibliography": [
+    "LENCIONI, P. Os Cinco Desafios das Equipes. Campus, 2015.",
+    "SUTHERLAND, J. Scrum: A Arte de Fazer o Dobro do Trabalho na Metade do Tempo. Leya, 2016."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Rubrica de maturidade para avaliar o fechamento do projeto e a qualidade das devolutivas e planos individuais."
+  },
+  "content": [
+    {
+      "type": "flightPlan",
+      "title": "Plano de voo da aula",
+      "items": [
+        "Boas-vindas e celebração dos resultados.",
+        "Síntese das notas e feedbacks da banca NP3.",
+        "Retrospectiva 360° (Start, Stop, Continue).",
+        "Construção dos PDIs individuais.",
+        "Encaminhamento das pendências e planos de continuidade.",
+        "Avaliação da disciplina e encerramento formal."
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Rubrica de Encerramento",
+      "content": [
+        {
+          "type": "table",
+          "headers": ["Critério", "Excelente (A)", "Adequado (B)", "Insuficiente (C)"],
+          "rows": [
+            [
+              "Reflexão",
+              "Lições aprendidas documentadas com causas, impactos e recomendações futuras.",
+              "Reflexões listadas, mas com análise superficial ou sem responsáveis.",
+              "Ausência de reflexão estruturada ou sem registro compartilhado."
+            ],
+            [
+              "Plano de continuidade",
+              "Pendências categorizadas (técnicas, negócio, operação) com responsáveis e prazos claros.",
+              "Pendências listadas com responsáveis, porém sem prazos definidos.",
+              "Sem plano de continuidade ou responsáveis atribuídos."
+            ],
+            [
+              "PDI individual",
+              "Metas SMART definidas, com indicadores e recursos necessários.",
+              "Metas listadas, porém sem indicadores ou datas.",
+              "PDI incompleto ou inexistente."
+            ],
+            [
+              "Comunicação",
+              "Agradecimentos enviados aos stakeholders e status final registrado no Moodle.",
+              "Comunicado elaborado mas ainda não enviado ou sem confirmação de recebimento.",
+              "Sem comunicação formal aos stakeholders."
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "Checklist de Encerramento",
+      "content": [
+        {
+          "type": "list",
+          "ordered": false,
+          "items": [
+            "Documento de Lições Aprendidas (lessons-learned.md) publicado no repositório.",
+            "PDI individual submetido via formulário Moodle.",
+            "Email de agradecimento enviado aos parceiros e mentores.",
+            "Pendências finais registradas na planilha de acompanhamento.",
+            "Avaliação da disciplina respondida no Moodle."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Orientações de Documentação",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Organizem o diretório /docs/encerramento contendo lessons-learned.md, pdis/ e comunicados/. Atualizem o README com links diretos para os novos artefatos e adicionem a data de encerramento do projeto."
+        },
+        {
+          "type": "list",
+          "ordered": true,
+          "items": [
+            "Registrar no lessons-learned.md as ações Start/Stop/Continue com responsáveis.",
+            "Salvar PDIs individuais nomeados como pdi_nome-sobrenome.pdf.",
+            "Anexar o comunicado final em formato PDF no diretório comunicados/."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Aviso Moodle",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Assunto: Feedback Final e Avaliação da Disciplina. Texto sugerido: \"Disponibilizamos o formulário 'Feedback Final DDM'. Preencham até sexta-feira às 20h e anexem o PDF do PDI. A ata de encerramento estará no tópico 'Conclusão do Projeto Integrador'.\""
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "status": "draft",
+    "updatedAt": "2024-10-10T00:00:00.000Z",
+    "owners": ["Equipe DDM"],
+    "sources": ["Guia de Retrospectivas DDM", "Plano de Carreira Tech 2024"]
+  }
+}


### PR DESCRIPTION
## Summary
- add lessons 35-40 covering final project planning, development cycles, NP3 evaluation, and closure with rubricas, checklists, orientações de documentação e avisos Moodle
- update the DDM lessons manifest to list the new aulas with títulos, descrições e durações consistentes

## Testing
- npm run validate:content -- --no-report src/content/courses/ddm/lessons.json src/content/courses/ddm/lessons/lesson-35.json src/content/courses/ddm/lessons/lesson-36.json src/content/courses/ddm/lessons/lesson-37.json src/content/courses/ddm/lessons/lesson-38.json src/content/courses/ddm/lessons/lesson-39.json src/content/courses/ddm/lessons/lesson-40.json

------
https://chatgpt.com/codex/tasks/task_e_68dc77d8f88c832c8519258dc93d745c