### PR TITLE
Align Algoritmos I lesson titles and competencies

### DIFF
--- a/src/content/courses/algi/lessons.json
+++ b/src/content/courses/algi/lessons.json
@@ -235,7 +235,7 @@
     },
     {
       "id": "lesson-22",
-      "title": "Aula 22: Integração de Condicionais e Laços",
+      "title": "Integrando Laços e Condicionais",
       "file": "lesson-22.json",
       "available": true,
       "description": "Integra validação, processamento iterativo e relatórios usando laços combinados com condicionais.",
@@ -246,7 +246,7 @@
     },
     {
       "id": "lesson-23",
-      "title": "Aula 23: Atividade Assíncrona de Triagem Clínica",
+      "title": "Atividade Assíncrona de Triagem Clínica",
       "file": "lesson-23.json",
       "available": true,
       "description": "Atividade assíncrona de triagem clínica integrando laços, condicionais e documentação de testes.",
@@ -257,7 +257,7 @@
     },
     {
       "id": "lesson-24",
-      "title": "Aula 24: Síntese e Retrospectiva dos Laços",
+      "title": "Síntese e Retrospectiva dos Laços",
       "file": "lesson-24.json",
       "available": true,
       "description": "Sessão híbrida de retrospectiva e síntese dos aprendizados de laços com plano de ação coletivo.",
@@ -301,7 +301,7 @@
     },
     {
       "id": "lesson-28",
-      "title": "Aula 28: Boas Práticas em Funções",
+      "title": "Boas Práticas e Manutenção de Funções",
       "file": "lesson-28.json",
       "available": true,
       "description": "Consolida padrões de revisão, métricas e manutenção preventiva para código modular em C.",
@@ -323,7 +323,7 @@
     },
     {
       "id": "lesson-30",
-      "title": "Aula 30: Introdução a Vetores (Arrays)",
+      "title": "Introdução a Vetores",
       "file": "lesson-30.json",
       "available": true,
       "description": "Apresenta vetores como coleções homogêneas, destacando sintaxe em C e cálculo de estatísticas básicas.",
@@ -334,7 +334,7 @@
     },
     {
       "id": "lesson-31",
-      "title": "Aula 31: Operações sobre Vetores",
+      "title": "Operações e Transformações com Vetores",
       "file": "lesson-31.json",
       "available": true,
       "description": "Explora operações de somatório, normalização e geração de tabelas de frequência com vetores.",
@@ -345,7 +345,7 @@
     },
     {
       "id": "lesson-32",
-      "title": "Aula 32: Busca e Contagem em Vetores",
+      "title": "Buscas em Vetores",
       "file": "lesson-32.json",
       "available": true,
       "description": "Discute algoritmos de busca linear e variações com sentinela aplicados a catálogos e inventários.",
@@ -356,7 +356,7 @@
     },
     {
       "id": "lesson-33",
-      "title": "Aula 33: Matrizes (Arrays 2D)",
+      "title": "Matrizes 2D e Geração de Tabelas",
       "file": "lesson-33.json",
       "available": true,
       "description": "Introduz matrizes 2D, loops aninhados e geração de tabelas formatadas com dados de presença.",
@@ -367,7 +367,7 @@
     },
     {
       "id": "lesson-34",
-      "title": "Aula 34: Operações sobre Matrizes",
+      "title": "Manipulações com Matrizes",
       "file": "lesson-34.json",
       "available": true,
       "description": "Aprofunda manipulações matriciais com transposição, somas e multiplicação aplicada a indicadores.",
@@ -378,7 +378,7 @@
     },
     {
       "id": "lesson-35",
-      "title": "Aula 35: Introdução a Structs (Registros)",
+      "title": "Introdução a Structs (Registros)",
       "file": "lesson-35.json",
       "available": true,
       "description": "Apresenta structs em C como registros compostos e organiza um CRUD inicial para consolidar o modelo de dados.",
@@ -389,7 +389,7 @@
     },
     {
       "id": "lesson-36",
-      "title": "Aula 36: Vetores de Structs",
+      "title": "Vetores de Structs",
       "file": "lesson-36.json",
       "available": true,
       "description": "Organiza coleções de registros com structs em vetor, adicionando ordenação e relatórios.",
@@ -400,7 +400,7 @@
     },
     {
       "id": "lesson-37",
-      "title": "Aula 37: Busca e Atualização em Vetores de Structs",
+      "title": "Busca e Atualização em Vetores de Structs",
       "file": "lesson-37.json",
       "available": true,
       "description": "Aprofunda operações de busca, atualização e remoção em vetores de structs com foco em integridade.",
@@ -411,7 +411,7 @@
     },
     {
       "id": "lesson-38",
-      "title": "Aula 38: Revisão Geral do Semestre",
+      "title": "Revisão Gamificada do Semestre",
       "file": "lesson-38.json",
       "available": true,
       "description": "Revisa o semestre com dinâmica gamificada envolvendo Jeopardy, ranking colaborativo e feedbacks.",

--- a/src/content/courses/algi/lessons/lesson-22.json
+++ b/src/content/courses/algi/lessons/lesson-22.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-22",
-  "title": "Aula 22: Integrando Laços e Condicionais",
+  "title": "Integrando Laços e Condicionais",
   "summary": "Integra estruturas de repetição com decisões complexas para tratar fluxos completos de processamento.",
   "description": "Integra validação, processamento iterativo e relatórios usando laços combinados com condicionais.",
   "objective": "Construir rotinas robustas que combinem laços e condicionais com validação e relatórios de execução.",
@@ -10,7 +10,7 @@
     "Implementar validações de entrada antes de iniciar ciclos.",
     "Gerar relatórios consolidados ao final do processamento."
   ],
-  "competencies": ["02", "05", "08"],
+  "competencies": ["02", "05"],
   "skills": [
     "Combinar condicionais e laços para construir fluxos completos de processamento.",
     "Monitorar estados intermediários usando logs ou tabelas de acompanhamento.",

--- a/src/content/courses/algi/lessons/lesson-23.json
+++ b/src/content/courses/algi/lessons/lesson-23.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-23",
-  "title": "Aula 23: Atividade Assíncrona de Triagem Clínica",
+  "title": "Atividade Assíncrona de Triagem Clínica",
   "summary": "Propõe atividade assíncrona integradora que combina laços, condicionais e registro de testes na simulação de triagem.",
   "description": "Atividade assíncrona de triagem clínica integrando laços, condicionais e documentação de testes.",
   "objective": "Planejar e executar a triagem automatizada cumprindo requisitos funcionais, documentação e entrega assíncrona.",
@@ -10,7 +10,7 @@
     "Implementar algoritmo que percorre formulários e classifica pacientes.",
     "Documentar testes, métricas e justificativas no relatório de entrega."
   ],
-  "competencies": ["05", "08", "12"],
+  "competencies": ["02", "12"],
   "skills": [
     "Documentar passo a passo a atividade assíncrona, incluindo critérios de avaliação.",
     "Executar testes clínicos simulados registrando evidências compartilháveis.",

--- a/src/content/courses/algi/lessons/lesson-24.json
+++ b/src/content/courses/algi/lessons/lesson-24.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-24",
-  "title": "Aula 24: Síntese e Retrospectiva dos Laços",
+  "title": "Síntese e Retrospectiva dos Laços",
   "summary": "Consolida aprendizados das aulas 19-23 com showcase da triagem, retroalimentação e plano de melhoria contínua.",
   "description": "Sessão híbrida de retrospectiva e síntese dos aprendizados de laços com plano de ação coletivo.",
   "objective": "Refletir sobre o ciclo de laços, compartilhar entregas da triagem e definir próximos passos de estudo.",
@@ -10,7 +10,7 @@
     "Identificar boas práticas e pontos de melhoria nas soluções.",
     "Planejar próximos estudos antes da introdução de funções."
   ],
-  "competencies": ["08", "11", "12"],
+  "competencies": ["05", "12"],
   "skills": [
     "Consolidar métricas e evidências coletadas nas atividades de laços.",
     "Facilitar retrospectiva identificando conquistas, riscos e melhorias.",

--- a/src/content/courses/algi/lessons/lesson-28.json
+++ b/src/content/courses/algi/lessons/lesson-28.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-28",
-  "title": "Aula 28: Boas Práticas e Manutenção de Funções",
+  "title": "Boas Práticas e Manutenção de Funções",
   "summary": "Consolida padrões de escrita, testes e documentação para funções em C, com foco em revisão de código e qualidade contínua.",
   "description": "Consolida padrões de revisão, métricas e manutenção preventiva para código modular em C.",
   "objective": "Aplicar boas práticas de legibilidade, cobertura de testes e monitoramento de métricas em projetos modulares.",
@@ -10,7 +10,7 @@
     "Instrumentar funções com logs e medições simples.",
     "Planejar manutenção preventiva em projetos com funções reutilizáveis."
   ],
-  "competencies": ["05", "08", "12"],
+  "competencies": ["02", "08"],
   "skills": [
     "Aplicar padrões de escrita e nomenclatura que favoreçam manutenção.",
     "Executar checklist de revisão identificando dívidas técnicas e riscos.",

--- a/src/content/courses/algi/lessons/lesson-30.json
+++ b/src/content/courses/algi/lessons/lesson-30.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-30",
-  "title": "Aula 30: Introdução a Vetores",
+  "title": "Introdução a Vetores",
   "summary": "Apresenta o conceito de vetores (arrays) em C, destacando sua utilidade na organização de dados homogêneos e no cálculo de estatísticas básicas.",
   "description": "Apresenta vetores como coleções homogêneas, destacando sintaxe em C e cálculo de estatísticas básicas.",
   "objective": "Reconhecer vetores como estruturas de dados fundamentais, compreender sua sintaxe em C e aplicar percursos lineares para obter estatísticas simples.",
@@ -10,7 +10,7 @@
     "Percorrer vetores com loops for para calcular média, mínimo e máximo.",
     "Relacionar vetores a cenários reais de armazenamento sequencial de dados."
   ],
-  "competencies": ["05", "08", "11"],
+  "competencies": ["05", "11"],
   "skills": [
     "Declarar vetores dimensionando corretamente e inicializando com dados de teste.",
     "Implementar percursos que calculem estatísticas básicas validando limites de índice.",

--- a/src/content/courses/algi/lessons/lesson-31.json
+++ b/src/content/courses/algi/lessons/lesson-31.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-31",
-  "title": "Aula 31: Operações e Transformações com Vetores",
+  "title": "Operações e Transformações com Vetores",
   "summary": "Explora padrões de somatório, normalização e geração de tabelas a partir de vetores, consolidando o domínio de loops e acumuladores.",
   "description": "Explora operações de somatório, normalização e geração de tabelas de frequência com vetores.",
   "objective": "Aplicar percursos sobre vetores para executar operações agregadas e construir tabelas de frequência ou rankings simples.",
@@ -10,7 +10,7 @@
     "Construir tabelas de frequência a partir de dados numéricos.",
     "Interpretar impactos de operações em tempo e memória."
   ],
-  "competencies": ["05", "08", "11"],
+  "competencies": ["05", "08"],
   "skills": [
     "Projetar transformações sobre vetores utilizando acumuladores e normalizações.",
     "Validar resultados comparando totais, médias e discrepâncias detectadas.",

--- a/src/content/courses/algi/lessons/lesson-32.json
+++ b/src/content/courses/algi/lessons/lesson-32.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-32",
-  "title": "Aula 32: Buscas em Vetores",
+  "title": "Buscas em Vetores",
   "summary": "Introduz algoritmos de busca linear e variantes com sentinela, conectando-os a cenários de catálogo e relatórios.",
   "description": "Discute algoritmos de busca linear e variações com sentinela aplicados a catálogos e inventários.",
   "objective": "Selecionar e implementar estratégias de busca apropriadas para localizar elementos em vetores não ordenados.",
@@ -10,7 +10,7 @@
     "Analisar custo temporal das buscas e seu impacto em coleções grandes.",
     "Planejar saídas informativas quando o elemento não é encontrado."
   ],
-  "competencies": ["05", "08", "11"],
+  "competencies": ["05", "08"],
   "skills": [
     "Implementar funções de busca linear com e sem sentinela.",
     "Medir quantidade de comparações executadas em diferentes cenários.",

--- a/src/content/courses/algi/lessons/lesson-33.json
+++ b/src/content/courses/algi/lessons/lesson-33.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-33",
-  "title": "Aula 33: Matrizes 2D e Geração de Tabelas",
+  "title": "Matrizes 2D e Geração de Tabelas",
   "summary": "Apresenta matrizes bidimensionais em C para organizar dados tabulares e gerar relatórios estruturados.",
   "description": "Introduz matrizes 2D, loops aninhados e geração de tabelas formatadas com dados de presença.",
   "objective": "Compreender a representação de matrizes 2D, percorrer linhas e colunas com loops aninhados e montar tabelas formatadas.",
@@ -10,7 +10,7 @@
     "Percorrer linhas e colunas utilizando loops aninhados.",
     "Gerar tabelas formatadas a partir de matrizes."
   ],
-  "competencies": ["05", "08", "11"],
+  "competencies": ["05", "11"],
   "skills": [
     "Mapear dados tabulares para estruturas de matrizes em C.",
     "Construir laços aninhados que preencham e apresentem tabelas formatadas.",

--- a/src/content/courses/algi/lessons/lesson-34.json
+++ b/src/content/courses/algi/lessons/lesson-34.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-34",
-  "title": "Aula 34: Manipulações com Matrizes",
+  "title": "Manipulações com Matrizes",
   "summary": "Aprofunda o trabalho com matrizes 2D realizando transposição, somas e multiplicação para resolver problemas de relatórios e transformações.",
   "description": "Aprofunda manipulações matriciais com transposição, somas e multiplicação aplicada a indicadores.",
   "objective": "Aplicar operações clássicas de matrizes para gerar indicadores combinados e preparar o terreno para algoritmos de processamento de imagens e dados.",
@@ -10,7 +10,7 @@
     "Executar multiplicação matricial com três loops.",
     "Validar dimensões e tratar entradas inválidas."
   ],
-  "competencies": ["05", "08", "11"],
+  "competencies": ["05", "08"],
   "skills": [
     "Implementar transposição, somas e multiplicação de matrizes controlando dimensões.",
     "Testar compatibilidade entre matrizes antes de executar operações.",

--- a/src/content/courses/algi/lessons/lesson-35.json
+++ b/src/content/courses/algi/lessons/lesson-35.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-35",
-  "title": "Aula 35: Introdução a Structs (Registros)",
+  "title": "Introdução a Structs (Registros)",
   "summary": "Apresenta structs em C como registros compostos e conduz um CRUD básico em memória para consolidar o modelo de dados.",
   "description": "Apresenta structs em C como registros compostos e organiza um CRUD inicial para consolidar o modelo de dados.",
   "objective": "Compreender a declaração, instância e manipulação inicial de structs em C, preparando-se para coleções de registros.",
@@ -10,7 +10,7 @@
     "Inicializar e acessar membros por ponto e ponteiros.",
     "Construir um mini-CRUD em memória com ênfase em criação e leitura."
   ],
-  "competencies": ["05", "08", "11"],
+  "competencies": ["05", "11"],
   "skills": [
     "Definir structs representando registros compostos com campos coerentes.",
     "Implementar operações CRUD em memória validando entrada e saída de dados.",

--- a/src/content/courses/algi/lessons/lesson-36.json
+++ b/src/content/courses/algi/lessons/lesson-36.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-36",
-  "title": "Aula 36: Vetores de Structs",
+  "title": "Vetores de Structs",
   "summary": "Constrói coleções de registros com structs em vetor e prepara o terreno para operações CRUD completas.",
   "description": "Organiza coleções de registros com structs em vetor, adicionando ordenação e relatórios.",
   "objective": "Estruturar vetores de structs para representar catálogos de dados e aplicar operações coletivas de ordenação e agregação.",
@@ -10,7 +10,7 @@
     "Aplicar ordenação simples para organizar a coleção.",
     "Documentar o estado da coleção com relatórios resumidos."
   ],
-  "competencies": ["05", "08", "12"],
+  "competencies": ["05", "12"],
   "skills": [
     "Organizar vetores de structs definindo estratégias de inserção e busca.",
     "Garantir consistência dos dados ao realizar atualizações em lote.",

--- a/src/content/courses/algi/lessons/lesson-37.json
+++ b/src/content/courses/algi/lessons/lesson-37.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-37",
-  "title": "Aula 37: Busca e Atualização em Vetores de Structs",
+  "title": "Busca e Atualização em Vetores de Structs",
   "summary": "Refina o CRUD em memória adicionando buscas flexíveis, atualização de campos e estratégias de auditoria.",
   "description": "Aprofunda operações de busca, atualização e remoção em vetores de structs com foco em integridade.",
   "objective": "Desenvolver habilidades para localizar, atualizar e remover registros em vetores de structs, garantindo integridade dos dados.",
@@ -10,7 +10,7 @@
     "Atualizar campos selecionados mantendo histórico mínimo.",
     "Realizar remoção lógica e física comparando abordagens."
   ],
-  "competencies": ["05", "08", "12"],
+  "competencies": ["05", "12"],
   "skills": [
     "Implementar buscas flexíveis em vetores de structs utilizando filtros variados.",
     "Aplicar auditoria registrando histórico de alterações e validações.",

--- a/src/content/courses/algi/lessons/lesson-38.json
+++ b/src/content/courses/algi/lessons/lesson-38.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-38",
-  "title": "Aula 38: Revisão Gamificada do Semestre",
+  "title": "Revisão Gamificada do Semestre",
   "summary": "Consolida conteúdos com dinâmica Jeopardy, ranking colaborativo e síntese dos aprendizados em squads.",
   "description": "Revisa o semestre com dinâmica gamificada envolvendo Jeopardy, ranking colaborativo e feedbacks.",
   "objective": "Promover revisão abrangente dos conceitos-chave da disciplina por meio de atividades gamificadas e colaborativas.",
@@ -10,7 +10,7 @@
     "Aplicar conhecimento em desafios práticos e quizzes competitivos.",
     "Mapear pontos de melhoria individuais a partir do ranking e feedbacks."
   ],
-  "competencies": ["05", "11", "12"],
+  "competencies": ["11", "12"],
   "skills": [
     "Preparar desafios que revisem conteúdos do semestre em formato gamificado.",
     "Compartilhar explicações rápidas das soluções adotadas pela equipe.",


### PR DESCRIPTION
## Summary
- update lessons 22, 23, 24, 28, and 30–38 to use the teaching-plan titles instead of the "Aula" prefix
- adjust the competency IDs in those lessons to the new pairs from the plan
- synchronize the Algoritmos I lessons manifest with the updated titles

## Testing
- npm run validate:content (warnings for existing DDM lessons without metadata owners/updatedAt)


------
https://chatgpt.com/codex/tasks/task_e_68dd5caaea80832cb1f6cb6e3d828582