### PR TITLE
Add DDM lessons 15-19 covering Room CRUD and MVVM

### DIFF
--- a/src/content/courses/ddm/lessons.json
+++ b/src/content/courses/ddm/lessons.json
@@ -157,6 +157,61 @@
       "formatVersion": "md3.lesson.v1"
     },
     {
+      "id": "lesson-15",
+      "title": "Aula 15: Unidade III – Revisão para NP1 e Checklist de Persistência",
+      "file": "lesson-15.json",
+      "available": true,
+      "description": "Consolida conceitos de persistência local e orienta a preparação para a avaliação NP1 com foco em Room e SharedPreferences.",
+      "summary": "Revisa estratégias de persistência, organiza o checklist da NP1 e direciona o trabalho avaliativo com base no app catálogo persistido.",
+      "tags": ["android", "room", "shared-preferences", "avaliacao"],
+      "duration": 100,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-16",
+      "title": "Aula 16: Unidade III – Estruturando o RoomDatabase e Migrações",
+      "file": "lesson-16.json",
+      "available": true,
+      "description": "Aprofunda a implementação da classe RoomDatabase, padrões de instância e migrações para evolução segura do schema.",
+      "summary": "Detalha como configurar RoomDatabase, criar migrações e validar persistência com testes instrumentados, preparando a base para um CRUD completo.",
+      "tags": ["android", "room", "migracoes", "persistencia"],
+      "duration": 120,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-17",
+      "title": "Aula 17: Unidade III – CRUD com Room (Parte 1)",
+      "file": "lesson-17.json",
+      "available": true,
+      "description": "Implementa operações de criação e leitura usando Room, conectando formulários Kotlin e listagens reativas à base local.",
+      "summary": "Constrói o fluxo Create + Read com Room, validando entradas e exibindo dados persistidos em RecyclerView com Flow/LiveData.",
+      "tags": ["android", "room", "crud", "persistencia"],
+      "duration": 120,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-18",
+      "title": "Aula 18: Unidade III – CRUD com Room (Parte 2)",
+      "file": "lesson-18.json",
+      "available": true,
+      "description": "Completa o CRUD com operações de atualização e exclusão no Room, enfatizando feedbacks visuais e consistência de dados.",
+      "summary": "Finaliza o ciclo CRUD no Room com fluxos de edição e remoção, garantindo UX consistente e testes de manutenção de dados.",
+      "tags": ["android", "room", "crud", "persistencia"],
+      "duration": 120,
+      "formatVersion": "md3.lesson.v1"
+    },
+    {
+      "id": "lesson-19",
+      "title": "Aula 19: Unidade III – ViewModel e LiveData para Persistência Local",
+      "file": "lesson-19.json",
+      "available": true,
+      "description": "Introduz ViewModel e LiveData como camada intermediária entre Room e a UI, garantindo reatividade e sobrevivência a mudanças de configuração.",
+      "summary": "Integra Room com ViewModel e LiveData, conectando dados persistidos à interface com observadores reativos e boas práticas de ciclo de vida.",
+      "tags": ["android", "viewmodel", "livedata", "persistencia"],
+      "duration": 110,
+      "formatVersion": "md3.lesson.v1"
+    },
+      {
       "id": "lesson-20",
       "title": "Aula 20: Unidade IV – Fundamentos de APIs REST e JSON",
       "file": "lesson-20.json",

--- a/src/content/courses/ddm/lessons/lesson-15.json
+++ b/src/content/courses/ddm/lessons/lesson-15.json
@@ -1,0 +1,172 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-15",
+  "title": "Aula 15: Unidade III – Revisão para NP1 e Checklist de Persistência",
+  "slug": "revisao-np1-persistencia",
+  "summary": "Consolida os conceitos de persistência local vistos até o momento e orienta a preparação para a avaliação NP1 com foco na camada de dados em apps Android.",
+  "objective": "Organizar evidências, revisar fundamentos de persistência local e alinhar expectativas para a prova e o trabalho da NP1.",
+  "objectives": [
+    "Revisitar SharedPreferences e Room, comparando casos de uso.",
+    "Resolver questões-guia sobre modelagem de dados locais.",
+    "Planejar o trabalho avaliativo da NP1 conectando requisitos de persistência.",
+    "Listar materiais obrigatórios a serem submetidos no Moodle."
+  ],
+  "competencies": [
+    "Análise crítica de soluções de persistência",
+    "Planejamento de avaliações práticas em desenvolvimento mobile",
+    "Comunicação técnica em times de desenvolvimento"
+  ],
+  "skills": [
+    "Diagnosticar problemas de persistência em apps Kotlin.",
+    "Elaborar respostas estruturadas para questões teóricas e práticas.",
+    "Montar um checklist de entrega compatível com critérios da disciplina."
+  ],
+  "outcomes": [
+    "Reforça conceitos-chave de SharedPreferences e Room para a prova.",
+    "Documenta o escopo do trabalho avaliativo alinhado com NP1.",
+    "Publica no Moodle o plano de estudos e o checklist acordado em aula."
+  ],
+  "prerequisites": [
+    "Aula 13 – Persistência com SharedPreferences.",
+    "Aula 14 – Introdução ao Room."
+  ],
+  "tags": ["android", "room", "shared-preferences", "avaliacao"],
+  "duration": 100,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Checklist oficial NP1",
+      "url": "https://classroom.example.edu/ddm/np1-checklist",
+      "type": "document"
+    },
+    {
+      "label": "Room persistence library",
+      "url": "https://developer.android.com/training/data-storage/room",
+      "type": "article"
+    },
+    {
+      "label": "SharedPreferences overview",
+      "url": "https://developer.android.com/training/data-storage/shared-preferences",
+      "type": "reference"
+    }
+  ],
+  "bibliography": [
+    "ANDROID DEVELOPERS. Save data in a local database using Room. 2024.",
+    "GOYAL, M. Android Room Database. Apress, 2023.",
+    "PHILLIPS, M. Kotlin Apprentice. raywenderlich, 2023."
+  ],
+  "assessment": {
+    "type": "diagnostic",
+    "description": "Simulado guiado da NP1 com rubrica comentada em sala e checklist de entrega do trabalho prático."
+  },
+  "content": [
+    {
+      "type": "flightPlan",
+      "title": "Plano de voo da aula",
+      "items": [
+        "Aquecimento: mapa mental colaborativo sobre persistência local.",
+        "Revisão dirigida: SharedPreferences x Room em cenários reais.",
+        "Simulado comentado: questões objetivas e discursivas modelo NP1.",
+        "Projeto prático: revisão do app catálogo com foco no banco local.",
+        "Checklist NP1: trabalho + prova, critérios e rubrica.",
+        "Avisos Moodle: prazos de submissão e fóruns de dúvidas.",
+        "TED de preparação: plano de estudos e ajustes finais no protótipo."
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Revisão orientada dos tópicos de persistência",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Trabalhamos em duplas para comparar as abordagens de SharedPreferences e Room usando um quadro Kanban com cartões de casos de uso."
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "items": [
+            "Dados chave-valor simples → SharedPreferences",
+            "Listas estruturadas com relações → Room",
+            "Sincronização com backend → Planejar cache e atualizações"
+          ]
+        },
+        {
+          "type": "callout",
+          "variant": "info",
+          "title": "Dica para a prova",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "Ao justificar uma escolha, cite pelo menos duas vantagens e uma limitação da tecnologia selecionada."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Projeto prático: catálogo de produtos com persistência",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Utilize o projeto iniciado na Aula 14 para validar se todas as entidades, DAOs e instância do RoomDatabase estão coerentes com os requisitos de NP1."
+        },
+        {
+          "type": "subBlock",
+          "title": "Checklist mínimo",
+          "items": [
+            "Entity com campos obrigatórios anotados corretamente.",
+            "DAO com consultas parametrizadas para filtragem.",
+            "Database expondo instância singleton e migração automática básica.",
+            "Tela que consome dados persistidos após reiniciar o app."
+          ]
+        },
+        {
+          "type": "callout",
+          "variant": "success",
+          "title": "Critérios da banca",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "Demonstre o fluxo completo: cadastro → persistência → leitura. Evidencie logs de erro tratados."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "TED 15 – Plano de estudos orientado",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Monte um quadro semanal com blocos de revisão (teoria) e prática (codificação) até a data da NP1. Inclua referências específicas e metas mensuráveis."
+        },
+        {
+          "type": "list",
+          "ordered": true,
+          "items": [
+            "Rever apostila de persistência local (páginas 42–59).",
+            "Praticar com o simulado extra disponibilizado no Moodle.",
+            "Testar o app catálogo em dispositivos diferentes ou emuladores."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "warning",
+      "title": "Avisos Moodle",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Envie o Plano de Estudos (PDF) e o checklist do projeto no Moodle > Unidade III > NP1 até 23h59 do dia seguinte."
+        },
+        {
+          "type": "paragraph",
+          "text": "Participe do fórum \"Dúvidas NP1 – Persistência\" com pelo menos uma pergunta ou contribuição até dois dias antes da prova."
+        }
+      ]
+    }
+  ]
+}

--- a/src/content/courses/ddm/lessons/lesson-16.json
+++ b/src/content/courses/ddm/lessons/lesson-16.json
@@ -1,0 +1,178 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-16",
+  "title": "Aula 16: Unidade III – Estruturando o RoomDatabase e Migrações",
+  "slug": "roomdatabase-e-migracoes",
+  "summary": "Aprofunda a construção da classe RoomDatabase, configuração de provedores, migrações e testes instrumentados para garantir persistência local confiável.",
+  "objective": "Construir uma base Room robusta com provedores de dependência, migrações controladas e verificações automatizadas.",
+  "objectives": [
+    "Configurar a classe RoomDatabase com padrão singleton seguro.",
+    "Criar migrações básicas entre versões do banco.",
+    "Integrar o Room com corrotinas e Flow para leitura reativa.",
+    "Validar a persistência com testes instrumentados simples."
+  ],
+  "competencies": [
+    "Arquitetura de dados em Android",
+    "Boas práticas de persistência local",
+    "Garantia de qualidade em banco de dados mobile"
+  ],
+  "skills": [
+    "Implementar RoomDatabase com instância compartilhada.",
+    "Escrever classes Migration controlando alterações de schema.",
+    "Configurar testes instrumentados para operações de banco.",
+    "Utilizar Flow/LiveData para observar mudanças nos dados."
+  ],
+  "outcomes": [
+    "Entende o ciclo de vida da base Room dentro do aplicativo.",
+    "Entrega uma migração funcional entre versões 1 e 2 do schema.",
+    "Documenta o setup do banco e publica evidências no Moodle."
+  ],
+  "prerequisites": [
+    "Aula 14 – Introdução ao Room: Entities e DAO.",
+    "Familiaridade com corrotinas em Kotlin."
+  ],
+  "tags": ["android", "room", "migracoes", "persistencia"],
+  "duration": 120,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Room database reference",
+      "url": "https://developer.android.com/reference/androidx/room/RoomDatabase",
+      "type": "reference"
+    },
+    {
+      "label": "Guide to Room migrations",
+      "url": "https://developer.android.com/training/data-storage/room/migrating-db-versions",
+      "type": "article"
+    },
+    {
+      "label": "Testing Room databases",
+      "url": "https://developer.android.com/training/data-storage/room/testing-db",
+      "type": "article"
+    }
+  ],
+  "bibliography": [
+    "ANDROID DEVELOPERS. Migrate Room databases. 2024.",
+    "FARQUHAR, I. et al. Android Programming: The Big Nerd Ranch Guide. 5. ed. 2023.",
+    "GOYAL, M. Android Room Database. Apress, 2023."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Revisão por pares do módulo RoomDatabase com checklist de migrações e testes automatizados."
+  },
+  "content": [
+    {
+      "type": "flightPlan",
+      "title": "Plano de voo da aula",
+      "items": [
+        "Recapitular componentes Room: Entity, DAO e Database.",
+        "Desenhar o ciclo de inicialização da RoomDatabase.",
+        "Configurar instância singleton com Room.databaseBuilder().",
+        "Criar MIGRATION_1_2 adicionando nova coluna.",
+        "Projeto prático: preparar módulo de persistência reutilizável.",
+        "Testes instrumentados: validar inserção/leitura.",
+        "TED e avisos Moodle para consolidação."
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Construindo a classe RoomDatabase",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Mostramos o padrão recomendado para expor a instância da base usando o contexto de aplicação e evitando vazamentos."
+        },
+        {
+          "type": "code",
+          "language": "kotlin",
+          "code": "@Database(entities = [Produto::class], version = 2, exportSchema = true)\nabstract class AppDatabase : RoomDatabase() {\n    abstract fun produtoDao(): ProdutoDao\n\n    companion object {\n        @Volatile\n        private var INSTANCE: AppDatabase? = null\n\n        fun getInstance(context: Context): AppDatabase {\n            return INSTANCE ?: synchronized(this) {\n                val instance = Room.databaseBuilder(\n                    context.applicationContext,\n                    AppDatabase::class.java,\n                    \"catalogo.db\"\n                )\n                    .addMigrations(MIGRATION_1_2)\n                    .fallbackToDestructiveMigrationOnDowngrade()\n                    .build()\n                INSTANCE = instance\n                instance\n            }\n        }\n    }\n}"
+        },
+        {
+          "type": "callout",
+          "variant": "info",
+          "title": "Boas práticas",
+          "content": [
+            {
+              "type": "list",
+              "ordered": false,
+              "items": [
+                "Prefira applicationContext para evitar leaks.",
+                "Documente as versões do schema no README do projeto.",
+                "ExportSchema=true facilita auditorias e diffs de migração."
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Projeto prático: módulo de persistência reutilizável",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Em trios, refatoramos o app catálogo criando um pacote data com AppDatabase, DAOs e providers de dependência (Hilt/Koin opcional)."
+        },
+        {
+          "type": "subBlock",
+          "title": "Entregáveis da aula",
+          "items": [
+            "Classe AppDatabase configurada.",
+            "Arquivo de provider (object ou módulo DI) retornando o DAO.",
+            "Teste instrumentado que insere e recupera um Produto.",
+            "Documento explicando as migrações registradas até o momento."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Migrações em prática",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Criamos uma nova coluna \"favorito\" na tabela Produto para ilustrar migrações incrementais."
+        },
+        {
+          "type": "code",
+          "language": "kotlin",
+          "code": "val MIGRATION_1_2 = object : Migration(1, 2) {\n    override fun migrate(database: SupportSQLiteDatabase) {\n        database.execSQL(\n            \"ALTER TABLE produto ADD COLUMN favorito INTEGER NOT NULL DEFAULT 0\"\n        )\n    }\n}"
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "TED 16 – Documentação técnica da base de dados",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Escreva um documento de 1 página descrevendo o fluxo de inicialização do RoomDatabase e as migrações criadas. Inclua captura do teste instrumentado rodando com sucesso."
+        },
+        {
+          "type": "list",
+          "ordered": true,
+          "items": [
+            "Detalhar responsabilidades de cada classe do pacote data.",
+            "Explicar como o app garante instância única.",
+            "Registrar próximos passos para migrações 2_3 e 3_4."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "warning",
+      "title": "Avisos Moodle",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Submeta o PDF da documentação, o script SQL da migração e o relatório de testes em Moodle > Unidade III > Aula 16 até 23h59 de amanhã."
+        },
+        {
+          "type": "paragraph",
+          "text": "Atualize o repositório no Moodle Classroom com a branch \"feature/roomdatabase\" antes da aula 17."
+        }
+      ]
+    }
+  ]
+}

--- a/src/content/courses/ddm/lessons/lesson-17.json
+++ b/src/content/courses/ddm/lessons/lesson-17.json
@@ -1,0 +1,154 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-17",
+  "title": "Aula 17: Unidade III – CRUD com Room (Parte 1)",
+  "slug": "crud-room-parte-1",
+  "summary": "Implementa operações de criação e leitura com Room, conectando formulários Kotlin/Android à camada de persistência local com corrotinas.",
+  "objective": "Construir o fluxo de cadastro e listagem de dados persistidos com Room, garantindo validação e feedback ao usuário.",
+  "objectives": [
+    "Criar formulários para inserir registros usando DAO e corrotinas.",
+    "Listar dados persistidos com Flow/LiveData e RecyclerView.",
+    "Aplicar validações básicas antes da persistência.",
+    "Organizar a camada de repositório para desacoplamento da UI."
+  ],
+  "competencies": [
+    "Desenvolvimento full-stack mobile",
+    "Persistência local reativa",
+    "Boas práticas de UX com dados persistidos"
+  ],
+  "skills": [
+    "Conectar DAO a corrotinas e Flow.",
+    "Implementar repositórios intermediários.",
+    "Construir listas reativas com DiffUtil.",
+    "Validar entradas de formulário antes de salvar."
+  ],
+  "outcomes": [
+    "Entrega formulário funcional que salva dados no Room.",
+    "Lista registros em RecyclerView observando o banco.",
+    "Publica gravação da funcionalidade e checklist no Moodle."
+  ],
+  "prerequisites": ["Aula 16 – Estruturando o RoomDatabase.", "Domínio de RecyclerView básico."],
+  "tags": ["android", "room", "crud", "persistencia"],
+  "duration": 120,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Room with a view codelab",
+      "url": "https://developer.android.com/codelabs/android-room-with-a-view-kotlin",
+      "type": "codelab"
+    },
+    {
+      "label": "RecyclerView documentation",
+      "url": "https://developer.android.com/guide/topics/ui/layout/recyclerview",
+      "type": "reference"
+    },
+    {
+      "label": "Kotlin coroutines on Android",
+      "url": "https://developer.android.com/kotlin/coroutines",
+      "type": "guide"
+    }
+  ],
+  "bibliography": [
+    "ANDROID DEVELOPERS. Room with a View. 2024.",
+    "GOYAL, M. Android Room Database. Apress, 2023.",
+    "MEDNICK, R. Kotlin Coroutines by Tutorials. raywenderlich, 2023."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Checklist de funcionalidades CRUD (Create + Read) validado por vídeo demonstrativo entregue no Moodle."
+  },
+  "content": [
+    {
+      "type": "flightPlan",
+      "title": "Plano de voo da aula",
+      "items": [
+        "Revisar arquitetura: UI → ViewModel/Repository → DAO.",
+        "Configurar corrotinas no módulo data.",
+        "Implementar inserção com suspend fun insert().",
+        "Construir listagem reativa com Flow.asLiveData().",
+        "Projeto prático: tela de cadastro + lista.",
+        "Checklist TED e avisos Moodle."
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Fluxo de criação: do formulário ao DAO",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Mostramos como validar campos, construir o objeto e chamar o DAO usando corrotinas no escopo do ViewModel."
+        },
+        {
+          "type": "code",
+          "language": "kotlin",
+          "code": "class ProdutoViewModel(private val repository: ProdutoRepository) : ViewModel() {\n    private val _estadoFormulario = MutableLiveData<FormState>()\n    val estadoFormulario: LiveData<FormState> = _estadoFormulario\n\n    fun salvar(nome: String, preco: String) {\n        if (nome.isBlank() || preco.isBlank()) {\n            _estadoFormulario.value = FormState.Erro(\"Preencha todos os campos\")\n            return\n        }\n        viewModelScope.launch {\n            repository.inserir(Produto(nome = nome, preco = preco.toBigDecimal()))\n            _estadoFormulario.postValue(FormState.Sucesso)\n        }\n    }\n}"
+        },
+        {
+          "type": "callout",
+          "variant": "info",
+          "title": "Validação incremental",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "Aplique máscaras ou conversões seguras para evitar NumberFormatException ao transformar strings em números."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Projeto prático: tela de cadastro e lista reativa",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Em duplas, evolua o app catálogo com uma Activity/Fragment de cadastro e outra de listagem, ambas conectadas ao mesmo ViewModel."
+        },
+        {
+          "type": "subBlock",
+          "title": "Entregáveis",
+          "items": [
+            "Formulário com validações visuais (TextInputLayout ou equivalente).",
+            "ViewModel chamando repository.inserir().",
+            "RecyclerView consumindo Flow<List<Produto>> convertido em LiveData.",
+            "Indicador de carregamento enquanto a inserção ocorre."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "TED 17 – Vídeo demonstrativo Create + Read",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Grave um vídeo curto (3–5 minutos) demonstrando cadastro e listagem funcionando, destacando logs e validações."
+        },
+        {
+          "type": "list",
+          "ordered": true,
+          "items": [
+            "Exibir o formulário preenchendo dados variados.",
+            "Mostrar o RecyclerView atualizando automaticamente.",
+            "Explicar como o repository interage com o DAO."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "warning",
+      "title": "Avisos Moodle",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Envie o vídeo e o checklist Create + Read no Moodle > Unidade III > Aula 17 até 23h59 do dia seguinte."
+        },
+        {
+          "type": "paragraph",
+          "text": "Atualize o repositório com tag `v0.3-crud` e registre no campo de entrega."
+        }
+      ]
+    }
+  ]
+}

--- a/src/content/courses/ddm/lessons/lesson-18.json
+++ b/src/content/courses/ddm/lessons/lesson-18.json
@@ -1,0 +1,154 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-18",
+  "title": "Aula 18: Unidade III – CRUD com Room (Parte 2)",
+  "slug": "crud-room-parte-2",
+  "summary": "Completa o ciclo CRUD com operações de atualização e remoção no Room, incluindo padrões de UX para edição in-line e confirmações de exclusão.",
+  "objective": "Implementar update e delete na camada Room garantindo consistência visual e transacional do aplicativo.",
+  "objectives": [
+    "Criar fluxos de edição reutilizando formulários e ViewModels.",
+    "Implementar operações delete confirmadas com Snackbar/Diálogo.",
+    "Propagar estados de sucesso/erro para a UI de forma reativa.",
+    "Preparar casos de teste para update/delete."
+  ],
+  "competencies": [
+    "Arquitetura limpa em Android",
+    "UX writing para fluxos críticos",
+    "Manutenção de dados persistidos"
+  ],
+  "skills": [
+    "Utilizar transactions ou estratégias de consistência em updates.",
+    "Configurar DiffUtil para refletir mudanças em listas.",
+    "Exibir confirmações amigáveis antes de deletar.",
+    "Criar testes instrumentados de exclusão."
+  ],
+  "outcomes": [
+    "Entrega tela de edição funcional ligada ao DAO.",
+    "Disponibiliza exclusão com feedback e undo opcional.",
+    "Registra evidências de testes no Moodle."
+  ],
+  "prerequisites": ["Aula 17 – CRUD com Room (Parte 1)."],
+  "tags": ["android", "room", "crud", "persistencia"],
+  "duration": 120,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "Room update/delete",
+      "url": "https://developer.android.com/reference/androidx/room/Dao#update",
+      "type": "reference"
+    },
+    {
+      "label": "Material Design dialogs",
+      "url": "https://m3.material.io/components/dialogs/overview",
+      "type": "guide"
+    },
+    {
+      "label": "Testing flows with Turbine",
+      "url": "https://cashapp.github.io/turbine/",
+      "type": "article"
+    }
+  ],
+  "bibliography": [
+    "ANDROID DEVELOPERS. Persist data with Room. 2024.",
+    "JOHNS, R. Android Clean Architecture. Packt, 2023.",
+    "NIELD, J. Kotlin Programming: The Big Nerd Ranch Guide. 3. ed. 2023."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Rubrica de pares avaliando a consistência de update/delete com foco em UX e feedback visual."
+  },
+  "content": [
+    {
+      "type": "flightPlan",
+      "title": "Plano de voo da aula",
+      "items": [
+        "Retomar o fluxo Create + Read da aula anterior.",
+        "Planejar UX para edição e exclusão.",
+        "Implementar @Update e @Delete no DAO.",
+        "Projeto prático: editar e excluir produtos.",
+        "Testes instrumentados e logs.",
+        "TED 18 e avisos Moodle."
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Update reativo com Room",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Demonstramos como reutilizar o mesmo formulário de cadastro em modo edição, populando campos e persistindo alterações."
+        },
+        {
+          "type": "code",
+          "language": "kotlin",
+          "code": "suspend fun atualizar(produto: Produto) = produtoDao.update(produto)\n\nfun carregarProduto(id: Int): LiveData<Produto> =\n    produtoDao.buscarPorId(id).asLiveData()"
+        },
+        {
+          "type": "callout",
+          "variant": "info",
+          "title": "Dica de UX",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "Indique visualmente que o formulário está em modo edição (ex.: título \"Editar produto\" e botão \"Salvar alterações\")."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Projeto prático: edição e exclusão com feedback",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Em duplas, evoluam o app catálogo permitindo editar itens e excluir com confirmação, garantindo undo via Snackbar."
+        },
+        {
+          "type": "subBlock",
+          "title": "Entregáveis",
+          "items": [
+            "Tela de edição com validação e persistência via ViewModel.",
+            "Botão contextual no RecyclerView para editar/excluir (Menu contextual ou Swipe).",
+            "Dialog ou Snackbar confirmando exclusão.",
+            "Teste instrumentado cobrindo update/delete."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "TED 18 – Evidências de Update/Delete",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Prepare um relatório curto com prints da edição, exclusão e undo funcionando, além de logs de testes."
+        },
+        {
+          "type": "list",
+          "ordered": true,
+          "items": [
+            "Explicar como o ViewModel diferencia modo cadastro vs. edição.",
+            "Mostrar configuração do SwipeToDelete/ContextMenu.",
+            "Anexar saída dos testes instrumentados ou Turbine."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "warning",
+      "title": "Avisos Moodle",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Envie o relatório TED 18 e o link do repositório atualizado no Moodle > Unidade III > Aula 18 até 23h59 do próximo dia útil."
+        },
+        {
+          "type": "paragraph",
+          "text": "Participe do fórum \"Melhorias de UX em CRUD\" compartilhando um insight sobre feedback visual."
+        }
+      ]
+    }
+  ]
+}

--- a/src/content/courses/ddm/lessons/lesson-19.json
+++ b/src/content/courses/ddm/lessons/lesson-19.json
@@ -1,0 +1,154 @@
+{
+  "formatVersion": "md3.lesson.v1",
+  "id": "lesson-19",
+  "title": "Aula 19: Unidade III – ViewModel e LiveData para Persistência Local",
+  "slug": "viewmodel-livedata-persistencia",
+  "summary": "Introduz ViewModel e LiveData como ponte entre a camada Room e a interface, reforçando reatividade e ciclo de vida em aplicativos Android.",
+  "objective": "Implementar ViewModel e LiveData integrados à base Room garantindo atualizações reativas e seguras após mudanças de configuração.",
+  "objectives": [
+    "Explicar o papel do ViewModel no ciclo de vida.",
+    "Conectar LiveData/Flow à UI para refletir mudanças do banco.",
+    "Implementar ViewModelFactory para injeção de dependências.",
+    "Criar observadores que atualizam listas e estados vazios."
+  ],
+  "competencies": [
+    "Arquitetura MVVM",
+    "Reatividade em Android",
+    "Manutenção de estado em aplicativos móveis"
+  ],
+  "skills": [
+    "Criar ViewModels que consomem repositórios Room.",
+    "Converter Flow em LiveData ou StateFlow conforme o cenário.",
+    "Gerenciar eventos de UI com LiveData de uso único.",
+    "Documentar o fluxo de dados entre camadas."
+  ],
+  "outcomes": [
+    "Disponibiliza ViewModel integrado ao Room com LiveData.",
+    "Implementa observadores que atualizam UI em tempo real.",
+    "Entrega infográfico explicando o fluxo MVVM no Moodle."
+  ],
+  "prerequisites": ["Aulas 17 e 18 – CRUD com Room."],
+  "tags": ["android", "viewmodel", "livedata", "persistencia"],
+  "duration": 110,
+  "modality": "in-person",
+  "resources": [
+    {
+      "label": "ViewModel overview",
+      "url": "https://developer.android.com/topic/libraries/architecture/viewmodel",
+      "type": "article"
+    },
+    {
+      "label": "LiveData guide",
+      "url": "https://developer.android.com/topic/libraries/architecture/livedata",
+      "type": "article"
+    },
+    {
+      "label": "Guide to app architecture",
+      "url": "https://developer.android.com/topic/architecture",
+      "type": "guide"
+    }
+  ],
+  "bibliography": [
+    "ANDROID DEVELOPERS. ViewModel overview. 2024.",
+    "GOOGLE. Guide to app architecture. 2024.",
+    "JORDAN, A. MVVM in Android. Packt, 2023."
+  ],
+  "assessment": {
+    "type": "formative",
+    "description": "Autoavaliação guiada comparando implementações MVVM com checklist de integração Room + ViewModel."
+  },
+  "content": [
+    {
+      "type": "flightPlan",
+      "title": "Plano de voo da aula",
+      "items": [
+        "Contextualização: porque ViewModel após persistência.",
+        "Ciclo de vida: Activity/Fragment vs. ViewModel.",
+        "LiveData e Flow: diferenças e complementaridade.",
+        "Projeto prático: ViewModel + LiveData para lista de produtos.",
+        "Eventos de UI (Snackbar/toasts) com SingleLiveEvent.",
+        "TED 19 e avisos Moodle."
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "ViewModel na prática",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Construímos um ViewModel que recebe o repositório Room via construtor e mantém estado independente da Activity."
+        },
+        {
+          "type": "code",
+          "language": "kotlin",
+          "code": "class CatalogoViewModel(private val repository: ProdutoRepository) : ViewModel() {\n    val produtos: LiveData<List<Produto>> = repository.todos().asLiveData()\n\n    private val _mensagem = MutableLiveData<Event<String>>()\n    val mensagem: LiveData<Event<String>> = _mensagem\n\n    fun remover(produto: Produto) {\n        viewModelScope.launch {\n            repository.remover(produto)\n            _mensagem.postValue(Event(\"Produto removido com sucesso!\"))\n        }\n    }\n}"
+        },
+        {
+          "type": "callout",
+          "variant": "info",
+          "title": "ViewModelFactory",
+          "content": [
+            {
+              "type": "paragraph",
+              "text": "Crie uma factory customizada ou use Hilt/Koin para injetar o repositório. Evite instanciar ViewModel com construtor vazio quando houver dependências."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Projeto prático: MVVM com Room",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Em grupos de três, adaptem o app catálogo para usar ViewModel e LiveData, garantindo que a UI sobreviva a rotações sem perder estado."
+        },
+        {
+          "type": "subBlock",
+          "title": "Entregáveis",
+          "items": [
+            "ViewModel com métodos para inserir, listar e remover produtos.",
+            "Fragment/Activity observando LiveData para atualizar RecyclerView.",
+            "SingleLiveEvent ou Channel para mensagens de sucesso/erro.",
+            "Diagrama explicando o fluxo de dados entre camadas."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "TED 19 – Infográfico MVVM Persistência",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Produza um infográfico (imagem ou PDF) mostrando como dados percorrem Repository → ViewModel → LiveData → UI → Room. Utilize exemplos do projeto."
+        },
+        {
+          "type": "list",
+          "ordered": true,
+          "items": [
+            "Destaque pontos de cache e atualização.",
+            "Liste boas práticas para evitar memory leaks.",
+            "Indique como testes podem validar o fluxo."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "warning",
+      "title": "Avisos Moodle",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Submeta o infográfico e o link do branch `mvvm-integration` no Moodle > Unidade III > Aula 19 até 23h59 do dia seguinte."
+        },
+        {
+          "type": "paragraph",
+          "text": "Responda ao questionário \"Check-in MVVM\" disponível no AVA para reforçar conceitos."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add detailed lesson plans for NP1 preparation, Room database setup, CRUD workflows, and MVVM integration in lessons 15–19
- register the new lessons in the course manifest with complete metadata

## Testing
- `node -e "const fs=require('fs'); ['lesson-15','lesson-16','lesson-17','lesson-18','lesson-19'].forEach(id=>{const p='edu/src/content/courses/ddm/lessons/'+id+'.json'; JSON.parse(fs.readFileSync(p,'utf8'));}); JSON.parse(fs.readFileSync('edu/src/content/courses/ddm/lessons.json','utf8')); console.log('ok');"`


------
https://chatgpt.com/codex/tasks/task_e_68dc77d555bc832c80e6d81c9f4dcc17