### PR TITLE
Align competencies for ALGI lessons 19-21

### DIFF
--- a/src/content/courses/algi/lessons/lesson-19.json
+++ b/src/content/courses/algi/lessons/lesson-19.json
@@ -9,7 +9,7 @@
     "Refatorar algoritmos simples convertendo entre for e while sem alterar resultados.",
     "Registrar evidências que sustentem a decisão sobre a estrutura de repetição escolhida."
   ],
-  "competencies": ["02", "05", "08"],
+  "competencies": ["02", "05"],
   "skills": [
     "Avaliar requisitos para decidir entre laços for e while considerando clareza e manutenção.",
     "Refatorar algoritmos convertendo entre estruturas sem alterar resultado final.",

--- a/src/content/courses/algi/lessons/lesson-20.json
+++ b/src/content/courses/algi/lessons/lesson-20.json
@@ -9,7 +9,7 @@
     "Implementar menus interativos utilizando a estrutura do-while.",
     "Comparar vantagens do do-while em relação a while e for em fluxos de confirmação."
   ],
-  "competencies": ["05", "08", "11"],
+  "competencies": ["05", "12"],
   "skills": [
     "Modelar menus que exigem execução inicial obrigatória utilizando do-while.",
     "Implementar validação de opções garantindo repetição até entrada aceitável.",

--- a/src/content/courses/algi/lessons/lesson-21.json
+++ b/src/content/courses/algi/lessons/lesson-21.json
@@ -9,7 +9,7 @@
     "Implementar algoritmos com laços aninhados simples para tabulações e padrões visuais.",
     "Analisar o custo computacional e a ordem de execução em aninhamentos."
   ],
-  "competencies": ["05", "08", "12"],
+  "competencies": ["05", "12"],
   "skills": [
     "Planejar laços aninhados definindo variáveis de controle e limites para cada nível.",
     "Executar testes que comprovem preenchimento correto de estruturas bidimensionais.",


### PR DESCRIPTION
## Summary
- update competencies for ALGI lesson 19 to IDs 02 and 05
- align competencies for lessons 20 and 21 with the required 05 and 12 mapping

## Testing
- `npm run validate:content` *(passes with existing warnings about metadata/objective fields in various lessons)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3b78771c832cacd54e40ed20d563