### PR TITLE
Add descriptions to ALG I lesson metadata

### DIFF
--- a/src/content/courses/algi/lessons/lesson-22.json
+++ b/src/content/courses/algi/lessons/lesson-22.json
@@ -3,6 +3,7 @@
   "id": "lesson-22",
   "title": "Aula 22: Integrando Laços e Condicionais",
   "summary": "Integra estruturas de repetição com decisões complexas para tratar fluxos completos de processamento.",
+  "description": "Integra validação, processamento iterativo e relatórios usando laços combinados com condicionais.",
   "objective": "Construir rotinas robustas que combinem laços e condicionais com validação e relatórios de execução.",
   "objectives": [
     "Mapear pontos de decisão dentro e fora de laços.",

--- a/src/content/courses/algi/lessons/lesson-23.json
+++ b/src/content/courses/algi/lessons/lesson-23.json
@@ -3,6 +3,7 @@
   "id": "lesson-23",
   "title": "Aula 23: Atividade Assíncrona de Triagem Clínica",
   "summary": "Propõe atividade assíncrona integradora que combina laços, condicionais e registro de testes na simulação de triagem.",
+  "description": "Atividade assíncrona de triagem clínica integrando laços, condicionais e documentação de testes.",
   "objective": "Planejar e executar a triagem automatizada cumprindo requisitos funcionais, documentação e entrega assíncrona.",
   "objectives": [
     "Interpretar o briefing de triagem e planejar o fluxo de decisão.",

--- a/src/content/courses/algi/lessons/lesson-24.json
+++ b/src/content/courses/algi/lessons/lesson-24.json
@@ -3,6 +3,7 @@
   "id": "lesson-24",
   "title": "Aula 24: Síntese e Retrospectiva dos Laços",
   "summary": "Consolida aprendizados das aulas 19-23 com showcase da triagem, retroalimentação e plano de melhoria contínua.",
+  "description": "Sessão híbrida de retrospectiva e síntese dos aprendizados de laços com plano de ação coletivo.",
   "objective": "Refletir sobre o ciclo de laços, compartilhar entregas da triagem e definir próximos passos de estudo.",
   "objectives": [
     "Apresentar resultados da atividade assíncrona de triagem.",

--- a/src/content/courses/algi/lessons/lesson-28.json
+++ b/src/content/courses/algi/lessons/lesson-28.json
@@ -3,6 +3,7 @@
   "id": "lesson-28",
   "title": "Aula 28: Boas Práticas e Manutenção de Funções",
   "summary": "Consolida padrões de escrita, testes e documentação para funções em C, com foco em revisão de código e qualidade contínua.",
+  "description": "Consolida padrões de revisão, métricas e manutenção preventiva para código modular em C.",
   "objective": "Aplicar boas práticas de legibilidade, cobertura de testes e monitoramento de métricas em projetos modulares.",
   "objectives": [
     "Avaliar código usando checklist de boas práticas.",

--- a/src/content/courses/algi/lessons/lesson-30.json
+++ b/src/content/courses/algi/lessons/lesson-30.json
@@ -3,6 +3,7 @@
   "id": "lesson-30",
   "title": "Aula 30: Introdução a Vetores",
   "summary": "Apresenta o conceito de vetores (arrays) em C, destacando sua utilidade na organização de dados homogêneos e no cálculo de estatísticas básicas.",
+  "description": "Apresenta vetores como coleções homogêneas, destacando sintaxe em C e cálculo de estatísticas básicas.",
   "objective": "Reconhecer vetores como estruturas de dados fundamentais, compreender sua sintaxe em C e aplicar percursos lineares para obter estatísticas simples.",
   "objectives": [
     "Declarar e inicializar vetores em C respeitando tipos e tamanhos.",

--- a/src/content/courses/algi/lessons/lesson-31.json
+++ b/src/content/courses/algi/lessons/lesson-31.json
@@ -3,6 +3,7 @@
   "id": "lesson-31",
   "title": "Aula 31: Operações e Transformações com Vetores",
   "summary": "Explora padrões de somatório, normalização e geração de tabelas a partir de vetores, consolidando o domínio de loops e acumuladores.",
+  "description": "Explora operações de somatório, normalização e geração de tabelas de frequência com vetores.",
   "objective": "Aplicar percursos sobre vetores para executar operações agregadas e construir tabelas de frequência ou rankings simples.",
   "objectives": [
     "Implementar funções para somar, normalizar e copiar vetores.",

--- a/src/content/courses/algi/lessons/lesson-32.json
+++ b/src/content/courses/algi/lessons/lesson-32.json
@@ -3,6 +3,7 @@
   "id": "lesson-32",
   "title": "Aula 32: Buscas em Vetores",
   "summary": "Introduz algoritmos de busca linear e variantes com sentinela, conectando-os a cenários de catálogo e relatórios.",
+  "description": "Discute algoritmos de busca linear e variações com sentinela aplicados a catálogos e inventários.",
   "objective": "Selecionar e implementar estratégias de busca apropriadas para localizar elementos em vetores não ordenados.",
   "objectives": [
     "Implementar busca linear tradicional e com sentinela.",

--- a/src/content/courses/algi/lessons/lesson-33.json
+++ b/src/content/courses/algi/lessons/lesson-33.json
@@ -3,6 +3,7 @@
   "id": "lesson-33",
   "title": "Aula 33: Matrizes 2D e Geração de Tabelas",
   "summary": "Apresenta matrizes bidimensionais em C para organizar dados tabulares e gerar relatórios estruturados.",
+  "description": "Introduz matrizes 2D, loops aninhados e geração de tabelas formatadas com dados de presença.",
   "objective": "Compreender a representação de matrizes 2D, percorrer linhas e colunas com loops aninhados e montar tabelas formatadas.",
   "objectives": [
     "Declarar matrizes estáticas e inicializá-las com dados reais.",

--- a/src/content/courses/algi/lessons/lesson-34.json
+++ b/src/content/courses/algi/lessons/lesson-34.json
@@ -3,6 +3,7 @@
   "id": "lesson-34",
   "title": "Aula 34: Manipulações com Matrizes",
   "summary": "Aprofunda o trabalho com matrizes 2D realizando transposição, somas e multiplicação para resolver problemas de relatórios e transformações.",
+  "description": "Aprofunda manipulações matriciais com transposição, somas e multiplicação aplicada a indicadores.",
   "objective": "Aplicar operações clássicas de matrizes para gerar indicadores combinados e preparar o terreno para algoritmos de processamento de imagens e dados.",
   "objectives": [
     "Implementar funções para transpor e somar matrizes.",

--- a/src/content/courses/algi/lessons/lesson-35.json
+++ b/src/content/courses/algi/lessons/lesson-35.json
@@ -3,6 +3,7 @@
   "id": "lesson-35",
   "title": "Aula 35: Introdução a Structs (Registros)",
   "summary": "Apresenta structs em C como registros compostos e conduz um CRUD básico em memória para consolidar o modelo de dados.",
+  "description": "Apresenta structs em C como registros compostos e organiza um CRUD inicial para consolidar o modelo de dados.",
   "objective": "Compreender a declaração, instância e manipulação inicial de structs em C, preparando-se para coleções de registros.",
   "objectives": [
     "Declarar structs com campos adequados ao domínio proposto.",

--- a/src/content/courses/algi/lessons/lesson-36.json
+++ b/src/content/courses/algi/lessons/lesson-36.json
@@ -3,6 +3,7 @@
   "id": "lesson-36",
   "title": "Aula 36: Vetores de Structs",
   "summary": "Constrói coleções de registros com structs em vetor e prepara o terreno para operações CRUD completas.",
+  "description": "Organiza coleções de registros com structs em vetor, adicionando ordenação e relatórios.",
   "objective": "Estruturar vetores de structs para representar catálogos de dados e aplicar operações coletivas de ordenação e agregação.",
   "objectives": [
     "Armazenar múltiplos registros em vetores de structs com limites configuráveis.",

--- a/src/content/courses/algi/lessons/lesson-37.json
+++ b/src/content/courses/algi/lessons/lesson-37.json
@@ -3,6 +3,7 @@
   "id": "lesson-37",
   "title": "Aula 37: Busca e Atualização em Vetores de Structs",
   "summary": "Refina o CRUD em memória adicionando buscas flexíveis, atualização de campos e estratégias de auditoria.",
+  "description": "Aprofunda operações de busca, atualização e remoção em vetores de structs com foco em integridade.",
   "objective": "Desenvolver habilidades para localizar, atualizar e remover registros em vetores de structs, garantindo integridade dos dados.",
   "objectives": [
     "Implementar buscas lineares e por chave composta.",

--- a/src/content/courses/algi/lessons/lesson-38.json
+++ b/src/content/courses/algi/lessons/lesson-38.json
@@ -3,6 +3,7 @@
   "id": "lesson-38",
   "title": "Aula 38: Revisão Gamificada do Semestre",
   "summary": "Consolida conteúdos com dinâmica Jeopardy, ranking colaborativo e síntese dos aprendizados em squads.",
+  "description": "Revisa o semestre com dinâmica gamificada envolvendo Jeopardy, ranking colaborativo e feedbacks.",
   "objective": "Promover revisão abrangente dos conceitos-chave da disciplina por meio de atividades gamificadas e colaborativas.",
   "objectives": [
     "Relembrar tópicos centrais (fluxo sequencial, controle, funções, structs).",


### PR DESCRIPTION
## Summary
- add description fields to ALG I lessons 22-24, 28, and 30-38 so the metadata matches the course manifest and can be rendered consistently

## Testing
- npm run validate:content *(passes with existing warnings about missing metadata owners/updatedAt in DDM lessons)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5ac05f8c832c9e6fe5204ec2e935