### PR TITLE
Normalize callout list blocks in ALG I lessons

### DIFF
--- a/src/content/courses/algi/lessons/lesson-01.json
+++ b/src/content/courses/algi/lessons/lesson-01.json
@@ -91,7 +91,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Introdução à Lógica e Algoritmos. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -307,7 +307,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 01' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Publique no Moodle a ficha de expectativas preenchida (PDF ou foto legível)."
@@ -322,7 +322,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-02.json
+++ b/src/content/courses/algi/lessons/lesson-02.json
@@ -89,7 +89,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Raciocínio Lógico e Operadores. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -421,7 +421,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 02' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Descreva o processo cotidiano escolhido pela dupla indicando entradas, decisões e saídas."
@@ -436,7 +436,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-03.json
+++ b/src/content/courses/algi/lessons/lesson-03.json
@@ -75,7 +75,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Estruturando Algoritmos. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -252,7 +252,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 03' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Envie o pseudocódigo final da dupla com comentários explicando cada bloco lógico."
@@ -267,7 +267,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-04.json
+++ b/src/content/courses/algi/lessons/lesson-04.json
@@ -80,7 +80,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Do Pseudocódigo ao Primeiro Programa em C. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -187,19 +187,37 @@
           "headers": ["Etapa", "Portugol", "C"],
           "rows": [
             [
-              { "value": "Entrada" },
-              { "value": "LEIA(num1, num2)" },
-              { "value": "scanf(\"%d\", &num1); scanf(\"%d\", &num2);" }
+              {
+                "value": "Entrada"
+              },
+              {
+                "value": "LEIA(num1, num2)"
+              },
+              {
+                "value": "scanf(\"%d\", &num1); scanf(\"%d\", &num2);"
+              }
             ],
             [
-              { "value": "Processamento" },
-              { "value": "soma <- num1 + num2" },
-              { "value": "soma = num1 + num2;" }
+              {
+                "value": "Processamento"
+              },
+              {
+                "value": "soma <- num1 + num2"
+              },
+              {
+                "value": "soma = num1 + num2;"
+              }
             ],
             [
-              { "value": "Saída" },
-              { "value": "ESCREVA(\"A soma é\", soma)" },
-              { "value": "printf(\"A soma é: %d\\n\", soma);" }
+              {
+                "value": "Saída"
+              },
+              {
+                "value": "ESCREVA(\"A soma é\", soma)"
+              },
+              {
+                "value": "printf(\"A soma é: %d\\n\", soma);"
+              }
             ]
           ]
         }
@@ -262,19 +280,20 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 04' para anexar um pacote contendo código, checklist e evidências."
         },
         {
-          "type": "orderedList",
+          "type": "list",
           "items": [
             "Implemente no template do VS Code o algoritmo de soma apresentado (entrada de dois inteiros, processamento da soma e saída formatada).",
             "Valide o comportamento comparando cada etapa com a tabela \"Comparativo MD3\" e registre os testes executados (mínimo três pares de números).",
             "Faça upload do arquivo .c, do print da execução e de um checklist assinalando Entrada, Processamento e Saída utilizados."
-          ]
+          ],
+          "ordered": true
         },
         {
           "type": "paragraph",
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-05.json
+++ b/src/content/courses/algi/lessons/lesson-05.json
@@ -85,7 +85,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Fluxogramas e Visualização da Lógica. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -335,12 +335,13 @@
       "title": "Roteiro de revisão cruzada",
       "content": [
         {
-          "type": "orderedList",
+          "type": "list",
           "items": [
             "Compare o fluxograma recebido com o Guia MD3 de simbologia e a biblioteca acima; marque símbolos ausentes ou trocados.",
             "Percorra cada caminho respondendo: entrada → processamento → decisão → saída estão completos? Documente lacunas.",
             "Sugira melhorias objetivas (organização, textos nos símbolos, conectores) e combine ajustes em até 10 minutos."
-          ]
+          ],
+          "ordered": true
         }
       ]
     },
@@ -364,7 +365,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 05' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Faça upload do fluxograma final exportado (PDF ou imagem) junto com o arquivo-fonte da ferramenta utilizada."
@@ -379,7 +380,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-06.json
+++ b/src/content/courses/algi/lessons/lesson-06.json
@@ -79,7 +79,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Variáveis, Constantes e Tipos de Dados. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -333,7 +333,7 @@
           "text": "Execute o código no projeto pré-configurado e registre evidências."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Valide pelo menos três cenários (padrão, limite e inválido)."
@@ -358,7 +358,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 06' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entregue o código do cadastro em C com declaração de variáveis, constantes e comentários sobre tipos escolhidos."
@@ -373,7 +373,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-07.json
+++ b/src/content/courses/algi/lessons/lesson-07.json
@@ -76,7 +76,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Operadores e Expressões em C. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -592,7 +592,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 07' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Implemente arquivo aula07_operadores.c reproduzindo os exercícios de precedência resolvidos em sala."
@@ -607,7 +607,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-08.json
+++ b/src/content/courses/algi/lessons/lesson-08.json
@@ -76,7 +76,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Leituras múltiplas, cálculos encadeados e printf. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -340,7 +340,7 @@
           "text": "Capture o console exibindo o recibo final e o código utilizado lado a lado antes de enviar a atividade."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Mostre pelo menos dois cenários diferentes (com desconto e sem desconto adicional)."
@@ -403,7 +403,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 08' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Envie o programa aula08_cashflow.c formatando recibos conforme o template apresentado."
@@ -418,7 +418,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-09.json
+++ b/src/content/courses/algi/lessons/lesson-09.json
@@ -81,7 +81,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Problemas sequenciais aplicados em C. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -276,7 +276,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 09' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Implemente solução inédita em C para um processo sequencial do seu contexto (ex.: cálculo de comissão)."
@@ -291,7 +291,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-10.json
+++ b/src/content/courses/algi/lessons/lesson-10.json
@@ -78,7 +78,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Condicionais com if e else. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -458,7 +458,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 10' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Implemente aula10_limite_credito.c validando saldo disponível ou bloqueio do cliente."
@@ -473,7 +473,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-11.json
+++ b/src/content/courses/algi/lessons/lesson-11.json
@@ -76,7 +76,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Seleção múltipla com switch-case. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -167,7 +167,7 @@
           "text": "Depois da aula, reserve 20 minutos para revisar sozinho o menu implementado, anotando dúvidas para o plantão."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Refaça os casos de teste sugeridos sem apoio do colega."
@@ -441,7 +441,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 11' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entregue aula11_calculadora.c com menu de operações, tratamento de divisão por zero e laço de repetição opcional."
@@ -456,7 +456,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-12.json
+++ b/src/content/courses/algi/lessons/lesson-12.json
@@ -76,7 +76,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Cadeias de decisão com else if. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -306,7 +306,7 @@
       "title": "Checklist de testes manuais",
       "content": [
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Valide limites inferior, superior e valores médios para cada faixa."
@@ -465,7 +465,7 @@
           "text": "Envie no Moodle (atividade TED Aula 12) até 23h59 do dia seguinte: código em C, planilha de testes preenchida e um parágrafo justificando a ordem dos ramos."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Arquivo principal: aula12_classificador.c."
@@ -486,7 +486,7 @@
       "title": "Critérios de avaliação TED 12",
       "content": [
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega no prazo registrado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-13.json
+++ b/src/content/courses/algi/lessons/lesson-13.json
@@ -71,7 +71,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Condições compostas e encadeadas. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -249,7 +249,7 @@
           "text": "No envio do TED, registre no campo de comentários a lógica adotada e explique como a tabela verdade comprova cada decisão."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Aponte qual combinação de sinais concede acesso."
@@ -530,7 +530,7 @@
           "text": "Submeta até 23h59 do dia seguinte: código em C, planilha de combinações preenchida e relatório em PDF (1 página) com análise dos casos limites."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Arquivo aula13_validacao.c com condições compostas."
@@ -551,7 +551,7 @@
       "title": "Critérios de avaliação TED 13",
       "content": [
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Expressões lógicas corretas e sem redundâncias (35%)."

--- a/src/content/courses/algi/lessons/lesson-14.json
+++ b/src/content/courses/algi/lessons/lesson-14.json
@@ -86,7 +86,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Avaliação NP1. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -248,7 +248,7 @@
           "text": "Mantenha silêncio absoluto e posicione materiais não autorizados dentro da mochila. Levantamentos só serão permitidos após os 90 minutos de execução."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Orientação (10 min): dúvidas somente coletivas; sem consulta a materiais."
@@ -376,7 +376,7 @@
           "text": "Esta aula substitui a TED por atividades avaliativas presenciais. Utilize o tempo pós-aula para registrar percepções e organizar as evidências."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Preencha o formulário de percepção pós-avaliação disponível no Moodle até 23h59."

--- a/src/content/courses/algi/lessons/lesson-15.json
+++ b/src/content/courses/algi/lessons/lesson-15.json
@@ -76,7 +76,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Correção da NP1 e aprofundamento. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -101,7 +101,7 @@
           "text": "Digitalize ou fotografe a prova com suas anotações e faça o upload no formulário indicado antes de iniciar a reescrita."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Utilize o formulário 'Upload prova NP1' disponível no Moodle."
@@ -533,7 +533,7 @@
           "text": "Submeta até 23h59 do dia seguinte: versão corrigida da questão escolhida, guia pessoal de correção e resumo das mudanças aplicadas."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Arquivo aula15_reescrita.c com comentários destacando alterações."
@@ -554,7 +554,7 @@
       "title": "Critérios de avaliação TED 15",
       "content": [
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega com prova anotada anexada e reescrita consistente (30%)."

--- a/src/content/courses/algi/lessons/lesson-16.json
+++ b/src/content/courses/algi/lessons/lesson-16.json
@@ -77,7 +77,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Atividade Prática Assíncrona – Condicionais. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -102,7 +102,7 @@
           "text": "Envie todos os arquivos pela tarefa 'Atividade Assíncrona Aula 16' até 23h59 da sexta-feira. Submissões parciais não serão corrigidas."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Arquivos obrigatórios: fluxograma (PDF ou imagem), pseudocódigo (.txt ou .pdf), código C (.c) e relatório sintetizando os testes."
@@ -461,7 +461,7 @@
           "text": "Compacte todos os artefatos em ALG1_A16_NomeSobrenome.zip e envie no Moodle até 23h59 da sexta-feira."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Fluxograma exportado (PDF/PNG)."
@@ -485,7 +485,7 @@
       "title": "Rubrica da atividade assíncrona",
       "content": [
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega completa e dentro do prazo (20%)."

--- a/src/content/courses/algi/lessons/lesson-17.json
+++ b/src/content/courses/algi/lessons/lesson-17.json
@@ -65,7 +65,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Estrutura de Repetição while. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -254,7 +254,7 @@
       "title": "Validação de entradas obrigatória",
       "content": [
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Rejeite notas fora do intervalo 0-10 antes de acumular."
@@ -333,7 +333,7 @@
           "text": "Envie até 23h59 do dia seguinte: código em C, planilha de testes e breve relato explicando a lógica de saída."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Arquivo aula17_media_while.c."
@@ -354,7 +354,7 @@
       "title": "Critérios de avaliação TED 17",
       "content": [
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega no prazo com todos os arquivos (20%)."

--- a/src/content/courses/algi/lessons/lesson-18.json
+++ b/src/content/courses/algi/lessons/lesson-18.json
@@ -79,7 +79,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Estrutura de Repetição for. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -182,7 +182,7 @@
           "text": "Backes (Cap. 5) recomenda testar saltos de 2, decrementos e atualizações múltiplas na mesma expressão; registre os resultados na planilha e compare-os com os limites estabelecidos por Santos (Cap. 7) para evitar extrapolar a capacidade produtiva."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Documente na planilha os valores percorridos em cada variação."
@@ -207,7 +207,7 @@
           "text": "Utilize a planilha fornecida para monitorar a produção diária de cápsulas manipuladas. Aplique laços for para calcular médias por turno, apontar desvios e gerar alertas automáticos conforme o protocolo descrito por Ascencio & Campos (Cap. 6)."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Inicialize contadores separados por turno seguindo o quadro sugerido por Forbellone & Eberspächer (Cap. 4)."
@@ -377,7 +377,7 @@
           "text": "Submeta até 23h59: código em C gerando tabuadas configuráveis para o caso da Farmácia Escola, captura do console e planilha com cenários testados seguindo o checklist de Ascencio & Campos (Cap. 6)."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Arquivo aula18_tabuada.c organizado conforme as recomendações de Forbellone & Eberspächer (Cap. 4)."
@@ -402,7 +402,7 @@
       "title": "Critérios de avaliação TED 18",
       "content": [
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Pensamento computacional (40%): uso correto do for com inicialização, condição e atualização claros conforme Forbellone & Eberspächer (Cap. 4)."

--- a/src/content/courses/algi/lessons/lesson-19.json
+++ b/src/content/courses/algi/lessons/lesson-19.json
@@ -136,7 +136,7 @@
           "text": "Comentários curtos ou nomes descritivos ajudam a equipe a compreender por que determinado laço foi escolhido."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Registre no cabeçalho quais variáveis são invariantes durante a repetição."
@@ -155,10 +155,18 @@
         {
           "type": "unorderedList",
           "items": [
-            { "text": "A sequência de valores processados é idêntica nas duas versões?" },
-            { "text": "O contador ou sentinela é inicializado com o mesmo valor de referência?" },
-            { "text": "Os efeitos colaterais dentro do laço permanecem na mesma ordem?" },
-            { "text": "Os casos de parada antecipada continuam garantidos?" }
+            {
+              "text": "A sequência de valores processados é idêntica nas duas versões?"
+            },
+            {
+              "text": "O contador ou sentinela é inicializado com o mesmo valor de referência?"
+            },
+            {
+              "text": "Os efeitos colaterais dentro do laço permanecem na mesma ordem?"
+            },
+            {
+              "text": "Os casos de parada antecipada continuam garantidos?"
+            }
           ]
         }
       ]
@@ -179,12 +187,14 @@
           "text": "Escolha um exercício da Unidade III e produza versões equivalentes usando for e while."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Registre na planilha da turma o problema escolhido e o critério de escolha de cada laço."
             },
-            { "text": "Anexe no AVA os casos de teste que comprovam a equivalência das saídas." }
+            {
+              "text": "Anexe no AVA os casos de teste que comprovam a equivalência das saídas."
+            }
           ]
         }
       ]

--- a/src/content/courses/algi/lessons/lesson-20.json
+++ b/src/content/courses/algi/lessons/lesson-20.json
@@ -118,9 +118,11 @@
           "text": "Garanta que as variáveis usadas na condição sejam inicializadas com um valor coerente antes do laço."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
-            { "text": "Faça a limpeza do buffer de entrada quando uma leitura falhar." },
+            {
+              "text": "Faça a limpeza do buffer de entrada quando uma leitura falhar."
+            },
             {
               "text": "Mantenha a lógica de decisão dentro de um switch ou função dedicada para evitar blocos extensos."
             }
@@ -141,7 +143,9 @@
         {
           "type": "orderedList",
           "items": [
-            { "text": "Descarte resíduos do buffer antes de repetir o menu." },
+            {
+              "text": "Descarte resíduos do buffer antes de repetir o menu."
+            },
             {
               "text": "Centralize a lógica de decisão em funções ou switch para manter o laço enxuto."
             },
@@ -162,10 +166,14 @@
           "text": "Adapte o menu para calcular o fatorial solicitado no TED, garantindo repetição até que o usuário peça para sair."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
-            { "text": "Inclua opção para exibir histórico das últimas respostas válidas." },
-            { "text": "Documente no relatório quando preferiria while ou for e por quê." }
+            {
+              "text": "Inclua opção para exibir histórico das últimas respostas válidas."
+            },
+            {
+              "text": "Documente no relatório quando preferiria while ou for e por quê."
+            }
           ]
         }
       ]

--- a/src/content/courses/algi/lessons/lesson-21.json
+++ b/src/content/courses/algi/lessons/lesson-21.json
@@ -30,7 +30,11 @@
       "type": "worksheet",
       "url": "https://example.edu/algi/labs/padroes-ascii.pdf"
     },
-    { "label": "Editor ASCII online", "type": "tool", "url": "https://asciiflow.com/" },
+    {
+      "label": "Editor ASCII online",
+      "type": "tool",
+      "url": "https://asciiflow.com/"
+    },
     {
       "label": "Dataset de padrões (CSV)",
       "type": "dataset",
@@ -83,8 +87,12 @@
         {
           "type": "unorderedList",
           "items": [
-            { "text": "Laço externo: controla linhas, registros ou agrupamentos maiores." },
-            { "text": "Laço interno: percorre colunas, campos ou elementos detalhados." },
+            {
+              "text": "Laço externo: controla linhas, registros ou agrupamentos maiores."
+            },
+            {
+              "text": "Laço interno: percorre colunas, campos ou elementos detalhados."
+            },
             {
               "text": "Reinicialize contadores internos ao avançar para a próxima iteração externa."
             }
@@ -147,7 +155,7 @@
       "title": "Armadilhas frequentes",
       "content": [
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Esquecer de reinicializar o índice interno gera laços infinitos ou dados corrompidos."
@@ -178,9 +186,11 @@
           "text": "Implemente um gerador de mapa de calor para notas (0 a 10) utilizando laços aninhados."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
-            { "text": "Use o laço externo para iterar alunos e o interno para iterar avaliações." },
+            {
+              "text": "Use o laço externo para iterar alunos e o interno para iterar avaliações."
+            },
             {
               "text": "Produza uma visualização textual que facilite a interpretação dos resultados."
             }

--- a/src/content/courses/algi/lessons/lesson-22.json
+++ b/src/content/courses/algi/lessons/lesson-22.json
@@ -65,7 +65,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Integrando Laços e Condicionais. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -224,7 +224,7 @@
           "text": "Submeta código, relatório e métricas no AVA na tarefa 'Integração de laços e condicionais'."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Inclua link do repositório e PDF do relatório."
@@ -349,7 +349,7 @@
           "text": "Envie até 23h59: repositório atualizado, relatório técnico e planilha de métricas."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Link do repositório com README atualizado."
@@ -370,7 +370,7 @@
       "title": "Critérios de avaliação Aula 22",
       "content": [
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Integração correta de laços e condicionais (35%)."

--- a/src/content/courses/algi/lessons/lesson-23.json
+++ b/src/content/courses/algi/lessons/lesson-23.json
@@ -78,7 +78,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Atividade Assíncrona de Triagem Clínica. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -138,7 +138,7 @@
       "title": "Prazos e checkpoints",
       "content": [
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Dia 1 até 22h: fluxograma e checklist inicial no repositório."
@@ -252,7 +252,7 @@
           "text": "Compacte código, fluxograma, planilha, relatório e reflexões em ALG1_A23_Nome.zip."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Código em C com logs."
@@ -273,7 +273,7 @@
       "title": "Rubrica Aula 23",
       "content": [
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Cumprimento dos checkpoints (25%)."

--- a/src/content/courses/algi/lessons/lesson-24.json
+++ b/src/content/courses/algi/lessons/lesson-24.json
@@ -68,7 +68,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Síntese e Retrospectiva dos Laços. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -159,7 +159,7 @@
       "title": "Evidências necessárias",
       "content": [
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Captura do board 360° preenchido pelo grupo."
@@ -262,7 +262,7 @@
           "text": "Envie no Moodle até 23h59: plano de ação individual, evidências do board e síntese pessoal."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Plano de ação (PDF) com metas SMART."
@@ -283,7 +283,7 @@
       "title": "Rubrica Aula 24",
       "content": [
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Participação e evidências do feedback 360° (30%)."

--- a/src/content/courses/algi/lessons/lesson-25.json
+++ b/src/content/courses/algi/lessons/lesson-25.json
@@ -86,7 +86,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Introdução a Funções e Modularização. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -218,7 +218,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 25' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Implemente aula25_funcoes.c extraindo ao menos três funções puras do exercício trabalhado."
@@ -233,7 +233,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-26.json
+++ b/src/content/courses/algi/lessons/lesson-26.json
@@ -86,7 +86,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Funções com Parâmetros e Retorno. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -203,7 +203,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 26' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entregue aula26_parametros.c demonstrando passagem por valor e referência."
@@ -218,7 +218,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-27.json
+++ b/src/content/courses/algi/lessons/lesson-27.json
@@ -86,7 +86,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Programas Modulares com Múltiplas Funções. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -225,7 +225,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 27' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Submeta repositório ZIP com estrutura modular (src, include, tests) e Makefile gerado em sala."
@@ -240,7 +240,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-28.json
+++ b/src/content/courses/algi/lessons/lesson-28.json
@@ -86,7 +86,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Boas Práticas e Manutenção de Funções. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -199,7 +199,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 28' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Carregue relatório de revisão por pares destacando métricas calculadas (complexidade, cobertura)."
@@ -214,7 +214,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-29.json
+++ b/src/content/courses/algi/lessons/lesson-29.json
@@ -13,7 +13,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Avaliação NP2. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -140,7 +140,7 @@
           "text": "Esta aula substitui a TED por atividades avaliativas presenciais. Utilize o tempo pós-aula para registrar percepções e organizar as evidências."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Preencha o formulário de percepção pós-avaliação disponível no Moodle até 23h59."

--- a/src/content/courses/algi/lessons/lesson-30.json
+++ b/src/content/courses/algi/lessons/lesson-30.json
@@ -84,7 +84,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Introdução a Vetores. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -296,7 +296,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 30' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Implemente aula30_vetores.c lendo 10 valores e calculando média, mínimo e máximo."
@@ -311,7 +311,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-31.json
+++ b/src/content/courses/algi/lessons/lesson-31.json
@@ -98,7 +98,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Operações e Transformações com Vetores. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -277,7 +277,7 @@
           "text": "Aplique as rotinas em um painel municipal de energia solar. Some e normalize os dados por bairro para priorizar investimentos, como sugerem Manzano & Oliveira (Cap. 9)."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Use vetores paralelos para armazenar geração e perdas, técnica destacada por Backes (Cap. 7)."
@@ -331,7 +331,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 31' para anexar o artefato solicitado, relatando o painel de energia e as vendas cruzadas conforme o roteiro de Forbellone & Eberspächer (Cap. 5)."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entregue aula31_operacoes_vetores.c com rotinas de soma acumulada, normalização e geração de tabela seguindo Manzano & Oliveira (Cap. 9)."
@@ -346,7 +346,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Pensamento crítico (45%): interpretação das tendências ao aplicar somatórios e rankings inspirados em Forbellone & Eberspächer (Cap. 5) e Manzano & Oliveira (Cap. 9)."

--- a/src/content/courses/algi/lessons/lesson-32.json
+++ b/src/content/courses/algi/lessons/lesson-32.json
@@ -118,7 +118,7 @@
           "text": "Revise o plano de ensino e leia Forbellone & Eberspächer (Cap. 7) sobre pesquisa sequencial e Manzano & Oliveira (Cap. 9) sobre vetores antes da aula. Registre dúvidas na planilha de preparação para que possamos conectá-las ao estudo de caso do Armazém Popular."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -315,7 +315,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 32' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Implemente aula32_busca_linear.c com duas estratégias (padrão e com sentinela)."
@@ -330,7 +330,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Implementação: código segue a decomposição proposta por Forbellone & Eberspächer (Cap. 7) e Manzano & Oliveira (Cap. 9) (35%)."

--- a/src/content/courses/algi/lessons/lesson-33.json
+++ b/src/content/courses/algi/lessons/lesson-33.json
@@ -80,7 +80,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Matrizes 2D e Geração de Tabelas. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -282,7 +282,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 33' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Submeta aula33_matrizes.c formatando relatórios 3x3 e 4x4 com alinhamento adequado."
@@ -297,7 +297,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-34.json
+++ b/src/content/courses/algi/lessons/lesson-34.json
@@ -115,7 +115,7 @@
           "text": "Leia Forbellone & Eberspächer (Cap. 8) e Manzano & Oliveira (Cap. 11) destacando como estruturam transposição e multiplicação. Registre dúvidas na planilha de preparação para relacioná-las ao estudo de caso do painel energético do Campus Vale."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -384,7 +384,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 34' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entregue aula34_matriz_operacoes.c com funções para transpor, somar e multiplicar matrizes."
@@ -399,7 +399,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Implementação: funções seguem Forbellone & Eberspächer (Cap. 8) e Manzano & Oliveira (Cap. 11) (35%)."

--- a/src/content/courses/algi/lessons/lesson-35.json
+++ b/src/content/courses/algi/lessons/lesson-35.json
@@ -81,7 +81,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Introdução a Structs (Registros). Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -221,7 +221,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 35' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Implemente aula35_structs.c criando struct Aluno e operações básicas de cadastro e listagem."
@@ -236,7 +236,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-36.json
+++ b/src/content/courses/algi/lessons/lesson-36.json
@@ -118,7 +118,7 @@
           "text": "Leia Forbellone & Eberspächer (Cap. 12) e Manzano & Oliveira (Cap. 13) sobre vetores de registros, registrando dúvidas na planilha de preparação para conectar à rotina da Cooperativa TechSul."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -258,7 +258,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 36' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entregue aula36_structs_vetor.c com rotinas de inclusão, ordenação e busca em vetor de structs."
@@ -273,7 +273,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Implementação: funções CRUD e ordenação aderem a Forbellone & Eberspächer (Cap. 12) e Manzano & Oliveira (Cap. 13) (30%)."

--- a/src/content/courses/algi/lessons/lesson-37.json
+++ b/src/content/courses/algi/lessons/lesson-37.json
@@ -98,7 +98,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Busca e Atualização em Vetores de Structs. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -231,7 +231,7 @@
           "text": "Use o dataset do Cadastro Central de Empresas e a planilha de logs para simular a triagem de atendimentos. Forbellone & Eberspächer (Cap. 8) recomendam registrar motivo de cada alteração antes de persistir os dados."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Implemente atualizações condicionais com validações de domínio inspiradas em Santos (Cap. 11)."
@@ -271,7 +271,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 37' para anexar o artefato solicitado, relatando como cada busca e atualização atende ao protocolo descrito por Forbellone & Eberspächer (Cap. 8)."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Implemente aula37_structs_auditoria.c registrando buscas, atualizações e logs de auditoria conforme Manzano & Oliveira (Cap. 12) e Backes (Cap. 12)."
@@ -286,7 +286,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Pensamento crítico (40%): define critérios de busca e atualização seguindo Forbellone & Eberspächer (Cap. 8) e Manzano & Oliveira (Cap. 12)."

--- a/src/content/courses/algi/lessons/lesson-38.json
+++ b/src/content/courses/algi/lessons/lesson-38.json
@@ -92,7 +92,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Revisão Gamificada do Semestre. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -154,14 +154,18 @@
         {
           "type": "unorderedList",
           "items": [
-            { "text": "Cartelas numeradas de 100 a 500 por categoria para escolha das perguntas." },
+            {
+              "text": "Cartelas numeradas de 100 a 500 por categoria para escolha das perguntas."
+            },
             {
               "text": "Campainha ou sinalizador para indicar resposta pronta (alternativa: reação no chat)."
             },
             {
               "text": "Cartões de badge (Insight, Fair Play, Mentor Relâmpago) para premiações adicionais."
             },
-            { "text": "Guia rápido com critérios de desempate e penalidades." }
+            {
+              "text": "Guia rápido com critérios de desempate e penalidades."
+            }
           ]
         },
         {
@@ -216,7 +220,7 @@
           "text": "Reserve 25 minutos para o círculo de feedback 360°. Projete o roteiro no slide 12 e oriente que cada squad forneça percepções sobre comunicação, domínio técnico e colaboração."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Preencha o formulário https://forms.gle/algi-feedback-360 durante a roda para capturar evidências."
@@ -224,7 +228,9 @@
             {
               "text": "Garanta que todos recebam ao menos um elogio (Keep) e uma sugestão de melhoria (Grow)."
             },
-            { "text": "Colete compromissos no mural digital para acompanhamento na aula 40." }
+            {
+              "text": "Colete compromissos no mural digital para acompanhamento na aula 40."
+            }
           ]
         },
         {
@@ -295,7 +301,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 38' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Publique resumo individual destacando aprendizados e questões que acertou/errou na dinâmica Jeopardy."
@@ -310,7 +316,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."

--- a/src/content/courses/algi/lessons/lesson-39.json
+++ b/src/content/courses/algi/lessons/lesson-39.json
@@ -13,7 +13,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Avaliação NP3. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -35,7 +35,9 @@
         {
           "type": "unorderedList",
           "items": [
-            { "text": "Duração total: 120 minutos, prova presencial com consulta vedada." },
+            {
+              "text": "Duração total: 120 minutos, prova presencial com consulta vedada."
+            },
             {
               "text": "Estrutura: três blocos (diagnóstico, desenvolvimento, reflexão) com entregas sequenciais."
             },
@@ -192,7 +194,7 @@
           "text": "Prova individual, sem consulta. Entregue todo material de rascunho ao final e mantenha dispositivos desligados."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Chegue com 15 minutos de antecedência para acomodação e conferência de documentos."
@@ -203,7 +205,9 @@
             {
               "text": "Saídas ao banheiro são registradas e realizadas uma pessoa por vez, com supervisão."
             },
-            { "text": "Assine a lista de presença e o recibo de entrega antes de deixar a sala." }
+            {
+              "text": "Assine a lista de presença e o recibo de entrega antes de deixar a sala."
+            }
           ]
         }
       ]
@@ -218,7 +222,7 @@
           "text": "Esta aula substitui a TED por atividades avaliativas presenciais. Utilize o tempo pós-aula para registrar percepções e organizar as evidências."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Preencha o formulário de percepção pós-avaliação disponível no Moodle até 23h59."

--- a/src/content/courses/algi/lessons/lesson-40.json
+++ b/src/content/courses/algi/lessons/lesson-40.json
@@ -92,7 +92,7 @@
           "text": "Revise o plano de ensino e leia o trecho recomendado em Forbellone & Eberspächer relacionado a Encerramento e Devolutiva. Assista ao vídeo indicado na playlist do Curso em Vídeo e anote dúvidas sobre o conteúdo descrito no sumário."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Verifique acesso ao OnlineGDB, Replit ou VS Code template para executar exemplos antes da aula."
@@ -196,7 +196,7 @@
           "text": "Reserve 10 minutos ao término do showcase para que cada estudante preencha o formulário oficial: https://forms.gle/algoritmosI-feedback-final."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Reforce que o envio é obrigatório para consolidar a presença e registrar percepções da disciplina."
@@ -292,7 +292,7 @@
           "text": "Prazo: submeta no Moodle até 23h59 do dia seguinte à aula. Formato: utilize a tarefa 'TED Aula 40' para anexar o artefato solicitado."
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Submeta checklist de feedback final preenchido com os compromissos assumidos."
@@ -307,7 +307,7 @@
           "text": "Rubrica de avaliação"
         },
         {
-          "type": "unorderedList",
+          "type": "list",
           "items": [
             {
               "text": "Entrega dentro do prazo indicado no Moodle (20%)."


### PR DESCRIPTION
## Summary
- update ALG I callout content to use the shared list block instead of ordered/unordered variants
- add the ordered flag to numbered callout lists so numbering is preserved
- spot-check nested structures and rendering to ensure callout and content block lists still display correctly

## Testing
- npm run validate:content
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68dd04b02334832c944b046fcad8cd49