### PR TITLE
Normalize MD3 lesson content blocks

### DIFF
--- a/scripts/convert-blocks.cjs
+++ b/scripts/convert-blocks.cjs
@@ -1,0 +1,502 @@
+const fs = require('fs');
+const path = require('path');
+
+const lessonNumbers = [22, 23, 24, 28, 30, 31, 32, 33, 34, 35, 36, 37, 38];
+const lessonFiles = lessonNumbers.map((num) => `lesson-${String(num).padStart(2, '0')}.json`);
+
+const baseDir = path.join(__dirname, '..', 'src', 'content', 'courses');
+
+const courses = fs
+  .readdirSync(baseDir)
+  .filter((entry) => fs.statSync(path.join(baseDir, entry)).isDirectory());
+
+const updatedFiles = [];
+
+for (const course of courses) {
+  const lessonsDir = path.join(baseDir, course, 'lessons');
+  for (const lessonFile of lessonFiles) {
+    const filePath = path.join(lessonsDir, lessonFile);
+    if (!fs.existsSync(filePath)) continue;
+
+    const original = fs.readFileSync(filePath, 'utf8');
+    const data = JSON.parse(original);
+    let changed = false;
+
+    function markChanged() {
+      changed = true;
+    }
+
+    const specialTypes = new Set([
+      'flightPlan',
+      'timeline',
+      'pipelineCanvas',
+      'videosBlock',
+      'cardGrid',
+      'md3Table',
+      'md3Flowchart',
+    ]);
+
+    function transformContentItem(item) {
+      if (!item || typeof item !== 'object') {
+        return item;
+      }
+
+      if (item.type && specialTypes.has(item.type)) {
+        return transformBlock(item);
+      }
+
+      if (item.type === 'code') {
+        markChanged();
+        const next = {
+          type: 'codeBlock',
+          language: 'c',
+          code: item.code,
+        };
+        if (item.title) {
+          next.title = item.title;
+        }
+        return next;
+      }
+
+      if (Array.isArray(item.items)) {
+        item.items = item.items.map((entry) => {
+          if (entry && typeof entry === 'object' && entry.type) {
+            return transformContentItem(entry);
+          }
+          return entry;
+        });
+      }
+
+      if (Array.isArray(item.content)) {
+        item.content = item.content.map((entry) => transformContentItem(entry));
+      }
+
+      return item;
+    }
+
+    function transformBlock(block) {
+      if (!block || typeof block !== 'object') {
+        return block;
+      }
+
+      switch (block.type) {
+        case 'flightPlan': {
+          markChanged();
+          const cards = Array.isArray(block.items)
+            ? block.items.map((item, index) => {
+                let title = `Etapa ${index + 1}`;
+                let content = typeof item === 'string' ? item.trim() : '';
+                if (typeof item === 'string') {
+                  const colonIndex = item.indexOf(':');
+                  if (colonIndex !== -1) {
+                    title = item.slice(0, colonIndex).trim();
+                    content = item.slice(colonIndex + 1).trim();
+                  } else {
+                    const timeMatch = item.match(/^\(([^)]+)\)\s*(.*)$/);
+                    if (timeMatch) {
+                      title = timeMatch[1].trim();
+                      content = timeMatch[2].trim();
+                    } else {
+                      const trimmed = item.trim();
+                      if (trimmed) {
+                        title = trimmed.length > 60 ? `${trimmed.slice(0, 57)}...` : trimmed;
+                        content = trimmed;
+                      }
+                    }
+                  }
+                }
+                return {
+                  icon: 'check-circle',
+                  title,
+                  content,
+                };
+              })
+            : [];
+          return {
+            type: 'lessonPlan',
+            title: block.title,
+            cards,
+          };
+        }
+        case 'timeline': {
+          markChanged();
+          const items = Array.isArray(block.steps)
+            ? block.steps.map((step) => {
+                const pieces = [];
+                if (step && typeof step === 'object') {
+                  if (step.title) {
+                    pieces.push(step.title.trim());
+                  }
+                  if (step.content) {
+                    pieces.push(step.content.trim());
+                  }
+                }
+                return { text: pieces.join(' – ') };
+              })
+            : [];
+          const content = [];
+          if (items.length > 0) {
+            content.push({
+              type: 'orderedList',
+              items,
+            });
+          }
+          return {
+            type: 'contentBlock',
+            title: block.title,
+            content,
+          };
+        }
+        case 'pipelineCanvas': {
+          markChanged();
+          const items = Array.isArray(block.stages)
+            ? block.stages.map((stage) => {
+                const parts = [];
+                if (stage.title) {
+                  parts.push(stage.title.trim());
+                }
+                if (stage.summary) {
+                  parts.push(stage.summary.trim());
+                }
+                if (Array.isArray(stage.owners) && stage.owners.length > 0) {
+                  parts.push(`Responsáveis: ${stage.owners.join(', ')}`);
+                }
+                if (typeof stage.durationHours === 'number') {
+                  parts.push(`Duração: ${stage.durationHours}h`);
+                }
+                if (Array.isArray(stage.activities) && stage.activities.length > 0) {
+                  const labels = stage.activities
+                    .map((activity) => (activity && activity.label ? activity.label.trim() : null))
+                    .filter(Boolean);
+                  if (labels.length > 0) {
+                    parts.push(`Atividades: ${labels.join('; ')}`);
+                  }
+                }
+                if (Array.isArray(stage.deliverables) && stage.deliverables.length > 0) {
+                  const deliverables = stage.deliverables
+                    .map((deliverable) =>
+                      deliverable && deliverable.label ? deliverable.label.trim() : null
+                    )
+                    .filter(Boolean);
+                  if (deliverables.length > 0) {
+                    parts.push(`Entregáveis: ${deliverables.join('; ')}`);
+                  }
+                }
+                if (Array.isArray(stage.risks) && stage.risks.length > 0) {
+                  const risks = stage.risks
+                    .map((risk) => {
+                      if (!risk || !risk.label) return null;
+                      const mitigation = risk.mitigation ? ` (${risk.mitigation.trim()})` : '';
+                      return `${risk.label.trim()}${mitigation}`;
+                    })
+                    .filter(Boolean);
+                  if (risks.length > 0) {
+                    parts.push(`Riscos: ${risks.join('; ')}`);
+                  }
+                }
+                if (Array.isArray(stage.checkpoints) && stage.checkpoints.length > 0) {
+                  parts.push(`Checkpoints: ${stage.checkpoints.join(', ')}`);
+                }
+                return { text: parts.join(' | ') };
+              })
+            : [];
+
+          const content = [];
+          if (block.summary) {
+            content.push({ type: 'paragraph', text: block.summary.trim() });
+          }
+          if (items.length > 0) {
+            content.push({ type: 'unorderedList', items });
+          }
+          return {
+            type: 'contentBlock',
+            title: block.title,
+            content,
+          };
+        }
+        case 'videosBlock': {
+          markChanged();
+          const items = Array.isArray(block.videos)
+            ? block.videos.map((video) => {
+                if (!video || typeof video !== 'object') {
+                  return { text: '' };
+                }
+                const pieces = [];
+                if (video.title) {
+                  pieces.push(video.title.trim());
+                }
+                if (video.caption) {
+                  pieces.push(video.caption.trim());
+                }
+                if (video.url) {
+                  pieces.push(video.url.trim());
+                } else if (video.youtubeId) {
+                  pieces.push(`https://www.youtube.com/watch?v=${video.youtubeId}`);
+                }
+                return { text: pieces.join(' – ') };
+              })
+            : [];
+          const content = [];
+          if (items.length > 0) {
+            content.push({ type: 'unorderedList', items });
+          }
+          return {
+            type: 'contentBlock',
+            title: block.title,
+            content,
+          };
+        }
+        case 'cardGrid': {
+          markChanged();
+          const items = Array.isArray(block.cards)
+            ? block.cards.map((card) => {
+                if (!card || typeof card !== 'object') {
+                  return null;
+                }
+                const details = [];
+                if (card.subtitle) {
+                  details.push(card.subtitle.trim());
+                }
+                if (card.content) {
+                  details.push(card.content.trim());
+                }
+                let bulletText = '';
+                let normalized = [];
+                if (Array.isArray(card.items) && card.items.length > 0) {
+                  normalized = card.items
+                    .map((entry) => {
+                      if (!entry) return null;
+                      if (typeof entry === 'string') {
+                        return entry.trim();
+                      }
+                      if (entry && typeof entry === 'object' && entry.text) {
+                        return entry.text.trim();
+                      }
+                      return null;
+                    })
+                    .filter(Boolean);
+                  if (normalized.length > 0) {
+                    bulletText = normalized.map((line) => `- ${line}`).join('\n');
+                  }
+                }
+                const detailText = details.join(' ').trim();
+                let contentText = detailText;
+                if (!contentText && normalized.length > 0) {
+                  contentText = normalized[0];
+                }
+                if (!contentText && card.title) {
+                  contentText = card.title.trim();
+                }
+                const representation = {
+                  title: card.title || 'Comparativo',
+                  content: contentText,
+                  language: 'plaintext',
+                };
+                const combined = [detailText, bulletText].filter(
+                  (value) => value && value.trim().length > 0
+                );
+                if (combined.length > 0) {
+                  representation.code = combined.join('\n');
+                }
+                return representation;
+              })
+            : [];
+
+          return {
+            type: 'representations',
+            title: block.title,
+            items: items.filter(Boolean),
+          };
+        }
+        case 'code': {
+          markChanged();
+          const content = [
+            {
+              type: 'codeBlock',
+              language: 'c',
+              code: block.code,
+            },
+          ];
+          return {
+            type: 'contentBlock',
+            title: block.title || block.caption || 'Exemplo de código',
+            content,
+          };
+        }
+        case 'codeBlock': {
+          markChanged();
+          const content = [
+            {
+              type: 'codeBlock',
+              language: block.language || 'c',
+              code: block.code,
+            },
+          ];
+          return {
+            type: 'contentBlock',
+            title: block.title || 'Exemplo de código',
+            content,
+          };
+        }
+        case 'md3Table': {
+          markChanged();
+          const headers = Array.isArray(block.headers) ? block.headers : [];
+          const items = Array.isArray(block.rows)
+            ? block.rows.map((row) => {
+                if (!Array.isArray(row)) {
+                  return { text: '' };
+                }
+                const cells = row.map((cell, index) => {
+                  const header = headers[index] ? `${headers[index]}: ` : '';
+                  return `${header}${cell}`.trim();
+                });
+                return { text: cells.join(' | ') };
+              })
+            : [];
+          const content = [];
+          if (block.title) {
+            // title will be set outside
+          }
+          if (items.length > 0) {
+            content.push({ type: 'unorderedList', items });
+          }
+          return {
+            type: 'contentBlock',
+            title: block.title,
+            content,
+          };
+        }
+        case 'md3Flowchart': {
+          markChanged();
+          const nodeItems = Array.isArray(block.nodes)
+            ? block.nodes
+                .map((node, index) => {
+                  if (!node || typeof node !== 'object') {
+                    return { text: `Passo ${index + 1}` };
+                  }
+                  const parts = [];
+                  if (node.label) {
+                    parts.push(node.label.trim());
+                  }
+                  if (node.type) {
+                    parts.push(`tipo: ${node.type}`);
+                  }
+                  const text = parts.join(' – ');
+                  return { text };
+                })
+                .filter((entry) => entry.text && entry.text.trim().length > 0)
+            : [];
+          const edgeItems = Array.isArray(block.edges)
+            ? block.edges
+                .map((edge) => {
+                  const parts = [];
+                  if (Array.isArray(edge)) {
+                    const [from, to, description] = edge;
+                    if (from && to) {
+                      parts.push(`${from} → ${to}`);
+                    }
+                    if (description) {
+                      parts.push(String(description).trim());
+                    }
+                  } else if (edge && typeof edge === 'object') {
+                    if (edge.from && edge.to) {
+                      parts.push(`${edge.from} → ${edge.to}`);
+                    }
+                    if (edge.description) {
+                      parts.push(edge.description.trim());
+                    }
+                  }
+                  const text = parts.join(' – ');
+                  return { text };
+                })
+                .filter((entry) => entry.text && entry.text.trim().length > 0)
+            : [];
+          const content = [];
+          if (block.summary) {
+            content.push({ type: 'paragraph', text: block.summary.trim() });
+          }
+          if (nodeItems.length > 0) {
+            content.push({ type: 'orderedList', items: nodeItems });
+          }
+          if (edgeItems.length > 0) {
+            content.push({ type: 'unorderedList', items: edgeItems });
+          }
+          return {
+            type: 'contentBlock',
+            title: block.title,
+            content,
+          };
+        }
+        case 'representations': {
+          const result = { ...block };
+          if (Array.isArray(result.items)) {
+            let mutated = false;
+            result.items = result.items.map((item) => {
+              if (!item || typeof item !== 'object') {
+                return item;
+              }
+              let content = typeof item.content === 'string' ? item.content.trim() : '';
+              if (!content) {
+                let fallback = '';
+                if (typeof item.code === 'string') {
+                  const lines = item.code.split('\n');
+                  const firstLine = lines.find((line) => line && line.trim().length > 0);
+                  if (firstLine) {
+                    fallback = firstLine.replace(/^[-•]\s*/, '').trim();
+                  }
+                }
+                if (!fallback && item.title) {
+                  fallback = item.title.trim();
+                }
+                const updated = {
+                  ...item,
+                  content: fallback,
+                };
+                mutated = true;
+                return updated;
+              }
+              return item;
+            });
+            if (mutated) {
+              markChanged();
+            }
+          }
+          return result;
+        }
+        default: {
+          const result = { ...block };
+          if (Array.isArray(result.content)) {
+            result.content = result.content.map((item) => transformContentItem({ ...item }));
+          }
+          if (Array.isArray(result.items)) {
+            result.items = result.items.map((item) => {
+              if (item && typeof item === 'object' && item.type) {
+                return transformContentItem({ ...item });
+              }
+              return item;
+            });
+          }
+          return result;
+        }
+      }
+    }
+
+    if (Array.isArray(data.content)) {
+      data.content = data.content.map((block) => transformBlock(block));
+    }
+
+    if (changed) {
+      fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n');
+      updatedFiles.push(filePath);
+    }
+  }
+}
+
+if (updatedFiles.length === 0) {
+  console.log('No files updated.');
+} else {
+  console.log('Updated files:');
+  for (const file of updatedFiles) {
+    console.log(` - ${path.relative(path.join(__dirname, '..'), file)}`);
+  }
+}

--- a/src/content/courses/algi/lessons/lesson-22.json
+++ b/src/content/courses/algi/lessons/lesson-22.json
@@ -103,115 +103,26 @@
       ]
     },
     {
-      "type": "pipelineCanvas",
+      "type": "contentBlock",
       "title": "Pipeline da integração",
-      "summary": "Etapas para combinar laços e condicionais em um mini-sistema.",
-      "stages": [
+      "content": [
         {
-          "id": "validacao",
-          "title": "Validação do briefing",
-          "summary": "Entender requisitos, entradas e saídas.",
-          "owners": ["Squad"],
-          "durationHours": 1.5,
-          "activities": [
-            {
-              "id": "requisitos",
-              "label": "Ler briefing",
-              "description": "Identificar regras e exceções."
-            },
-            {
-              "id": "risco",
-              "label": "Registrar riscos",
-              "description": "Listar dúvidas e dependências."
-            }
-          ],
-          "deliverables": [
-            {
-              "id": "canvas",
-              "label": "Canvas de requisitos"
-            }
-          ],
-          "risks": [
-            {
-              "id": "escopo",
-              "label": "Requisitos ambíguos",
-              "severity": "medium",
-              "mitigation": "Validar com professor."
-            }
-          ],
-          "checkpoints": ["Briefing validado"]
+          "type": "paragraph",
+          "text": "Etapas para combinar laços e condicionais em um mini-sistema."
         },
         {
-          "id": "dojo",
-          "title": "Dojo guiado",
-          "summary": "Implementar esqueleto com apoio do professor.",
-          "owners": ["Squad"],
-          "durationHours": 2,
-          "activities": [
+          "type": "unorderedList",
+          "items": [
             {
-              "id": "setup",
-              "label": "Configurar projeto",
-              "description": "Clonar template e preparar ambiente."
+              "text": "Validação do briefing | Entender requisitos, entradas e saídas. | Responsáveis: Squad | Duração: 1.5h | Atividades: Ler briefing; Registrar riscos | Entregáveis: Canvas de requisitos | Riscos: Requisitos ambíguos (Validar com professor.) | Checkpoints: Briefing validado"
             },
             {
-              "id": "rotinas",
-              "label": "Criar rotinas base",
-              "description": "Menus, validações e loops principais."
-            }
-          ],
-          "deliverables": [
-            {
-              "id": "checkpoint",
-              "label": "Commit inicial"
-            }
-          ],
-          "risks": [
-            {
-              "id": "bloqueio",
-              "label": "Divergência de abordagem",
-              "severity": "low",
-              "mitigation": "Seguir padrão definido no dojo."
-            }
-          ],
-          "checkpoints": ["Commit compartilhado"]
-        },
-        {
-          "id": "laboratorio",
-          "title": "Laboratório e relatório",
-          "summary": "Refinar funcionalidades e documentar métricas.",
-          "owners": ["Dupla"],
-          "durationHours": 3,
-          "activities": [
-            {
-              "id": "refino",
-              "label": "Refinar funcionalidades",
-              "description": "Adicionar logs, validações e testes."
+              "text": "Dojo guiado | Implementar esqueleto com apoio do professor. | Responsáveis: Squad | Duração: 2h | Atividades: Configurar projeto; Criar rotinas base | Entregáveis: Commit inicial | Riscos: Divergência de abordagem (Seguir padrão definido no dojo.) | Checkpoints: Commit compartilhado"
             },
             {
-              "id": "documentar",
-              "label": "Escrever relatório",
-              "description": "Preencher métricas e reflexões."
+              "text": "Laboratório e relatório | Refinar funcionalidades e documentar métricas. | Responsáveis: Dupla | Duração: 3h | Atividades: Refinar funcionalidades; Escrever relatório | Entregáveis: Código final; Relatório técnico | Riscos: Atraso na documentação (Reservar 1h exclusiva para o relatório.) | Checkpoints: Logs revisados, Relatório submetido"
             }
-          ],
-          "deliverables": [
-            {
-              "id": "portfolio",
-              "label": "Código final"
-            },
-            {
-              "id": "relatorio",
-              "label": "Relatório técnico"
-            }
-          ],
-          "risks": [
-            {
-              "id": "prazo",
-              "label": "Atraso na documentação",
-              "severity": "high",
-              "mitigation": "Reservar 1h exclusiva para o relatório."
-            }
-          ],
-          "checkpoints": ["Logs revisados", "Relatório submetido"]
+          ]
         }
       ]
     },
@@ -241,30 +152,65 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (2h00)",
-      "items": [
-        "(15 min) Revisão do ciclo completo de processamento.",
-        "(20 min) Workshop: validar entrada antes do laço.",
-        "(30 min) Coding dojo: processamento de pedidos com regras condicionais.",
-        "(20 min) Laboratório em trios: tratamento de exceções e logs.",
-        "(15 min) Construção do relatório de métricas.",
-        "(10 min) Pausa ativa e dúvidas rápidas.",
-        "(10 min) Socialização das soluções.",
-        "(10 min) Briefing da tarefa avaliativa."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "15 min",
+          "content": "Revisão do ciclo completo de processamento."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(20 min) Workshop",
+          "content": "validar entrada antes do laço."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(30 min) Coding dojo",
+          "content": "processamento de pedidos com regras condicionais."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(20 min) Laboratório em trios",
+          "content": "tratamento de exceções e logs."
+        },
+        {
+          "icon": "check-circle",
+          "title": "15 min",
+          "content": "Construção do relatório de métricas."
+        },
+        {
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Pausa ativa e dúvidas rápidas."
+        },
+        {
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Socialização das soluções."
+        },
+        {
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Briefing da tarefa avaliativa."
+        }
       ]
     },
     {
-      "type": "videosBlock",
+      "type": "contentBlock",
       "title": "Referências em vídeo",
-      "videos": [
+      "content": [
         {
-          "youtubeId": "l1dwYQz9g7E",
-          "title": "Pipelines de processamento com C"
-        },
-        {
-          "youtubeId": "vCsjG8xqQng",
-          "title": "Validação de dados em laços"
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Pipelines de processamento com C – https://www.youtube.com/watch?v=l1dwYQz9g7E"
+            },
+            {
+              "text": "Validação de dados em laços – https://www.youtube.com/watch?v=vCsjG8xqQng"
+            }
+          ]
         }
       ]
     },
@@ -286,28 +232,39 @@
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Regras condicionais prioritárias",
-      "cards": [
+      "items": [
         {
           "title": "Casos críticos",
-          "content": "Tratam prioridade absoluta (ex.: estoque zerado → alerta)."
+          "content": "Tratam prioridade absoluta (ex.: estoque zerado → alerta).",
+          "language": "plaintext",
+          "code": "Tratam prioridade absoluta (ex.: estoque zerado → alerta)."
         },
         {
           "title": "Casos prioritários",
-          "content": "Aplicam descontos, filas preferenciais, mensagens personalizadas."
+          "content": "Aplicam descontos, filas preferenciais, mensagens personalizadas.",
+          "language": "plaintext",
+          "code": "Aplicam descontos, filas preferenciais, mensagens personalizadas."
         },
         {
           "title": "Casos padrão",
-          "content": "Processamento nominal com logs básicos."
+          "content": "Processamento nominal com logs básicos.",
+          "language": "plaintext",
+          "code": "Processamento nominal com logs básicos."
         }
       ]
     },
     {
-      "type": "code",
-      "language": "c",
+      "type": "contentBlock",
       "title": "Integração completa",
-      "code": "int totalPedidos = 0, atrasados = 0;\nint quantidade;\nprintf(\"Quantos pedidos serão processados? \");\nscanf(\"%d\", &quantidade);\nif (quantidade <= 0) {\n  printf(\"Nada a processar.\\n\");\n  return 0;\n}\nfor (int i = 0; i < quantidade; i++) {\n  Pedido pedido = lerPedido();\n  if (!pedido.valido) {\n    printf(\"Pedido %d inválido.\\n\", i + 1);\n    continue;\n  }\n  if (pedido.prioridade == ALTA) {\n    trataPrioritario(pedido);\n  } else if (pedido.atrasado) {\n    atrasados++;\n    trataAtrasado(pedido);\n  } else {\n    trataNormal(pedido);\n  }\n  totalPedidos++;\n}\nprintf(\"Processados: %d | Atrasados: %d\\n\", totalPedidos, atrasados);\n"
+      "content": [
+        {
+          "type": "codeBlock",
+          "language": "c",
+          "code": "int totalPedidos = 0, atrasados = 0;\nint quantidade;\nprintf(\"Quantos pedidos serão processados? \");\nscanf(\"%d\", &quantidade);\nif (quantidade <= 0) {\n  printf(\"Nada a processar.\\n\");\n  return 0;\n}\nfor (int i = 0; i < quantidade; i++) {\n  Pedido pedido = lerPedido();\n  if (!pedido.valido) {\n    printf(\"Pedido %d inválido.\\n\", i + 1);\n    continue;\n  }\n  if (pedido.prioridade == ALTA) {\n    trataPrioritario(pedido);\n  } else if (pedido.atrasado) {\n    atrasados++;\n    trataAtrasado(pedido);\n  } else {\n    trataNormal(pedido);\n  }\n  totalPedidos++;\n}\nprintf(\"Processados: %d | Atrasados: %d\\n\", totalPedidos, atrasados);\n"
+        }
+      ]
     },
     {
       "type": "checklist",
@@ -319,24 +276,32 @@
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Checklist de logs",
-      "cards": [
+      "items": [
         {
           "title": "Entradas",
-          "content": "Registre valores recebidos e validações aplicadas."
+          "content": "Registre valores recebidos e validações aplicadas.",
+          "language": "plaintext",
+          "code": "Registre valores recebidos e validações aplicadas."
         },
         {
           "title": "Decisões",
-          "content": "Anote quando condicionais direcionam para caminhos distintos."
+          "content": "Anote quando condicionais direcionam para caminhos distintos.",
+          "language": "plaintext",
+          "code": "Anote quando condicionais direcionam para caminhos distintos."
         },
         {
           "title": "Iterações",
-          "content": "Logue quantas vezes cada laço executou."
+          "content": "Logue quantas vezes cada laço executou.",
+          "language": "plaintext",
+          "code": "Logue quantas vezes cada laço executou."
         },
         {
           "title": "Erros",
-          "content": "Documente exceções e como foram tratadas."
+          "content": "Documente exceções e como foram tratadas.",
+          "language": "plaintext",
+          "code": "Documente exceções e como foram tratadas."
         }
       ]
     },

--- a/src/content/courses/algi/lessons/lesson-23.json
+++ b/src/content/courses/algi/lessons/lesson-23.json
@@ -116,20 +116,22 @@
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Cronograma de 3 dias",
-      "steps": [
+      "content": [
         {
-          "title": "Dia 1 – Briefing e modelagem",
-          "content": "Ler briefing, definir responsabilidades e desenhar fluxograma."
-        },
-        {
-          "title": "Dia 2 – Implementação",
-          "content": "Codificar solução, registrar logs e validar com checklist."
-        },
-        {
-          "title": "Dia 3 – Testes e relatório",
-          "content": "Executar testes completos, finalizar relatório e preparar envio."
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Dia 1 – Briefing e modelagem – Ler briefing, definir responsabilidades e desenhar fluxograma."
+            },
+            {
+              "text": "Dia 2 – Implementação – Codificar solução, registrar logs e validar com checklist."
+            },
+            {
+              "text": "Dia 3 – Testes e relatório – Executar testes completos, finalizar relatório e preparar envio."
+            }
+          ]
         }
       ]
     },
@@ -155,43 +157,64 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo assíncrono (3 dias)",
-      "items": [
-        "Dia 1 (1h) – Ler briefing, mapear fluxograma, listar dúvidas.",
-        "Dia 2 (1h30) – Codificar solução, gerar CSV e validar casos extremos.",
-        "Dia 3 (30 min) – Revisar testes, preencher relatório e publicar reflexão."
-      ]
-    },
-    {
-      "type": "videosBlock",
-      "title": "Suportes em vídeo",
-      "videos": [
+      "cards": [
         {
-          "youtubeId": "8kK-cA99SA0",
-          "title": "Triagem com estruturas de controle"
+          "icon": "check-circle",
+          "title": "Dia 1 (1h) – Ler briefing, mapear fluxograma, listar dúvi...",
+          "content": "Dia 1 (1h) – Ler briefing, mapear fluxograma, listar dúvidas."
         },
         {
-          "youtubeId": "2LzgBBrZPdg",
-          "title": "Registrando testes e evidências"
+          "icon": "check-circle",
+          "title": "Dia 2 (1h30) – Codificar solução, gerar CSV e validar cas...",
+          "content": "Dia 2 (1h30) – Codificar solução, gerar CSV e validar casos extremos."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Dia 3 (30 min) – Revisar testes, preencher relatório e pu...",
+          "content": "Dia 3 (30 min) – Revisar testes, preencher relatório e publicar reflexão."
         }
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "contentBlock",
+      "title": "Suportes em vídeo",
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Triagem com estruturas de controle – https://www.youtube.com/watch?v=8kK-cA99SA0"
+            },
+            {
+              "text": "Registrando testes e evidências – https://www.youtube.com/watch?v=2LzgBBrZPdg"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "representations",
       "title": "Checklist de planejamento",
-      "cards": [
+      "items": [
         {
           "title": "Dados críticos",
-          "content": "Definir estruturas para sintomas, sinais vitais e riscos."
+          "content": "Definir estruturas para sintomas, sinais vitais e riscos.",
+          "language": "plaintext",
+          "code": "Definir estruturas para sintomas, sinais vitais e riscos."
         },
         {
           "title": "Regras de decisão",
-          "content": "Priorizar emergências, depois riscos e casos padrão."
+          "content": "Priorizar emergências, depois riscos e casos padrão.",
+          "language": "plaintext",
+          "code": "Priorizar emergências, depois riscos e casos padrão."
         },
         {
           "title": "Saídas",
-          "content": "CSV com nome, classificação e justificativa textual."
+          "content": "CSV com nome, classificação e justificativa textual.",
+          "language": "plaintext",
+          "code": "CSV com nome, classificação e justificativa textual."
         }
       ]
     },
@@ -222,24 +245,32 @@
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Critérios da triagem",
-      "cards": [
+      "items": [
         {
           "title": "Cobertura de casos",
-          "content": "Fluxo trata pacientes críticos, regulares e encerramento."
+          "content": "Fluxo trata pacientes críticos, regulares e encerramento.",
+          "language": "plaintext",
+          "code": "Fluxo trata pacientes críticos, regulares e encerramento."
         },
         {
           "title": "Automação de testes",
-          "content": "Planilha e scripts demonstram execução repetível."
+          "content": "Planilha e scripts demonstram execução repetível.",
+          "language": "plaintext",
+          "code": "Planilha e scripts demonstram execução repetível."
         },
         {
           "title": "Relatório técnico",
-          "content": "Documento resume decisões, métricas e próximos passos."
+          "content": "Documento resume decisões, métricas e próximos passos.",
+          "language": "plaintext",
+          "code": "Documento resume decisões, métricas e próximos passos."
         },
         {
           "title": "Trabalho colaborativo",
-          "content": "Registre contribuições de cada membro no repositório."
+          "content": "Registre contribuições de cada membro no repositório.",
+          "language": "plaintext",
+          "code": "Registre contribuições de cada membro no repositório."
         }
       ]
     },

--- a/src/content/courses/algi/lessons/lesson-24.json
+++ b/src/content/courses/algi/lessons/lesson-24.json
@@ -121,36 +121,68 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (1h40)",
-      "items": [
-        "(10 min) Icebreaker e alinhamento de objetivos.",
-        "(30 min) Showcase rápido: squads apresentam solução da triagem.",
-        "(20 min) Mesa de feedback cruzado com painel Start/Stop/Continue.",
-        "(15 min) Consolidação de boas práticas em mural coletivo.",
-        "(15 min) Redação de plano de ação individual.",
-        "(10 min) Compartilhamento voluntário e orientações finais."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Icebreaker e alinhamento de objetivos."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(30 min) Showcase rápido",
+          "content": "squads apresentam solução da triagem."
+        },
+        {
+          "icon": "check-circle",
+          "title": "20 min",
+          "content": "Mesa de feedback cruzado com painel Start/Stop/Continue."
+        },
+        {
+          "icon": "check-circle",
+          "title": "15 min",
+          "content": "Consolidação de boas práticas em mural coletivo."
+        },
+        {
+          "icon": "check-circle",
+          "title": "15 min",
+          "content": "Redação de plano de ação individual."
+        },
+        {
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Compartilhamento voluntário e orientações finais."
+        }
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Board 360° de feedback",
-      "cards": [
+      "items": [
         {
           "title": "Start",
-          "content": "Quais práticas iniciar a partir dos insights da triagem."
+          "content": "Quais práticas iniciar a partir dos insights da triagem.",
+          "language": "plaintext",
+          "code": "Quais práticas iniciar a partir dos insights da triagem."
         },
         {
           "title": "Stop",
-          "content": "Atividades que devem ser interrompidas ou revistas."
+          "content": "Atividades que devem ser interrompidas ou revistas.",
+          "language": "plaintext",
+          "code": "Atividades que devem ser interrompidas ou revistas."
         },
         {
           "title": "Continue",
-          "content": "Boas práticas que precisam ser mantidas."
+          "content": "Boas práticas que precisam ser mantidas.",
+          "language": "plaintext",
+          "code": "Boas práticas que precisam ser mantidas."
         },
         {
           "title": "Amplify",
-          "content": "Iniciativas que merecem investimento extra."
+          "content": "Iniciativas que merecem investimento extra.",
+          "language": "plaintext",
+          "code": "Iniciativas que merecem investimento extra."
         }
       ]
     },
@@ -176,34 +208,43 @@
       ]
     },
     {
-      "type": "videosBlock",
+      "type": "contentBlock",
       "title": "Inspirações",
-      "videos": [
+      "content": [
         {
-          "youtubeId": "Ud8Hksm_0vQ",
-          "title": "Como conduzir retrospectivas efetivas"
-        },
-        {
-          "youtubeId": "5nVvYw84yKc",
-          "title": "Feedback construtivo para times técnicos"
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Como conduzir retrospectivas efetivas – https://www.youtube.com/watch?v=Ud8Hksm_0vQ"
+            },
+            {
+              "text": "Feedback construtivo para times técnicos – https://www.youtube.com/watch?v=5nVvYw84yKc"
+            }
+          ]
         }
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Perguntas norteadoras",
-      "cards": [
+      "items": [
         {
           "title": "O que funcionou?",
-          "content": "Identifique práticas que devem continuar."
+          "content": "Identifique práticas que devem continuar.",
+          "language": "plaintext",
+          "code": "Identifique práticas que devem continuar."
         },
         {
           "title": "O que não funcionou?",
-          "content": "Liste obstáculos e gargalos encontrados."
+          "content": "Liste obstáculos e gargalos encontrados.",
+          "language": "plaintext",
+          "code": "Liste obstáculos e gargalos encontrados."
         },
         {
           "title": "O que mudar agora?",
-          "content": "Defina ações concretas para o próximo módulo."
+          "content": "Defina ações concretas para o próximo módulo.",
+          "language": "plaintext",
+          "code": "Defina ações concretas para o próximo módulo."
         }
       ]
     },
@@ -223,24 +264,32 @@
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Compromissos pós-aula",
-      "cards": [
+      "items": [
         {
           "title": "Estudos complementares",
-          "content": "Agende revisão sobre funções antes do próximo módulo."
+          "content": "Agende revisão sobre funções antes do próximo módulo.",
+          "language": "plaintext",
+          "code": "Agende revisão sobre funções antes do próximo módulo."
         },
         {
           "title": "Dupla de responsabilidade",
-          "content": "Combine check-ins quinzenais com um colega."
+          "content": "Combine check-ins quinzenais com um colega.",
+          "language": "plaintext",
+          "code": "Combine check-ins quinzenais com um colega."
         },
         {
           "title": "Aplicação prática",
-          "content": "Selecione um projeto pessoal para aplicar laços e logs."
+          "content": "Selecione um projeto pessoal para aplicar laços e logs.",
+          "language": "plaintext",
+          "code": "Selecione um projeto pessoal para aplicar laços e logs."
         },
         {
           "title": "Monitoria",
-          "content": "Reserve horário na monitoria para dúvidas pendentes."
+          "content": "Reserve horário na monitoria para dúvidas pendentes.",
+          "language": "plaintext",
+          "code": "Reserve horário na monitoria para dúvidas pendentes."
         }
       ]
     },

--- a/src/content/courses/algi/lessons/lesson-28.json
+++ b/src/content/courses/algi/lessons/lesson-28.json
@@ -124,15 +124,39 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (1h50)",
-      "items": [
-        "(10 min) Abertura: valor de manter funções pequenas e testáveis.",
-        "(20 min) Revisão demonstrativa: comparar função verbosa vs. refatorada.",
-        "(30 min) Rodada 1 de revisão cruzada com checklist.",
-        "(20 min) Coleta de métricas de cobertura/logs.",
-        "(20 min) Rodada 2 focada em naming e contratos.",
-        "(10 min) Síntese e definição de backlog preventivo."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "(10 min) Abertura",
+          "content": "valor de manter funções pequenas e testáveis."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(20 min) Revisão demonstrativa",
+          "content": "comparar função verbosa vs. refatorada."
+        },
+        {
+          "icon": "check-circle",
+          "title": "30 min",
+          "content": "Rodada 1 de revisão cruzada com checklist."
+        },
+        {
+          "icon": "check-circle",
+          "title": "20 min",
+          "content": "Coleta de métricas de cobertura/logs."
+        },
+        {
+          "icon": "check-circle",
+          "title": "20 min",
+          "content": "Rodada 2 focada em naming e contratos."
+        },
+        {
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Síntese e definição de backlog preventivo."
+        }
       ]
     },
     {
@@ -150,34 +174,43 @@
       ]
     },
     {
-      "type": "videosBlock",
+      "type": "contentBlock",
       "title": "Curadoria de vídeos",
-      "videos": [
+      "content": [
         {
-          "youtubeId": "E8I19uA-wGY",
-          "title": "Como revisar código de maneira efetiva"
-        },
-        {
-          "youtubeId": "s0g4ty29wqo",
-          "title": "Cobertura de testes em C com gcov"
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Como revisar código de maneira efetiva – https://www.youtube.com/watch?v=E8I19uA-wGY"
+            },
+            {
+              "text": "Cobertura de testes em C com gcov – https://www.youtube.com/watch?v=s0g4ty29wqo"
+            }
+          ]
         }
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Perguntas para revisão",
-      "cards": [
+      "items": [
         {
           "title": "Responsabilidade",
-          "content": "Esta função faz apenas uma coisa?"
+          "content": "Esta função faz apenas uma coisa?",
+          "language": "plaintext",
+          "code": "Esta função faz apenas uma coisa?"
         },
         {
           "title": "Testabilidade",
-          "content": "Há casos negativos cobrindo erros e limites?"
+          "content": "Há casos negativos cobrindo erros e limites?",
+          "language": "plaintext",
+          "code": "Há casos negativos cobrindo erros e limites?"
         },
         {
           "title": "Observabilidade",
-          "content": "Existe log ou retorno que ajude a diagnosticar problemas?"
+          "content": "Existe log ou retorno que ajude a diagnosticar problemas?",
+          "language": "plaintext",
+          "code": "Existe log ou retorno que ajude a diagnosticar problemas?"
         }
       ]
     },

--- a/src/content/courses/algi/lessons/lesson-30.json
+++ b/src/content/courses/algi/lessons/lesson-30.json
@@ -132,120 +132,167 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (1h50)",
-      "items": [
-        "(10 min) Icebreaker: cole o post-it com a palavra que associa a 'vetor'.",
-        "(20 min) Mini-aula: anatomia de um vetor em C.",
-        "(25 min) Demonstração no projetor: percorrendo o vetor e imprimindo índices.",
-        "(35 min) Oficina prática: cálculo de média/mínimo/máximo usando o CSV.",
-        "(10 min) Compartilhamento de resultados no quadro.",
-        "(10 min) Atividade pós-aula orientada."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "(10 min) Icebreaker",
+          "content": "cole o post-it com a palavra que associa a 'vetor'."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(20 min) Mini-aula",
+          "content": "anatomia de um vetor em C."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(25 min) Demonstração no projetor",
+          "content": "percorrendo o vetor e imprimindo índices."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(35 min) Oficina prática",
+          "content": "cálculo de média/mínimo/máximo usando o CSV."
+        },
+        {
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Compartilhamento de resultados no quadro."
+        },
+        {
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Atividade pós-aula orientada."
+        }
       ]
     },
     {
-      "type": "videosBlock",
+      "type": "contentBlock",
       "title": "Para revisar depois",
-      "videos": [
+      "content": [
         {
-          "youtubeId": "Q0qkBhe-Z4w",
-          "title": "CS50 Shorts - Arrays"
-        },
-        {
-          "youtubeId": "gQcW5Pg0TBM",
-          "title": "Array basics (Khan Academy)"
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "CS50 Shorts - Arrays – https://www.youtube.com/watch?v=Q0qkBhe-Z4w"
+            },
+            {
+              "text": "Array basics (Khan Academy) – https://www.youtube.com/watch?v=gQcW5Pg0TBM"
+            }
+          ]
         }
       ]
     },
     {
-      "type": "md3Table",
+      "type": "contentBlock",
       "title": "Sintaxe essencial do vetor em C",
-      "headers": ["Elemento", "Exemplo", "Observação"],
-      "rows": [
-        ["Declaração", "int notas[5];", "Cria vetor com 5 inteiros não inicializados."],
-        ["Inicialização", "float medias[3] = {7.2, 8.5, 6.9};", "Valores em ordem definida."],
-        ["Acesso", "notas[i]", "Índices iniciam em 0 e vão até tamanho-1."],
-        [
-          "Tamanho",
-          "sizeof(notas)/sizeof(notas[0])",
-          "Estratégia para calcular o número de posições."
-        ]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Elemento: Declaração | Exemplo: int notas[5]; | Observação: Cria vetor com 5 inteiros não inicializados."
+            },
+            {
+              "text": "Elemento: Inicialização | Exemplo: float medias[3] = {7.2, 8.5, 6.9}; | Observação: Valores em ordem definida."
+            },
+            {
+              "text": "Elemento: Acesso | Exemplo: notas[i] | Observação: Índices iniciam em 0 e vão até tamanho-1."
+            },
+            {
+              "text": "Elemento: Tamanho | Exemplo: sizeof(notas)/sizeof(notas[0]) | Observação: Estratégia para calcular o número de posições."
+            }
+          ]
+        }
       ]
     },
     {
-      "type": "md3Flowchart",
+      "type": "contentBlock",
       "title": "Fluxo do cálculo de média, mínimo e máximo",
-      "nodes": [
+      "content": [
         {
-          "id": "start",
-          "type": "start",
-          "label": "Início"
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Início – tipo: start"
+            },
+            {
+              "text": "Ler vetor de notas – tipo: process"
+            },
+            {
+              "text": "media = 0, min = notas[0], max = notas[0] – tipo: process"
+            },
+            {
+              "text": "Para i = 0 até n-1 – tipo: loop"
+            },
+            {
+              "text": "media += notas[i] – tipo: process"
+            },
+            {
+              "text": "notas[i] < min? – tipo: decision"
+            },
+            {
+              "text": "min = notas[i] – tipo: process"
+            },
+            {
+              "text": "notas[i] > max? – tipo: decision"
+            },
+            {
+              "text": "max = notas[i] – tipo: process"
+            },
+            {
+              "text": "media = media / n – tipo: process"
+            },
+            {
+              "text": "Fim – tipo: end"
+            }
+          ]
         },
         {
-          "id": "read",
-          "type": "process",
-          "label": "Ler vetor de notas"
-        },
-        {
-          "id": "init",
-          "type": "process",
-          "label": "media = 0, min = notas[0], max = notas[0]"
-        },
-        {
-          "id": "loop",
-          "type": "loop",
-          "label": "Para i = 0 até n-1"
-        },
-        {
-          "id": "acc",
-          "type": "process",
-          "label": "media += notas[i]"
-        },
-        {
-          "id": "min",
-          "type": "decision",
-          "label": "notas[i] < min?"
-        },
-        {
-          "id": "updateMin",
-          "type": "process",
-          "label": "min = notas[i]"
-        },
-        {
-          "id": "max",
-          "type": "decision",
-          "label": "notas[i] > max?"
-        },
-        {
-          "id": "updateMax",
-          "type": "process",
-          "label": "max = notas[i]"
-        },
-        {
-          "id": "calc",
-          "type": "process",
-          "label": "media = media / n"
-        },
-        {
-          "id": "end",
-          "type": "end",
-          "label": "Fim"
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "start → read"
+            },
+            {
+              "text": "read → init"
+            },
+            {
+              "text": "init → loop"
+            },
+            {
+              "text": "loop → acc"
+            },
+            {
+              "text": "acc → min"
+            },
+            {
+              "text": "min → updateMin – sim"
+            },
+            {
+              "text": "min → max – não"
+            },
+            {
+              "text": "updateMin → max"
+            },
+            {
+              "text": "max → updateMax – sim"
+            },
+            {
+              "text": "max → loop – não"
+            },
+            {
+              "text": "updateMax → loop"
+            },
+            {
+              "text": "loop → calc – fim"
+            },
+            {
+              "text": "calc → end"
+            }
+          ]
         }
-      ],
-      "edges": [
-        ["start", "read"],
-        ["read", "init"],
-        ["init", "loop"],
-        ["loop", "acc"],
-        ["acc", "min"],
-        ["min", "updateMin", "sim"],
-        ["min", "max", "não"],
-        ["updateMin", "max"],
-        ["max", "updateMax", "sim"],
-        ["max", "loop", "não"],
-        ["updateMax", "loop"],
-        ["loop", "calc", "fim"],
-        ["calc", "end"]
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-31.json
+++ b/src/content/courses/algi/lessons/lesson-31.json
@@ -146,47 +146,65 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (1h55)",
-      "items": [
-        "(10 min) Perguntas diagnósticas sobre Aula 30.",
-        "(20 min) Live coding: funções soma e média.",
-        "(25 min) Mini-projeto: normalizar vendas para percentual.",
-        "(30 min) Geração de tabela de frequência em MD3 Table.",
-        "(20 min) Rodada de revisão por pares.",
-        "(10 min) Atividade pós-aula guiada em sala virtual."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Perguntas diagnósticas sobre Aula 30."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(20 min) Live coding",
+          "content": "funções soma e média."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(25 min) Mini-projeto",
+          "content": "normalizar vendas para percentual."
+        },
+        {
+          "icon": "check-circle",
+          "title": "30 min",
+          "content": "Geração de tabela de frequência em MD3 Table."
+        },
+        {
+          "icon": "check-circle",
+          "title": "20 min",
+          "content": "Rodada de revisão por pares."
+        },
+        {
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Atividade pós-aula guiada em sala virtual."
+        }
       ]
     },
     {
-      "type": "md3Table",
+      "type": "contentBlock",
       "title": "Operações comuns sobre vetores",
-      "headers": ["Operação", "Assinatura sugerida", "Tempo", "Observações"],
-      "rows": [
-        ["Somatório", "int soma(int v[], int n)", "O(n)", "Retorna a soma, não altera o vetor."],
-        [
-          "Cópia",
-          "void copia(int origem[], int destino[], int n)",
-          "O(n)",
-          "Necessário vetor destino previamente alocado."
-        ],
-        [
-          "Normalização",
-          "void normaliza(float v[], int n)",
-          "O(n)",
-          "Divide cada posição pelo somatório total."
-        ],
-        [
-          "Média móvel",
-          "void mediaMovel(float v[], int n, int janela, float saida[])",
-          "O(n)",
-          "Requer vetor auxiliar para resultados."
-        ],
-        [
-          "Busca maior",
-          "int indiceMaior(float v[], int n)",
-          "O(n)",
-          "Retorna índice do maior elemento."
-        ]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Operação: Somatório | Assinatura sugerida: int soma(int v[], int n) | Tempo: O(n) | Observações: Retorna a soma, não altera o vetor."
+            },
+            {
+              "text": "Operação: Cópia | Assinatura sugerida: void copia(int origem[], int destino[], int n) | Tempo: O(n) | Observações: Necessário vetor destino previamente alocado."
+            },
+            {
+              "text": "Operação: Normalização | Assinatura sugerida: void normaliza(float v[], int n) | Tempo: O(n) | Observações: Divide cada posição pelo somatório total."
+            },
+            {
+              "text": "Operação: Média móvel | Assinatura sugerida: void mediaMovel(float v[], int n, int janela, float saida[]) | Tempo: O(n) | Observações: Requer vetor auxiliar para resultados."
+            },
+            {
+              "text": "Operação: Busca maior | Assinatura sugerida: int indiceMaior(float v[], int n) | Tempo: O(n) | Observações: Retorna índice do maior elemento."
+            }
+          ]
+        }
       ]
     },
     {
@@ -218,54 +236,64 @@
       ]
     },
     {
-      "type": "md3Flowchart",
+      "type": "contentBlock",
       "title": "Fluxo de normalização do vetor",
-      "nodes": [
+      "content": [
         {
-          "id": "start",
-          "type": "start",
-          "label": "Início"
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Início – tipo: start"
+            },
+            {
+              "text": "total = soma(v) – tipo: process"
+            },
+            {
+              "text": "total == 0? – tipo: decision"
+            },
+            {
+              "text": "Se zero, emitir aviso – tipo: process"
+            },
+            {
+              "text": "Para i = 0 até n-1 – tipo: loop"
+            },
+            {
+              "text": "v[i] = v[i] / total – tipo: process"
+            },
+            {
+              "text": "Fim – tipo: end"
+            }
+          ]
         },
         {
-          "id": "sum",
-          "type": "process",
-          "label": "total = soma(v)"
-        },
-        {
-          "id": "decision",
-          "type": "decision",
-          "label": "total == 0?"
-        },
-        {
-          "id": "guard",
-          "type": "process",
-          "label": "Se zero, emitir aviso"
-        },
-        {
-          "id": "loop",
-          "type": "loop",
-          "label": "Para i = 0 até n-1"
-        },
-        {
-          "id": "norm",
-          "type": "process",
-          "label": "v[i] = v[i] / total"
-        },
-        {
-          "id": "end",
-          "type": "end",
-          "label": "Fim"
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "start → sum"
+            },
+            {
+              "text": "sum → decision"
+            },
+            {
+              "text": "decision → guard – sim"
+            },
+            {
+              "text": "decision → loop – não"
+            },
+            {
+              "text": "guard → end"
+            },
+            {
+              "text": "loop → norm"
+            },
+            {
+              "text": "norm → loop"
+            },
+            {
+              "text": "loop → end – fim"
+            }
+          ]
         }
-      ],
-      "edges": [
-        ["start", "sum"],
-        ["sum", "decision"],
-        ["decision", "guard", "sim"],
-        ["decision", "loop", "não"],
-        ["guard", "end"],
-        ["loop", "norm"],
-        ["norm", "loop"],
-        ["loop", "end", "fim"]
       ]
     },
     {
@@ -294,16 +322,19 @@
       ]
     },
     {
-      "type": "videosBlock",
+      "type": "contentBlock",
       "title": "Clipes recomendados",
-      "videos": [
+      "content": [
         {
-          "youtubeId": "N-0At__Wwzg",
-          "title": "CS50 Lab Arrays"
-        },
-        {
-          "youtubeId": "mYVz5ZdGJ0s",
-          "title": "Khan Academy - Frequency tables"
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "CS50 Lab Arrays – https://www.youtube.com/watch?v=N-0At__Wwzg"
+            },
+            {
+              "text": "Khan Academy - Frequency tables – https://www.youtube.com/watch?v=mYVz5ZdGJ0s"
+            }
+          ]
         }
       ]
     },

--- a/src/content/courses/algi/lessons/lesson-32.json
+++ b/src/content/courses/algi/lessons/lesson-32.json
@@ -166,87 +166,126 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (1h50)",
-      "items": [
-        "(10 min) Aquecimento com estimativas de busca.",
-        "(20 min) Demonstração da função buscaLinear no dataset.",
-        "(20 min) Refatoração para versão com sentinela.",
-        "(30 min) Laboratório: medir comparações para elementos existentes e ausentes.",
-        "(20 min) Discussão guiada sobre eficiência.",
-        "(10 min) Briefing da atividade pós-aula."
-      ]
-    },
-    {
-      "type": "md3Table",
-      "title": "Comparativo de variantes de busca",
-      "headers": ["Algoritmo", "Pré-condição", "Retorno", "Comparações médias"],
-      "rows": [
-        ["Linear simples", "Vetor não ordenado", "Índice ou -1", "n/2"],
-        [
-          "Linear com sentinela",
-          "Vetor não ordenado com espaço extra",
-          "Índice ou n",
-          "n/2 (menos checagens de limite)"
-        ],
-        ["Busca binária", "Vetor ordenado", "Índice ou -1", "log2 n"]
-      ]
-    },
-    {
-      "type": "md3Flowchart",
-      "title": "Fluxograma da busca linear",
-      "nodes": [
+      "cards": [
         {
-          "id": "start",
-          "type": "start",
-          "label": "Início"
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Aquecimento com estimativas de busca."
         },
         {
-          "id": "init",
-          "type": "process",
-          "label": "i = 0"
+          "icon": "check-circle",
+          "title": "20 min",
+          "content": "Demonstração da função buscaLinear no dataset."
         },
         {
-          "id": "loop",
-          "type": "loop",
-          "label": "Enquanto i < n"
+          "icon": "check-circle",
+          "title": "20 min",
+          "content": "Refatoração para versão com sentinela."
         },
         {
-          "id": "decision",
-          "type": "decision",
-          "label": "v[i] == chave?"
+          "icon": "check-circle",
+          "title": "(30 min) Laboratório",
+          "content": "medir comparações para elementos existentes e ausentes."
         },
         {
-          "id": "found",
-          "type": "process",
-          "label": "Retornar i"
+          "icon": "check-circle",
+          "title": "20 min",
+          "content": "Discussão guiada sobre eficiência."
         },
         {
-          "id": "inc",
-          "type": "process",
-          "label": "i++"
-        },
-        {
-          "id": "notfound",
-          "type": "process",
-          "label": "Retornar -1"
-        },
-        {
-          "id": "end",
-          "type": "end",
-          "label": "Fim"
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Briefing da atividade pós-aula."
         }
-      ],
-      "edges": [
-        ["start", "init"],
-        ["init", "loop"],
-        ["loop", "decision"],
-        ["decision", "found", "sim"],
-        ["decision", "inc", "não"],
-        ["inc", "loop"],
-        ["loop", "notfound", "fim"],
-        ["notfound", "end"],
-        ["found", "end"]
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Comparativo de variantes de busca",
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Algoritmo: Linear simples | Pré-condição: Vetor não ordenado | Retorno: Índice ou -1 | Comparações médias: n/2"
+            },
+            {
+              "text": "Algoritmo: Linear com sentinela | Pré-condição: Vetor não ordenado com espaço extra | Retorno: Índice ou n | Comparações médias: n/2 (menos checagens de limite)"
+            },
+            {
+              "text": "Algoritmo: Busca binária | Pré-condição: Vetor ordenado | Retorno: Índice ou -1 | Comparações médias: log2 n"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Fluxograma da busca linear",
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Início – tipo: start"
+            },
+            {
+              "text": "i = 0 – tipo: process"
+            },
+            {
+              "text": "Enquanto i < n – tipo: loop"
+            },
+            {
+              "text": "v[i] == chave? – tipo: decision"
+            },
+            {
+              "text": "Retornar i – tipo: process"
+            },
+            {
+              "text": "i++ – tipo: process"
+            },
+            {
+              "text": "Retornar -1 – tipo: process"
+            },
+            {
+              "text": "Fim – tipo: end"
+            }
+          ]
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "start → init"
+            },
+            {
+              "text": "init → loop"
+            },
+            {
+              "text": "loop → decision"
+            },
+            {
+              "text": "decision → found – sim"
+            },
+            {
+              "text": "decision → inc – não"
+            },
+            {
+              "text": "inc → loop"
+            },
+            {
+              "text": "loop → notfound – fim"
+            },
+            {
+              "text": "notfound → end"
+            },
+            {
+              "text": "found → end"
+            }
+          ]
+        }
       ]
     },
     {
@@ -274,16 +313,19 @@
       ]
     },
     {
-      "type": "videosBlock",
+      "type": "contentBlock",
       "title": "Recomendações de estudo",
-      "videos": [
+      "content": [
         {
-          "youtubeId": "9YddVVsdG5A",
-          "title": "CS50 Shorts - Linear Search"
-        },
-        {
-          "youtubeId": "qN3b9YzKz7w",
-          "title": "Khan Academy - Linear search walkthrough"
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "CS50 Shorts - Linear Search – https://www.youtube.com/watch?v=9YddVVsdG5A"
+            },
+            {
+              "text": "Khan Academy - Linear search walkthrough – https://www.youtube.com/watch?v=qN3b9YzKz7w"
+            }
+          ]
         }
       ]
     },

--- a/src/content/courses/algi/lessons/lesson-33.json
+++ b/src/content/courses/algi/lessons/lesson-33.json
@@ -128,96 +128,144 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (1h55)",
-      "items": [
-        "(10 min) Warm-up com quiz sobre índices.",
-        "(20 min) Aula expositiva com slides e md3Table de sintaxe.",
-        "(25 min) Demonstração de loops aninhados em C.",
-        "(30 min) Oficina: gerar tabela de presença a partir do CSV.",
-        "(20 min) Revisão de código em duplas.",
-        "(10 min) Orientação da prática pós-aula."
-      ]
-    },
-    {
-      "type": "md3Table",
-      "title": "Sintaxe de matrizes em C",
-      "headers": ["Elemento", "Exemplo", "Descrição"],
-      "rows": [
-        ["Declaração", "int matriz[3][4];", "3 linhas, 4 colunas não inicializadas."],
-        ["Inicialização", "int notas[2][3] = {{7,8,9},{6,5,10}};", "Valores linha a linha."],
-        ["Acesso", "matriz[i][j]", "Primeiro índice = linha, segundo = coluna."],
-        ["Percurso", "for (i) for (j)", "Loops aninhados para percorrer todos os elementos."],
-        ["Constante de coluna", "#define COL 4", "Facilita manutenção de dimensões."]
-      ]
-    },
-    {
-      "type": "md3Flowchart",
-      "title": "Fluxograma de impressão da matriz",
-      "nodes": [
+      "cards": [
         {
-          "id": "start",
-          "type": "start",
-          "label": "Início"
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Warm-up com quiz sobre índices."
         },
         {
-          "id": "initI",
-          "type": "process",
-          "label": "i = 0"
+          "icon": "check-circle",
+          "title": "20 min",
+          "content": "Aula expositiva com slides e md3Table de sintaxe."
         },
         {
-          "id": "loopI",
-          "type": "loop",
-          "label": "Enquanto i < linhas"
+          "icon": "check-circle",
+          "title": "25 min",
+          "content": "Demonstração de loops aninhados em C."
         },
         {
-          "id": "initJ",
-          "type": "process",
-          "label": "j = 0"
+          "icon": "check-circle",
+          "title": "(30 min) Oficina",
+          "content": "gerar tabela de presença a partir do CSV."
         },
         {
-          "id": "loopJ",
-          "type": "loop",
-          "label": "Enquanto j < colunas"
+          "icon": "check-circle",
+          "title": "20 min",
+          "content": "Revisão de código em duplas."
         },
         {
-          "id": "print",
-          "type": "process",
-          "label": "Imprimir matriz[i][j]"
-        },
-        {
-          "id": "incJ",
-          "type": "process",
-          "label": "j++"
-        },
-        {
-          "id": "newline",
-          "type": "process",
-          "label": "Imprimir \n"
-        },
-        {
-          "id": "incI",
-          "type": "process",
-          "label": "i++"
-        },
-        {
-          "id": "end",
-          "type": "end",
-          "label": "Fim"
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Orientação da prática pós-aula."
         }
-      ],
-      "edges": [
-        ["start", "initI"],
-        ["initI", "loopI"],
-        ["loopI", "initJ"],
-        ["initJ", "loopJ"],
-        ["loopJ", "print"],
-        ["print", "incJ"],
-        ["incJ", "loopJ"],
-        ["loopJ", "newline", "fim"],
-        ["newline", "incI"],
-        ["incI", "loopI"],
-        ["loopI", "end", "fim"]
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Sintaxe de matrizes em C",
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Elemento: Declaração | Exemplo: int matriz[3][4]; | Descrição: 3 linhas, 4 colunas não inicializadas."
+            },
+            {
+              "text": "Elemento: Inicialização | Exemplo: int notas[2][3] = {{7,8,9},{6,5,10}}; | Descrição: Valores linha a linha."
+            },
+            {
+              "text": "Elemento: Acesso | Exemplo: matriz[i][j] | Descrição: Primeiro índice = linha, segundo = coluna."
+            },
+            {
+              "text": "Elemento: Percurso | Exemplo: for (i) for (j) | Descrição: Loops aninhados para percorrer todos os elementos."
+            },
+            {
+              "text": "Elemento: Constante de coluna | Exemplo: #define COL 4 | Descrição: Facilita manutenção de dimensões."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Fluxograma de impressão da matriz",
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Início – tipo: start"
+            },
+            {
+              "text": "i = 0 – tipo: process"
+            },
+            {
+              "text": "Enquanto i < linhas – tipo: loop"
+            },
+            {
+              "text": "j = 0 – tipo: process"
+            },
+            {
+              "text": "Enquanto j < colunas – tipo: loop"
+            },
+            {
+              "text": "Imprimir matriz[i][j] – tipo: process"
+            },
+            {
+              "text": "j++ – tipo: process"
+            },
+            {
+              "text": "Imprimir – tipo: process"
+            },
+            {
+              "text": "i++ – tipo: process"
+            },
+            {
+              "text": "Fim – tipo: end"
+            }
+          ]
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "start → initI"
+            },
+            {
+              "text": "initI → loopI"
+            },
+            {
+              "text": "loopI → initJ"
+            },
+            {
+              "text": "initJ → loopJ"
+            },
+            {
+              "text": "loopJ → print"
+            },
+            {
+              "text": "print → incJ"
+            },
+            {
+              "text": "incJ → loopJ"
+            },
+            {
+              "text": "loopJ → newline – fim"
+            },
+            {
+              "text": "newline → incI"
+            },
+            {
+              "text": "incI → loopI"
+            },
+            {
+              "text": "loopI → end – fim"
+            }
+          ]
+        }
       ]
     },
     {
@@ -245,16 +293,19 @@
       ]
     },
     {
-      "type": "videosBlock",
+      "type": "contentBlock",
       "title": "Para continuar estudando",
-      "videos": [
+      "content": [
         {
-          "youtubeId": "Q0qkBhe-Z4w",
-          "title": "CS50 2023 - Arrays (trecho de matrizes)"
-        },
-        {
-          "youtubeId": "0oGJTQCy4cQ",
-          "title": "Khan Academy - Introdução a matrizes"
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "CS50 2023 - Arrays (trecho de matrizes) – https://www.youtube.com/watch?v=Q0qkBhe-Z4w"
+            },
+            {
+              "text": "Khan Academy - Introdução a matrizes – https://www.youtube.com/watch?v=0oGJTQCy4cQ"
+            }
+          ]
         }
       ]
     },

--- a/src/content/courses/algi/lessons/lesson-34.json
+++ b/src/content/courses/algi/lessons/lesson-34.json
@@ -163,159 +163,186 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (2h00)",
-      "items": [
-        "(10 min) Check-in com quiz sobre matrizes.",
-        "(20 min) Código ao vivo da função transpose.",
-        "(15 min) Exercício individual: soma de matrizes.",
-        "(35 min) Workshop: multiplicação com validação de dimensões.",
-        "(25 min) Estudo de caso: combinar matrizes de indicadores do JSON.",
-        "(15 min) Apresentação rápida dos resultados por squads."
-      ]
-    },
-    {
-      "type": "md3Table",
-      "title": "Operações com matrizes",
-      "headers": ["Operação", "Pré-condição", "Assinatura sugerida", "Observações"],
-      "rows": [
-        [
-          "Transposição",
-          "Matriz m x n",
-          "void transpose(int src[m][n], int dst[n][m])",
-          "Usar matrizes distintas para evitar sobrescrita."
-        ],
-        [
-          "Soma",
-          "Mesmas dimensões",
-          "void add(int A[m][n], int B[m][n], int C[m][n])",
-          "Executar operação elemento a elemento."
-        ],
-        [
-          "Subtração",
-          "Mesmas dimensões",
-          "void subtract(int A[m][n], int B[m][n], int C[m][n])",
-          "Útil para variação entre indicadores."
-        ],
-        [
-          "Multiplicação",
-          "A m x n, B n x p",
-          "void multiply(int A[m][n], int B[n][p], int C[m][p])",
-          "Três loops e acumulador local."
-        ],
-        [
-          "Escalonamento",
-          "Qualquer dimensão",
-          "void scale(float A[m][n], float fator)",
-          "Multiplica cada elemento pelo fator."
-        ]
-      ]
-    },
-    {
-      "type": "md3Flowchart",
-      "title": "Fluxograma da multiplicação de matrizes",
-      "nodes": [
+      "cards": [
         {
-          "id": "start",
-          "type": "start",
-          "label": "Início"
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Check-in com quiz sobre matrizes."
         },
         {
-          "id": "check",
-          "type": "decision",
-          "label": "n == colunasA && n == linhasB?"
+          "icon": "check-circle",
+          "title": "20 min",
+          "content": "Código ao vivo da função transpose."
         },
         {
-          "id": "error",
-          "type": "process",
-          "label": "Exibir erro de dimensão"
+          "icon": "check-circle",
+          "title": "(15 min) Exercício individual",
+          "content": "soma de matrizes."
         },
         {
-          "id": "initI",
-          "type": "process",
-          "label": "i = 0"
+          "icon": "check-circle",
+          "title": "(35 min) Workshop",
+          "content": "multiplicação com validação de dimensões."
         },
         {
-          "id": "loopI",
-          "type": "loop",
-          "label": "Enquanto i < m"
+          "icon": "check-circle",
+          "title": "(25 min) Estudo de caso",
+          "content": "combinar matrizes de indicadores do JSON."
         },
         {
-          "id": "initJ",
-          "type": "process",
-          "label": "j = 0"
-        },
-        {
-          "id": "loopJ",
-          "type": "loop",
-          "label": "Enquanto j < p"
-        },
-        {
-          "id": "acc",
-          "type": "process",
-          "label": "soma = 0"
-        },
-        {
-          "id": "initK",
-          "type": "process",
-          "label": "k = 0"
-        },
-        {
-          "id": "loopK",
-          "type": "loop",
-          "label": "Enquanto k < n"
-        },
-        {
-          "id": "mul",
-          "type": "process",
-          "label": "soma += A[i][k] * B[k][j]"
-        },
-        {
-          "id": "incK",
-          "type": "process",
-          "label": "k++"
-        },
-        {
-          "id": "assign",
-          "type": "process",
-          "label": "C[i][j] = soma"
-        },
-        {
-          "id": "incJ",
-          "type": "process",
-          "label": "j++"
-        },
-        {
-          "id": "incI",
-          "type": "process",
-          "label": "i++"
-        },
-        {
-          "id": "end",
-          "type": "end",
-          "label": "Fim"
+          "icon": "check-circle",
+          "title": "15 min",
+          "content": "Apresentação rápida dos resultados por squads."
         }
-      ],
-      "edges": [
-        ["start", "check"],
-        ["check", "error", "não"],
-        ["error", "end"],
-        ["check", "initI", "sim"],
-        ["initI", "loopI"],
-        ["loopI", "initJ"],
-        ["initJ", "loopJ"],
-        ["loopJ", "acc"],
-        ["acc", "initK"],
-        ["initK", "loopK"],
-        ["loopK", "mul"],
-        ["mul", "incK"],
-        ["incK", "loopK"],
-        ["loopK", "assign", "fim"],
-        ["assign", "incJ"],
-        ["incJ", "loopJ"],
-        ["loopJ", "incI", "fim"],
-        ["incI", "loopI"],
-        ["loopI", "end", "fim"]
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Operações com matrizes",
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Operação: Transposição | Pré-condição: Matriz m x n | Assinatura sugerida: void transpose(int src[m][n], int dst[n][m]) | Observações: Usar matrizes distintas para evitar sobrescrita."
+            },
+            {
+              "text": "Operação: Soma | Pré-condição: Mesmas dimensões | Assinatura sugerida: void add(int A[m][n], int B[m][n], int C[m][n]) | Observações: Executar operação elemento a elemento."
+            },
+            {
+              "text": "Operação: Subtração | Pré-condição: Mesmas dimensões | Assinatura sugerida: void subtract(int A[m][n], int B[m][n], int C[m][n]) | Observações: Útil para variação entre indicadores."
+            },
+            {
+              "text": "Operação: Multiplicação | Pré-condição: A m x n, B n x p | Assinatura sugerida: void multiply(int A[m][n], int B[n][p], int C[m][p]) | Observações: Três loops e acumulador local."
+            },
+            {
+              "text": "Operação: Escalonamento | Pré-condição: Qualquer dimensão | Assinatura sugerida: void scale(float A[m][n], float fator) | Observações: Multiplica cada elemento pelo fator."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Fluxograma da multiplicação de matrizes",
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Início – tipo: start"
+            },
+            {
+              "text": "n == colunasA && n == linhasB? – tipo: decision"
+            },
+            {
+              "text": "Exibir erro de dimensão – tipo: process"
+            },
+            {
+              "text": "i = 0 – tipo: process"
+            },
+            {
+              "text": "Enquanto i < m – tipo: loop"
+            },
+            {
+              "text": "j = 0 – tipo: process"
+            },
+            {
+              "text": "Enquanto j < p – tipo: loop"
+            },
+            {
+              "text": "soma = 0 – tipo: process"
+            },
+            {
+              "text": "k = 0 – tipo: process"
+            },
+            {
+              "text": "Enquanto k < n – tipo: loop"
+            },
+            {
+              "text": "soma += A[i][k] * B[k][j] – tipo: process"
+            },
+            {
+              "text": "k++ – tipo: process"
+            },
+            {
+              "text": "C[i][j] = soma – tipo: process"
+            },
+            {
+              "text": "j++ – tipo: process"
+            },
+            {
+              "text": "i++ – tipo: process"
+            },
+            {
+              "text": "Fim – tipo: end"
+            }
+          ]
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "start → check"
+            },
+            {
+              "text": "check → error – não"
+            },
+            {
+              "text": "error → end"
+            },
+            {
+              "text": "check → initI – sim"
+            },
+            {
+              "text": "initI → loopI"
+            },
+            {
+              "text": "loopI → initJ"
+            },
+            {
+              "text": "initJ → loopJ"
+            },
+            {
+              "text": "loopJ → acc"
+            },
+            {
+              "text": "acc → initK"
+            },
+            {
+              "text": "initK → loopK"
+            },
+            {
+              "text": "loopK → mul"
+            },
+            {
+              "text": "mul → incK"
+            },
+            {
+              "text": "incK → loopK"
+            },
+            {
+              "text": "loopK → assign – fim"
+            },
+            {
+              "text": "assign → incJ"
+            },
+            {
+              "text": "incJ → loopJ"
+            },
+            {
+              "text": "loopJ → incI – fim"
+            },
+            {
+              "text": "incI → loopI"
+            },
+            {
+              "text": "loopI → end – fim"
+            }
+          ]
+        }
       ]
     },
     {
@@ -343,16 +370,19 @@
       ]
     },
     {
-      "type": "videosBlock",
+      "type": "contentBlock",
       "title": "Referências audiovisuais",
-      "videos": [
+      "content": [
         {
-          "youtubeId": "ykP1t9hYx7A",
-          "title": "CS50 Short - Matrix Multiplication"
-        },
-        {
-          "youtubeId": "zjMuIxRvygQ",
-          "title": "Khan Academy - Matrix multiplication"
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "CS50 Short - Matrix Multiplication – https://www.youtube.com/watch?v=ykP1t9hYx7A"
+            },
+            {
+              "text": "Khan Academy - Matrix multiplication – https://www.youtube.com/watch?v=zjMuIxRvygQ"
+            }
+          ]
         }
       ]
     },

--- a/src/content/courses/algi/lessons/lesson-35.json
+++ b/src/content/courses/algi/lessons/lesson-35.json
@@ -129,52 +129,65 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (1h55)",
-      "items": [
-        "(10 min) Icebreaker com cartões de atributos empresariais.",
-        "(20 min) Live coding: declaração e inicialização de Empresa.",
-        "(15 min) Exercício individual: função para imprimir struct formatada.",
-        "(30 min) Laboratório guiado: operações create/list com vetor local.",
-        "(20 min) Debriefing: decisões de modelagem e validação de dados.",
-        "(20 min) Check-out com quiz interativo (Kahoot) sobre sintaxe de structs."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Icebreaker com cartões de atributos empresariais."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(20 min) Live coding",
+          "content": "declaração e inicialização de Empresa."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(15 min) Exercício individual",
+          "content": "função para imprimir struct formatada."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(30 min) Laboratório guiado",
+          "content": "operações create/list com vetor local."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(20 min) Debriefing",
+          "content": "decisões de modelagem e validação de dados."
+        },
+        {
+          "icon": "check-circle",
+          "title": "20 min",
+          "content": "Check-out com quiz interativo (Kahoot) sobre sintaxe de structs."
+        }
       ]
     },
     {
-      "type": "md3Table",
+      "type": "contentBlock",
       "title": "Componentes essenciais de um registro",
-      "headers": ["Elemento", "Descrição", "Exemplo", "Boas práticas"],
-      "rows": [
-        [
-          "Campos",
-          "Definem as informações necessárias do domínio.",
-          "int id; char nome[64];",
-          "Escolha tipos apropriados e limites realistas."
-        ],
-        [
-          "Typedef",
-          "Simplifica a declaração de variáveis do registro.",
-          "typedef struct { ... } Empresa;",
-          "Use nomes no singular representando a entidade."
-        ],
-        [
-          "Funções auxiliares",
-          "Centralizam operações comuns sobre o registro.",
-          "void imprimir(const Empresa *e);",
-          "Evite duplicar prints/formatos no código."
-        ],
-        [
-          "Constantes",
-          "Guardam limites e tamanhos máximos.",
-          "#define MAX_EMPRESAS 50",
-          "Documente o motivo do limite em comentários."
-        ],
-        [
-          "Documentação",
-          "Explica finalidade e origem dos campos.",
-          "// Faturamento médio mensal (R$)",
-          "Padronize comentários para revisão coletiva."
-        ]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Elemento: Campos | Descrição: Definem as informações necessárias do domínio. | Exemplo: int id; char nome[64]; | Boas práticas: Escolha tipos apropriados e limites realistas."
+            },
+            {
+              "text": "Elemento: Typedef | Descrição: Simplifica a declaração de variáveis do registro. | Exemplo: typedef struct { ... } Empresa; | Boas práticas: Use nomes no singular representando a entidade."
+            },
+            {
+              "text": "Elemento: Funções auxiliares | Descrição: Centralizam operações comuns sobre o registro. | Exemplo: void imprimir(const Empresa *e); | Boas práticas: Evite duplicar prints/formatos no código."
+            },
+            {
+              "text": "Elemento: Constantes | Descrição: Guardam limites e tamanhos máximos. | Exemplo: #define MAX_EMPRESAS 50 | Boas práticas: Documente o motivo do limite em comentários."
+            },
+            {
+              "text": "Elemento: Documentação | Descrição: Explica finalidade e origem dos campos. | Exemplo: // Faturamento médio mensal (R$) | Boas práticas: Padronize comentários para revisão coletiva."
+            }
+          ]
+        }
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-36.json
+++ b/src/content/courses/algi/lessons/lesson-36.json
@@ -166,52 +166,65 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (2h00)",
-      "items": [
-        "(15 min) Icebreaker com cards de dados reais SEBRAE.",
-        "(20 min) Live coding: carga inicial do vetor com dados fictícios.",
-        "(25 min) Oficina: implementar função de ordenação crescente por faturamento.",
-        "(30 min) Laboratório orientado: integrar ordenação ao menu CRUD.",
-        "(20 min) Relato rápido por squads: métricas derivadas do vetor.",
-        "(10 min) Quiz interativo sobre complexidade e estabilidade de ordenações."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "15 min",
+          "content": "Icebreaker com cards de dados reais SEBRAE."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(20 min) Live coding",
+          "content": "carga inicial do vetor com dados fictícios."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(25 min) Oficina",
+          "content": "implementar função de ordenação crescente por faturamento."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(30 min) Laboratório orientado",
+          "content": "integrar ordenação ao menu CRUD."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(20 min) Relato rápido por squads",
+          "content": "métricas derivadas do vetor."
+        },
+        {
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Quiz interativo sobre complexidade e estabilidade de ordenações."
+        }
       ]
     },
     {
-      "type": "md3Table",
+      "type": "contentBlock",
       "title": "Estratégias de ordenação para vetores de structs",
-      "headers": ["Algoritmo", "Quando usar", "Custo", "Observações"],
-      "rows": [
-        [
-          "Bubble Sort",
-          "Listas pequenas e necessidade de implementação rápida",
-          "O(n^2)",
-          "Fácil de adaptar para ordenação decrescente."
-        ],
-        [
-          "Insertion Sort",
-          "Coleções quase ordenadas",
-          "O(n^2)",
-          "Bom para inserir novos registros mantendo a ordem."
-        ],
-        [
-          "qsort (stdlib)",
-          "Quando o custo de implementação importa",
-          "O(n log n)",
-          "Exige comparador consistente e inclui ponteiros void."
-        ],
-        [
-          "Selection Sort",
-          "Situações de memória crítica",
-          "O(n^2)",
-          "Poucas trocas, útil para dados estáticos."
-        ],
-        [
-          "Counting Sort",
-          "Campos inteiros com domínio pequeno",
-          "O(n + k)",
-          "Requer estrutura auxiliar e limites bem definidos."
-        ]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Algoritmo: Bubble Sort | Quando usar: Listas pequenas e necessidade de implementação rápida | Custo: O(n^2) | Observações: Fácil de adaptar para ordenação decrescente."
+            },
+            {
+              "text": "Algoritmo: Insertion Sort | Quando usar: Coleções quase ordenadas | Custo: O(n^2) | Observações: Bom para inserir novos registros mantendo a ordem."
+            },
+            {
+              "text": "Algoritmo: qsort (stdlib) | Quando usar: Quando o custo de implementação importa | Custo: O(n log n) | Observações: Exige comparador consistente e inclui ponteiros void."
+            },
+            {
+              "text": "Algoritmo: Selection Sort | Quando usar: Situações de memória crítica | Custo: O(n^2) | Observações: Poucas trocas, útil para dados estáticos."
+            },
+            {
+              "text": "Algoritmo: Counting Sort | Quando usar: Campos inteiros com domínio pequeno | Custo: O(n + k) | Observações: Requer estrutura auxiliar e limites bem definidos."
+            }
+          ]
+        }
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-37.json
+++ b/src/content/courses/algi/lessons/lesson-37.json
@@ -146,15 +146,39 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (2h05)",
-      "items": [
-        "(15 min) Estudo de caso: empresas que cresceram segundo IBGE.",
-        "(25 min) Live coding: busca por id com retorno de ponteiro.",
-        "(30 min) Oficina: atualização de faturamento com logs de alterações.",
-        "(25 min) Laboratório: remoção e compactação do vetor com relatório automático.",
-        "(20 min) Testes cruzados entre squads (pair review).",
-        "(10 min) Reflexão escrita sobre integridade e auditoria."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "(15 min) Estudo de caso",
+          "content": "empresas que cresceram segundo IBGE."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(25 min) Live coding",
+          "content": "busca por id com retorno de ponteiro."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(30 min) Oficina",
+          "content": "atualização de faturamento com logs de alterações."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(25 min) Laboratório",
+          "content": "remoção e compactação do vetor com relatório automático."
+        },
+        {
+          "icon": "check-circle",
+          "title": "20 min",
+          "content": "Testes cruzados entre squads (pair review)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Reflexão escrita sobre integridade e auditoria."
+        }
       ]
     },
     {
@@ -186,40 +210,29 @@
       ]
     },
     {
-      "type": "md3Table",
+      "type": "contentBlock",
       "title": "Padrões de retorno para operações CRUD",
-      "headers": ["Operação", "Retorno sugerido", "Descrição", "Quando aplicar"],
-      "rows": [
-        [
-          "create",
-          "int (novo tamanho)",
-          "Incrementa contador e retorna total de registros.",
-          "Ao inserir no fim do vetor."
-        ],
-        [
-          "read",
-          "int (índice) ou ponteiro",
-          "Localiza registro e permite inspeção.",
-          "Quando busca por id ou prefixo."
-        ],
-        [
-          "update",
-          "bool",
-          "Indica sucesso/falha após validações.",
-          "Atualização de campos sensíveis."
-        ],
-        [
-          "delete",
-          "bool",
-          "Retorna sucesso após compactação.",
-          "Remoção física movendo elementos."
-        ],
-        [
-          "auditLog",
-          "void",
-          "Gera linha de log com contexto da alteração.",
-          "Chamar após operações críticas."
-        ]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Operação: create | Retorno sugerido: int (novo tamanho) | Descrição: Incrementa contador e retorna total de registros. | Quando aplicar: Ao inserir no fim do vetor."
+            },
+            {
+              "text": "Operação: read | Retorno sugerido: int (índice) ou ponteiro | Descrição: Localiza registro e permite inspeção. | Quando aplicar: Quando busca por id ou prefixo."
+            },
+            {
+              "text": "Operação: update | Retorno sugerido: bool | Descrição: Indica sucesso/falha após validações. | Quando aplicar: Atualização de campos sensíveis."
+            },
+            {
+              "text": "Operação: delete | Retorno sugerido: bool | Descrição: Retorna sucesso após compactação. | Quando aplicar: Remoção física movendo elementos."
+            },
+            {
+              "text": "Operação: auditLog | Retorno sugerido: void | Descrição: Gera linha de log com contexto da alteração. | Quando aplicar: Chamar após operações críticas."
+            }
+          ]
+        }
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-38.json
+++ b/src/content/courses/algi/lessons/lesson-38.json
@@ -176,15 +176,39 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (2h10)",
-      "items": [
-        "(10 min) Icebreaker com quiz flash e revisão das regras nos slides.",
-        "(45 min) Rodadas principais: squads escolhem casas, respondem e registram tentativas na planilha.",
-        "(15 min) Painel do ranking: atualização coletiva e registro dos badges conquistados.",
-        "(20 min) Desafio relâmpago com perguntas de alta complexidade e possibilidade de aposta.",
-        "(25 min) Círculo de feedback 360° mediado por roteiro de perguntas.",
-        "(15 min) Construção do mural digital com insights e anúncio dos destaques."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Icebreaker com quiz flash e revisão das regras nos slides."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(45 min) Rodadas principais",
+          "content": "squads escolhem casas, respondem e registram tentativas na planilha."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(15 min) Painel do ranking",
+          "content": "atualização coletiva e registro dos badges conquistados."
+        },
+        {
+          "icon": "check-circle",
+          "title": "20 min",
+          "content": "Desafio relâmpago com perguntas de alta complexidade e possibilidade de aposta."
+        },
+        {
+          "icon": "check-circle",
+          "title": "25 min",
+          "content": "Círculo de feedback 360° mediado por roteiro de perguntas."
+        },
+        {
+          "icon": "check-circle",
+          "title": "15 min",
+          "content": "Construção do mural digital com insights e anúncio dos destaques."
+        }
       ]
     },
     {
@@ -241,40 +265,29 @@
       ]
     },
     {
-      "type": "md3Table",
+      "type": "contentBlock",
       "title": "Categorias e exemplos de perguntas",
-      "headers": ["Categoria", "Exemplo", "Resolução esperada", "Pontuação"],
-      "rows": [
-        [
-          "Structs",
-          "Identificar erro em typedef e sugerir correção.",
-          "Mostrar typedef completo e motivo da falha.",
-          "200"
-        ],
-        [
-          "Vetores",
-          "Reordenar vetor de registros após remoção.",
-          "Apresentar código com deslocamento correto.",
-          "300"
-        ],
-        [
-          "CRUD",
-          "Escolher retorno adequado para função delete.",
-          "Explicar bool e mensagens ao usuário.",
-          "100"
-        ],
-        [
-          "Controle",
-          "Converter laço while em for mantendo lógica.",
-          "Código equivalente com justificativa.",
-          "400"
-        ],
-        [
-          "Desafios",
-          "Aplicar busca por prefixo em lista ordenada.",
-          "Implementar varredura até mismatch.",
-          "500"
-        ]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Categoria: Structs | Exemplo: Identificar erro em typedef e sugerir correção. | Resolução esperada: Mostrar typedef completo e motivo da falha. | Pontuação: 200"
+            },
+            {
+              "text": "Categoria: Vetores | Exemplo: Reordenar vetor de registros após remoção. | Resolução esperada: Apresentar código com deslocamento correto. | Pontuação: 300"
+            },
+            {
+              "text": "Categoria: CRUD | Exemplo: Escolher retorno adequado para função delete. | Resolução esperada: Explicar bool e mensagens ao usuário. | Pontuação: 100"
+            },
+            {
+              "text": "Categoria: Controle | Exemplo: Converter laço while em for mantendo lógica. | Resolução esperada: Código equivalente com justificativa. | Pontuação: 400"
+            },
+            {
+              "text": "Categoria: Desafios | Exemplo: Aplicar busca por prefixo em lista ordenada. | Resolução esperada: Implementar varredura até mismatch. | Pontuação: 500"
+            }
+          ]
+        }
       ]
     },
     {

--- a/src/content/courses/ddm/lessons/lesson-22.json
+++ b/src/content/courses/ddm/lessons/lesson-22.json
@@ -80,27 +80,50 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo",
-      "items": [
-        "Warm-up: Kahoot sobre conceitos de corrotinas (10 min).",
-        "Refatorando serviço Retrofit para funções suspensas (25 min).",
-        "Laboratório: Expondo Flow no repositório e ViewModel (40 min).",
-        "Debrief: Estratégias de retry e limites de API (15 min).",
-        "TED: Documentar política de retries no projeto integrador (10 min)."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "Warm-up",
+          "content": "Kahoot sobre conceitos de corrotinas (10 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Refatorando serviço Retrofit para funções suspensas (25 m...",
+          "content": "Refatorando serviço Retrofit para funções suspensas (25 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Laboratório",
+          "content": "Expondo Flow no repositório e ViewModel (40 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Debrief",
+          "content": "Estratégias de retry e limites de API (15 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "TED",
+          "content": "Documentar política de retries no projeto integrador (10 min)."
+        }
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Warm-up colaborativo",
-      "steps": [
+      "content": [
         {
-          "title": "00:05 – Quiz corrotinas vs threads",
-          "content": "Equipes respondem perguntas rápidas sobre diferenças entre threads e corrotinas."
-        },
-        {
-          "title": "00:05 – Storyboard de fluxo de dados",
-          "content": "Esboçar no quadro branco como dados fluem da API até a UI usando Flow."
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "00:05 – Quiz corrotinas vs threads – Equipes respondem perguntas rápidas sobre diferenças entre threads e corrotinas."
+            },
+            {
+              "text": "00:05 – Storyboard de fluxo de dados – Esboçar no quadro branco como dados fluem da API até a UI usando Flow."
+            }
+          ]
         }
       ]
     },
@@ -173,8 +196,8 @@
           "text": "O fragmento resume o padrão de cliente Retrofit aplicado às discussões de Retrofit com corrotinas e Flow."
         },
         {
-          "type": "code",
-          "language": "kotlin",
+          "type": "codeBlock",
+          "language": "c",
           "code": "interface ApiService {\n    @GET(\"/posts\")\n    suspend fun listarPosts(): List<PostResponse>\n}\n\nval retrofit = Retrofit.Builder()\n    .baseUrl(\"https://api.exemplo.dev\")\n    .addConverterFactory(MoshiConverterFactory.create())\n    .build()\n\nval service = retrofit.create(ApiService::class.java)\n// Referência: NILSON, M (2023)"
         },
         {

--- a/src/content/courses/ddm/lessons/lesson-23.json
+++ b/src/content/courses/ddm/lessons/lesson-23.json
@@ -80,27 +80,50 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo",
-      "items": [
-        "Warm-up: Lightning talk sobre listas reativas (10 min).",
-        "Setup do adapter com DiffUtil (20 min).",
-        "Laboratório: Conectando Flow/LiveData à RecyclerView (35 min).",
-        "Hands-on: Paginação e estados de carregamento (35 min).",
-        "TED: Checklist de UX e limites de paginação (10 min)."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "Warm-up",
+          "content": "Lightning talk sobre listas reativas (10 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Setup do adapter com DiffUtil (20 min).",
+          "content": "Setup do adapter com DiffUtil (20 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Laboratório",
+          "content": "Conectando Flow/LiveData à RecyclerView (35 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Hands-on",
+          "content": "Paginação e estados de carregamento (35 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "TED",
+          "content": "Checklist de UX e limites de paginação (10 min)."
+        }
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Warm-up",
-      "steps": [
+      "content": [
         {
-          "title": "00:05 – Show and tell",
-          "content": "Estudantes apresentam apps que usam listas infinitas e discutem UX."
-        },
-        {
-          "title": "00:05 – Quiz de diffing",
-          "content": "Perguntas rápidas sobre como o DiffUtil detecta mudanças e quando usar notifyDataSetChanged."
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "00:05 – Show and tell – Estudantes apresentam apps que usam listas infinitas e discutem UX."
+            },
+            {
+              "text": "00:05 – Quiz de diffing – Perguntas rápidas sobre como o DiffUtil detecta mudanças e quando usar notifyDataSetChanged."
+            }
+          ]
         }
       ]
     },
@@ -173,8 +196,8 @@
           "text": "O fragmento resume o padrão de cliente Retrofit aplicado às discussões de RecyclerView com dados remotos."
         },
         {
-          "type": "code",
-          "language": "kotlin",
+          "type": "codeBlock",
+          "language": "c",
           "code": "interface ApiService {\n    @GET(\"/posts\")\n    suspend fun listarPosts(): List<PostResponse>\n}\n\nval retrofit = Retrofit.Builder()\n    .baseUrl(\"https://api.exemplo.dev\")\n    .addConverterFactory(MoshiConverterFactory.create())\n    .build()\n\nval service = retrofit.create(ApiService::class.java)\n// Referência: GRANDE, A (2022)"
         },
         {

--- a/src/content/courses/ddm/lessons/lesson-24.json
+++ b/src/content/courses/ddm/lessons/lesson-24.json
@@ -80,27 +80,50 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo",
-      "items": [
-        "Warm-up: Mitos e verdades sobre Firebase (10 min).",
-        "Configuração no console (20 min).",
-        "Laboratório: Integração do google-services.json (35 min).",
-        "Hands-on: Estruturando build variants e segurança (35 min).",
-        "TED: Checklist de segurança e documentação (10 min)."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "Warm-up",
+          "content": "Mitos e verdades sobre Firebase (10 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Configuração no console (20 min).",
+          "content": "Configuração no console (20 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Laboratório",
+          "content": "Integração do google-services.json (35 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Hands-on",
+          "content": "Estruturando build variants e segurança (35 min)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "TED",
+          "content": "Checklist de segurança e documentação (10 min)."
+        }
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Warm-up",
-      "steps": [
+      "content": [
         {
-          "title": "00:05 – Quiz mitos x verdades",
-          "content": "Cartões com afirmações sobre Firebase para classificar como mito ou verdade."
-        },
-        {
-          "title": "00:05 – Mapa de serviços",
-          "content": "Grupos listam quais serviços pretendem usar no projeto integrador."
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "00:05 – Quiz mitos x verdades – Cartões com afirmações sobre Firebase para classificar como mito ou verdade."
+            },
+            {
+              "text": "00:05 – Mapa de serviços – Grupos listam quais serviços pretendem usar no projeto integrador."
+            }
+          ]
         }
       ]
     },
@@ -177,8 +200,8 @@
           "text": "Este trecho demonstra a integração em tempo real discutida em Setup do Firebase para Android, com listeners seguros."
         },
         {
-          "type": "code",
-          "language": "kotlin",
+          "type": "codeBlock",
+          "language": "c",
           "code": "val db = Firebase.firestore\nval usuarios = db.collection(\"usuarios\")\nusuarios.whereEqualTo(\"ativo\", true)\n    .addSnapshotListener { snapshot, erro ->\n        if (erro != null) {\n            Log.e(\"UnidadeV\", \"Erro ao consultar Setup do Firebase para Android\", erro)\n            return@addSnapshotListener\n        }\n        val ativos = snapshot?.documents?.size ?: 0\n        Log.d(\"UnidadeV\", \"Usuários ativos: $ativos\")\n    }\n// Referência: GOOGLE (2024)"
         },
         {

--- a/src/content/courses/ddm/lessons/lesson-28.json
+++ b/src/content/courses/ddm/lessons/lesson-28.json
@@ -70,14 +70,34 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (120 min)",
-      "items": [
-        "(10 min) Warm-up: recapitulando aprendizados nativos da Unidade V.",
-        "(25 min) Exposição guiada: panorama nativo x híbrido x multiplataforma.",
-        "(30 min) Estudo de caso: benchmark de apps brasileiros e internacionais.",
-        "(35 min) Oficina orientada: construção da matriz de decisão do projeto.",
-        "(20 min) Socialização e feedback cruzado + alinhamento da TED da semana."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "(10 min) Warm-up",
+          "content": "recapitulando aprendizados nativos da Unidade V."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(25 min) Exposição guiada",
+          "content": "panorama nativo x híbrido x multiplataforma."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(30 min) Estudo de caso",
+          "content": "benchmark de apps brasileiros e internacionais."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(35 min) Oficina orientada",
+          "content": "construção da matriz de decisão do projeto."
+        },
+        {
+          "icon": "check-circle",
+          "title": "20 min",
+          "content": "Socialização e feedback cruzado + alinhamento da TED da semana."
+        }
       ]
     },
     {
@@ -113,173 +133,73 @@
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Critérios para comparar abordagens",
-      "columns": 3,
-      "cards": [
+      "items": [
         {
           "title": "Experiência do usuário",
-          "subtitle": "Performance e UX",
-          "tone": "primary",
-          "items": [
-            "FPS e fluidez em animações complexas.",
-            "Acesso a APIs nativas e hardware.",
-            "Consistência com guias de plataforma."
-          ]
+          "content": "Performance e UX",
+          "language": "plaintext",
+          "code": "Performance e UX\n- FPS e fluidez em animações complexas.\n- Acesso a APIs nativas e hardware.\n- Consistência com guias de plataforma."
         },
         {
           "title": "Equipes e processos",
-          "subtitle": "Capacitação",
-          "tone": "secondary",
-          "items": [
-            "Stack já dominada pelo time.",
-            "Curva de aprendizado e onboarding.",
-            "Ferramentas de CI/CD disponíveis."
-          ]
+          "content": "Capacitação",
+          "language": "plaintext",
+          "code": "Capacitação\n- Stack já dominada pelo time.\n- Curva de aprendizado e onboarding.\n- Ferramentas de CI/CD disponíveis."
         },
         {
           "title": "Negócio e operação",
-          "subtitle": "Time-to-market",
-          "tone": "info",
+          "content": "Time-to-market",
+          "language": "plaintext",
+          "code": "Time-to-market\n- Custo de manutenção a longo prazo.\n- Roadmap e dispositivos suportados.\n- Compliance com lojas e parceiros."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Linha do tempo de decisão",
+      "content": [
+        {
+          "type": "orderedList",
           "items": [
-            "Custo de manutenção a longo prazo.",
-            "Roadmap e dispositivos suportados.",
-            "Compliance com lojas e parceiros."
+            {
+              "text": "Diagnóstico – Mapeie requisitos funcionais, dispositivos alvo e restrições da organização."
+            },
+            {
+              "text": "Seleção de critérios – Priorize critérios técnicos, de UX e de negócio com o patrocinador."
+            },
+            {
+              "text": "Avaliação de alternativas – Pontue nativo, híbrido e multiplataforma considerando riscos e oportunidades."
+            },
+            {
+              "text": "Recomendação – Documente a abordagem vencedora, indicando planos de mitigação para pontos fracos."
+            }
           ]
         }
       ]
     },
     {
-      "type": "timeline",
-      "title": "Linha do tempo de decisão",
-      "steps": [
-        {
-          "title": "Diagnóstico",
-          "content": "Mapeie requisitos funcionais, dispositivos alvo e restrições da organização."
-        },
-        {
-          "title": "Seleção de critérios",
-          "content": "Priorize critérios técnicos, de UX e de negócio com o patrocinador."
-        },
-        {
-          "title": "Avaliação de alternativas",
-          "content": "Pontue nativo, híbrido e multiplataforma considerando riscos e oportunidades."
-        },
-        {
-          "title": "Recomendação",
-          "content": "Documente a abordagem vencedora, indicando planos de mitigação para pontos fracos."
-        }
-      ]
-    },
-    {
-      "type": "pipelineCanvas",
+      "type": "contentBlock",
       "title": "Pipeline da TED – Matriz de decisão",
-      "summary": "Atividade assíncrona prevista no plano de ensino para consolidar a Unidade VI.",
-      "stages": [
+      "content": [
         {
-          "id": "levantamento",
-          "title": "Levantamento de requisitos",
-          "summary": "Consolidar expectativas do cliente interno.",
-          "owners": ["Grupo"],
-          "durationHours": 2,
-          "activities": [
-            {
-              "id": "briefing",
-              "label": "Revisar briefing do projeto",
-              "description": "Listar objetivos, métricas e restrições de prazo."
-            },
-            {
-              "id": "personas",
-              "label": "Atualizar personas",
-              "description": "Identificar necessidades críticas de UX."
-            }
-          ],
-          "deliverables": [
-            {
-              "id": "resumo",
-              "label": "Resumo executivo",
-              "description": "Documento compartilhado no drive da turma."
-            }
-          ],
-          "risks": [
-            {
-              "id": "informacao",
-              "label": "Requisitos incompletos",
-              "severity": "medium",
-              "mitigation": "Solicitar validação com o professor até 24h após a aula."
-            }
-          ],
-          "checkpoints": ["Objetivos claros", "Stakeholders confirmados"]
+          "type": "paragraph",
+          "text": "Atividade assíncrona prevista no plano de ensino para consolidar a Unidade VI."
         },
         {
-          "id": "comparacao",
-          "title": "Comparação das abordagens",
-          "summary": "Pontuar nativo, híbrido e cross-platform.",
-          "owners": ["Grupo"],
-          "durationHours": 3,
-          "activities": [
+          "type": "unorderedList",
+          "items": [
             {
-              "id": "pesquisa",
-              "label": "Coletar benchmarks",
-              "description": "Usar relatórios de mercado e experiências da turma."
+              "text": "Levantamento de requisitos | Consolidar expectativas do cliente interno. | Responsáveis: Grupo | Duração: 2h | Atividades: Revisar briefing do projeto; Atualizar personas | Entregáveis: Resumo executivo | Riscos: Requisitos incompletos (Solicitar validação com o professor até 24h após a aula.) | Checkpoints: Objetivos claros, Stakeholders confirmados"
             },
             {
-              "id": "matriz",
-              "label": "Preencher matriz",
-              "description": "Atribuir pesos e justificativas para cada critério."
-            }
-          ],
-          "deliverables": [
-            {
-              "id": "planilha",
-              "label": "Matriz comparativa",
-              "description": "Planilha atualizada no AVA até sexta-feira, 23h59."
-            }
-          ],
-          "risks": [
-            {
-              "id": "viés",
-              "label": "Viés de familiaridade",
-              "severity": "high",
-              "mitigation": "Buscar opinião de pelo menos um colega de outro grupo."
-            }
-          ],
-          "checkpoints": ["Critérios pontuados", "Justificativas registradas"]
-        },
-        {
-          "id": "validacao",
-          "title": "Validação e registro",
-          "summary": "Garantir aderência ao plano de ensino.",
-          "owners": ["Grupo"],
-          "durationHours": 1,
-          "activities": [
-            {
-              "id": "feedback",
-              "label": "Coletar feedback",
-              "description": "Compartilhar a matriz no fórum da disciplina."
+              "text": "Comparação das abordagens | Pontuar nativo, híbrido e cross-platform. | Responsáveis: Grupo | Duração: 3h | Atividades: Coletar benchmarks; Preencher matriz | Entregáveis: Matriz comparativa | Riscos: Viés de familiaridade (Buscar opinião de pelo menos um colega de outro grupo.) | Checkpoints: Critérios pontuados, Justificativas registradas"
             },
             {
-              "id": "ajustes",
-              "label": "Ajustar recomendações",
-              "description": "Atualizar a justificativa conforme orientações recebidas."
+              "text": "Validação e registro | Garantir aderência ao plano de ensino. | Responsáveis: Grupo | Duração: 1h | Atividades: Coletar feedback; Ajustar recomendações | Entregáveis: Postagem no AVA | Riscos: Atraso no feedback (Registrar dúvidas no mural até 48h antes do prazo final.) | Checkpoints: Feedback recebido, TED concluída"
             }
-          ],
-          "deliverables": [
-            {
-              "id": "post",
-              "label": "Postagem no AVA",
-              "description": "Resumo da decisão com evidências anexas."
-            }
-          ],
-          "risks": [
-            {
-              "id": "atraso",
-              "label": "Atraso no feedback",
-              "severity": "low",
-              "mitigation": "Registrar dúvidas no mural até 48h antes do prazo final."
-            }
-          ],
-          "checkpoints": ["Feedback recebido", "TED concluída"]
+          ]
         }
       ]
     },
@@ -292,8 +212,8 @@
           "text": "O código reforça os padrões de navegação modular discutidos em Nativo vs Híbrido: Estratégias de Plataforma usando Expo e React Navigation."
         },
         {
-          "type": "code",
-          "language": "tsx",
+          "type": "codeBlock",
+          "language": "c",
           "code": "import { useEffect } from 'react'\nimport { NavigationContainer } from '@react-navigation/native'\nimport { createNativeStackNavigator } from '@react-navigation/native-stack'\n\nconst Stack = createNativeStackNavigator()\n\nexport function App() {\n  useEffect(() => {\n    console.log('Nativo vs Híbrido: Estratégias de Plataforma: stack pronto')\n  }, [])\n\n  return (\n    <NavigationContainer>\n      <Stack.Navigator>\n        <Stack.Screen name=\"Home\" component={HomeScreen} />\n      </Stack.Navigator>\n    </NavigationContainer>\n  )\n}\n// Referência: THOUGHTWORKS (2024)"
         },
         {

--- a/src/content/courses/ddm/lessons/lesson-30.json
+++ b/src/content/courses/ddm/lessons/lesson-30.json
@@ -67,14 +67,34 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Cronograma da avaliação (160 min)",
-      "items": [
-        "(15 min) Acolhida, conferência de presença e leitura das instruções.",
-        "(15 min) Organização do ambiente e download dos insumos da prova.",
-        "(90 min) Desenvolvimento prático do desafio React Native/Expo.",
-        "(30 min) Redação do relatório técnico comparativo.",
-        "(10 min) Revisão final, checklist de entrega e submissão no AVA."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "15 min",
+          "content": "Acolhida, conferência de presença e leitura das instruções."
+        },
+        {
+          "icon": "check-circle",
+          "title": "15 min",
+          "content": "Organização do ambiente e download dos insumos da prova."
+        },
+        {
+          "icon": "check-circle",
+          "title": "90 min",
+          "content": "Desenvolvimento prático do desafio React Native/Expo."
+        },
+        {
+          "icon": "check-circle",
+          "title": "30 min",
+          "content": "Redação do relatório técnico comparativo."
+        },
+        {
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Revisão final, checklist de entrega e submissão no AVA."
+        }
       ]
     },
     {
@@ -124,165 +144,70 @@
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Rubrica resumida",
-      "columns": 2,
-      "cards": [
+      "items": [
         {
           "title": "Implementação (60%)",
-          "tone": "primary",
-          "items": [
-            "Consumo correto da API e tratamento de erros.",
-            "Uso adequado de estados, hooks e componentes reutilizáveis.",
-            "Persistência offline funcionando conforme instrução."
-          ]
+          "content": "Consumo correto da API e tratamento de erros.",
+          "language": "plaintext",
+          "code": "- Consumo correto da API e tratamento de erros.\n- Uso adequado de estados, hooks e componentes reutilizáveis.\n- Persistência offline funcionando conforme instrução."
         },
         {
           "title": "Relatório (40%)",
-          "tone": "secondary",
+          "content": "Comparação objetiva entre abordagens nativa e híbrida.",
+          "language": "plaintext",
+          "code": "- Comparação objetiva entre abordagens nativa e híbrida.\n- Justificativas alinhadas ao plano de ensino (critérios de negócio, equipe, arquitetura).\n- Clareza, concisão e referências corretas."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Checkpoint da prova",
+      "content": [
+        {
+          "type": "orderedList",
           "items": [
-            "Comparação objetiva entre abordagens nativa e híbrida.",
-            "Justificativas alinhadas ao plano de ensino (critérios de negócio, equipe, arquitetura).",
-            "Clareza, concisão e referências corretas."
+            {
+              "text": "T-15 min – Receba as instruções, abra o repositório e confirme credenciais de acesso ao AVA."
+            },
+            {
+              "text": "T+45 min – Estrutura básica do app pronta, componentes principais renderizando dados mockados."
+            },
+            {
+              "text": "T+105 min – Integração com API concluída, testes de erro realizados e prints capturados."
+            },
+            {
+              "text": "T+150 min – Relatório finalizado e revisado, com comparativo claro e anexos de evidência."
+            },
+            {
+              "text": "T+160 min – Entrega enviada no AVA e commit final com tag `np2-2025`."
+            }
           ]
         }
       ]
     },
     {
-      "type": "timeline",
-      "title": "Checkpoint da prova",
-      "steps": [
-        {
-          "title": "T-15 min",
-          "content": "Receba as instruções, abra o repositório e confirme credenciais de acesso ao AVA."
-        },
-        {
-          "title": "T+45 min",
-          "content": "Estrutura básica do app pronta, componentes principais renderizando dados mockados."
-        },
-        {
-          "title": "T+105 min",
-          "content": "Integração com API concluída, testes de erro realizados e prints capturados."
-        },
-        {
-          "title": "T+150 min",
-          "content": "Relatório finalizado e revisado, com comparativo claro e anexos de evidência."
-        },
-        {
-          "title": "T+160 min",
-          "content": "Entrega enviada no AVA e commit final com tag `np2-2025`."
-        }
-      ]
-    },
-    {
-      "type": "pipelineCanvas",
+      "type": "contentBlock",
       "title": "Fluxo de submissão NP2",
-      "summary": "Passos obrigatórios para registrar a avaliação conforme o regulamento institucional.",
-      "stages": [
+      "content": [
         {
-          "id": "pre-prova",
-          "title": "Pré-prova",
-          "summary": "Conferir requisitos antes da aplicação.",
-          "owners": ["Aluno"],
-          "durationHours": 0.5,
-          "activities": [
-            {
-              "id": "documentos",
-              "label": "Validar documentos",
-              "description": "Tenha identificação oficial e crachá institucional."
-            },
-            {
-              "id": "ambiente",
-              "label": "Testar ambiente",
-              "description": "Atualize dependências e execute `expo start` com antecedência."
-            }
-          ],
-          "deliverables": [
-            {
-              "id": "checklist",
-              "label": "Checklist assinado",
-              "description": "Formulário pré-prova entregue ao fiscal."
-            }
-          ],
-          "risks": [
-            {
-              "id": "ambiente-quebrado",
-              "label": "Ambiente não executa",
-              "severity": "high",
-              "mitigation": "Buscar posto de apoio técnico até 24h antes da avaliação."
-            }
-          ],
-          "checkpoints": ["Documentos ok", "Ambiente validado"]
+          "type": "paragraph",
+          "text": "Passos obrigatórios para registrar a avaliação conforme o regulamento institucional."
         },
         {
-          "id": "execucao",
-          "title": "Execução",
-          "summary": "Desenvolvimento da prova em sala.",
-          "owners": ["Aluno"],
-          "durationHours": 2.5,
-          "activities": [
+          "type": "unorderedList",
+          "items": [
             {
-              "id": "codar",
-              "label": "Implementar requisitos",
-              "description": "Priorize as histórias obrigatórias antes das extras."
+              "text": "Pré-prova | Conferir requisitos antes da aplicação. | Responsáveis: Aluno | Duração: 0.5h | Atividades: Validar documentos; Testar ambiente | Entregáveis: Checklist assinado | Riscos: Ambiente não executa (Buscar posto de apoio técnico até 24h antes da avaliação.) | Checkpoints: Documentos ok, Ambiente validado"
             },
             {
-              "id": "testar",
-              "label": "Testar funcionalidades",
-              "description": "Registrar evidências (prints/logs) no repositório."
-            }
-          ],
-          "deliverables": [
-            {
-              "id": "tag",
-              "label": "Commit + tag",
-              "description": "Commit final com mensagem `feat: entrega np2` e tag `np2-2025`."
-            }
-          ],
-          "risks": [
-            {
-              "id": "perda-codigo",
-              "label": "Perda de código",
-              "severity": "medium",
-              "mitigation": "Realize commits incrementais a cada 30 minutos."
-            }
-          ],
-          "checkpoints": ["Histórias essenciais concluídas", "Testes executados"]
-        },
-        {
-          "id": "pos-prova",
-          "title": "Pós-prova",
-          "summary": "Finalizar submissão e autoavaliação.",
-          "owners": ["Aluno"],
-          "durationHours": 0.5,
-          "activities": [
-            {
-              "id": "upload",
-              "label": "Enviar no AVA",
-              "description": "Anexar relatório em PDF e link do repositório."
+              "text": "Execução | Desenvolvimento da prova em sala. | Responsáveis: Aluno | Duração: 2.5h | Atividades: Implementar requisitos; Testar funcionalidades | Entregáveis: Commit + tag | Riscos: Perda de código (Realize commits incrementais a cada 30 minutos.) | Checkpoints: Histórias essenciais concluídas, Testes executados"
             },
             {
-              "id": "autoavaliacao",
-              "label": "Preencher autoavaliação",
-              "description": "Responder formulário de reflexão com pontos fortes e melhorias."
+              "text": "Pós-prova | Finalizar submissão e autoavaliação. | Responsáveis: Aluno | Duração: 0.5h | Atividades: Enviar no AVA; Preencher autoavaliação | Entregáveis: Recibo de entrega | Riscos: Não preencher autoavaliação (Agendar lembrete automático no celular ao fim da prova.) | Checkpoints: Upload confirmado, Autoavaliação enviada"
             }
-          ],
-          "deliverables": [
-            {
-              "id": "recibo",
-              "label": "Recibo de entrega",
-              "description": "Salvar comprovante disponibilizado pelo AVA."
-            }
-          ],
-          "risks": [
-            {
-              "id": "esquecimento",
-              "label": "Não preencher autoavaliação",
-              "severity": "low",
-              "mitigation": "Agendar lembrete automático no celular ao fim da prova."
-            }
-          ],
-          "checkpoints": ["Upload confirmado", "Autoavaliação enviada"]
+          ]
         }
       ]
     },
@@ -295,8 +220,8 @@
           "text": "O código reforça os padrões de navegação modular discutidos em Avaliação NP2 (Prova Integrada) usando Expo e React Navigation."
         },
         {
-          "type": "code",
-          "language": "tsx",
+          "type": "codeBlock",
+          "language": "c",
           "code": "import { useEffect } from 'react'\nimport { NavigationContainer } from '@react-navigation/native'\nimport { createNativeStackNavigator } from '@react-navigation/native-stack'\n\nconst Stack = createNativeStackNavigator()\n\nexport function App() {\n  useEffect(() => {\n    console.log('Avaliação NP2 (Prova Integrada): stack pronto')\n  }, [])\n\n  return (\n    <NavigationContainer>\n      <Stack.Navigator>\n        <Stack.Screen name=\"Home\" component={HomeScreen} />\n      </Stack.Navigator>\n    </NavigationContainer>\n  )\n}\n// Referência: Material compilado da disciplina (Aulas 13-29) (s.d.)"
         },
         {

--- a/src/content/courses/ddm/lessons/lesson-31.json
+++ b/src/content/courses/ddm/lessons/lesson-31.json
@@ -70,14 +70,34 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (140 min)",
-      "items": [
-        "(10 min) Debrief pós-NP2 e conexão com roadmap do MVP.",
-        "(30 min) Introdução teórica: conceitos de navegação, padrões MD3 e boas práticas.",
-        "(40 min) Setup guiado do React Navigation e criação do Stack principal.",
-        "(40 min) Oficina: Tabs, modais e passagem de parâmetros.",
-        "(20 min) Revisão da TED: definição de fluxo final e testes de deep link."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "10 min",
+          "content": "Debrief pós-NP2 e conexão com roadmap do MVP."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(30 min) Introdução teórica",
+          "content": "conceitos de navegação, padrões MD3 e boas práticas."
+        },
+        {
+          "icon": "check-circle",
+          "title": "40 min",
+          "content": "Setup guiado do React Navigation e criação do Stack principal."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(40 min) Oficina",
+          "content": "Tabs, modais e passagem de parâmetros."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(20 min) Revisão da TED",
+          "content": "definição de fluxo final e testes de deep link."
+        }
       ]
     },
     {
@@ -113,168 +133,73 @@
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Padrões recomendados",
-      "columns": 3,
-      "cards": [
+      "items": [
         {
           "title": "Stack",
-          "subtitle": "Fluxo linear",
-          "tone": "primary",
-          "items": [
-            "Ideal para onboarding e fluxos sequenciais.",
-            "Permite transições customizadas (slide, fade).",
-            "Suporta parâmetros obrigatórios via tipos."
-          ]
+          "content": "Fluxo linear",
+          "language": "plaintext",
+          "code": "Fluxo linear\n- Ideal para onboarding e fluxos sequenciais.\n- Permite transições customizadas (slide, fade).\n- Suporta parâmetros obrigatórios via tipos."
         },
         {
           "title": "Tab",
-          "subtitle": "Seções principais",
-          "tone": "secondary",
-          "items": [
-            "Até cinco itens para manter clareza.",
-            "Ícones alinhados ao design system MD3.",
-            "Uso de badges para notificações."
-          ]
+          "content": "Seções principais",
+          "language": "plaintext",
+          "code": "Seções principais\n- Até cinco itens para manter clareza.\n- Ícones alinhados ao design system MD3.\n- Uso de badges para notificações."
         },
         {
           "title": "Modal",
-          "subtitle": "Ações pontuais",
-          "tone": "neutral",
+          "content": "Ações pontuais",
+          "language": "plaintext",
+          "code": "Ações pontuais\n- Confirmações, formulários curtos e visualizações detalhadas.\n- Fechamento com gesto ou botão explícito.\n- Foco inicial em elementos interativos."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Roadmap de implementação",
+      "content": [
+        {
+          "type": "orderedList",
           "items": [
-            "Confirmações, formulários curtos e visualizações detalhadas.",
-            "Fechamento com gesto ou botão explícito.",
-            "Foco inicial em elementos interativos."
+            {
+              "text": "1. Planejamento – Mapear telas obrigatórias e desenhar diagrama de navegação."
+            },
+            {
+              "text": "2. Configuração – Instalar dependências, criar `NavigationContainer` e definir Stack raiz."
+            },
+            {
+              "text": "3. Componentização – Extrair cabeçalhos, ícones e estilos compartilhados."
+            },
+            {
+              "text": "4. Testes – Validar navegação via deep link, VoiceOver/TalkBack e fallback offline."
+            }
           ]
         }
       ]
     },
     {
-      "type": "timeline",
-      "title": "Roadmap de implementação",
-      "steps": [
-        {
-          "title": "1. Planejamento",
-          "content": "Mapear telas obrigatórias e desenhar diagrama de navegação."
-        },
-        {
-          "title": "2. Configuração",
-          "content": "Instalar dependências, criar `NavigationContainer` e definir Stack raiz."
-        },
-        {
-          "title": "3. Componentização",
-          "content": "Extrair cabeçalhos, ícones e estilos compartilhados."
-        },
-        {
-          "title": "4. Testes",
-          "content": "Validar navegação via deep link, VoiceOver/TalkBack e fallback offline."
-        }
-      ]
-    },
-    {
-      "type": "pipelineCanvas",
+      "type": "contentBlock",
       "title": "Pipeline da TED – Fluxo de navegação",
-      "summary": "Atividade avaliativa que integra a entrega parcial 3 do projeto.",
-      "stages": [
+      "content": [
         {
-          "id": "design",
-          "title": "Design do fluxo",
-          "summary": "Refinar mapa de telas e estados.",
-          "owners": ["Grupo"],
-          "durationHours": 1.5,
-          "activities": [
-            {
-              "id": "wireflow",
-              "label": "Atualizar wireflow",
-              "description": "Registrar fluxo no Figma com estados principais."
-            }
-          ],
-          "deliverables": [
-            {
-              "id": "wireflow-arquivo",
-              "label": "Wireflow atualizado",
-              "description": "Link compartilhado no AVA até quarta-feira."
-            }
-          ],
-          "risks": [
-            {
-              "id": "divergencia",
-              "label": "Fluxo divergente",
-              "severity": "medium",
-              "mitigation": "Validar com o professor orientador antes de codificar."
-            }
-          ],
-          "checkpoints": ["Fluxo aprovado"]
+          "type": "paragraph",
+          "text": "Atividade avaliativa que integra a entrega parcial 3 do projeto."
         },
         {
-          "id": "implementacao",
-          "title": "Implementação",
-          "summary": "Codificar rotas e componentes.",
-          "owners": ["Grupo"],
-          "durationHours": 4,
-          "activities": [
+          "type": "unorderedList",
+          "items": [
             {
-              "id": "stack",
-              "label": "Criar Stack principal",
-              "description": "Definir rotas públicas e privadas."
+              "text": "Design do fluxo | Refinar mapa de telas e estados. | Responsáveis: Grupo | Duração: 1.5h | Atividades: Atualizar wireflow | Entregáveis: Wireflow atualizado | Riscos: Fluxo divergente (Validar com o professor orientador antes de codificar.) | Checkpoints: Fluxo aprovado"
             },
             {
-              "id": "tab",
-              "label": "Configurar Tabs",
-              "description": "Aplicar ícones, labels e badges conforme MD3."
-            }
-          ],
-          "deliverables": [
-            {
-              "id": "pull-request",
-              "label": "Pull request aberto",
-              "description": "PR com título `feat: navigation flow` enviado até domingo."
-            }
-          ],
-          "risks": [
-            {
-              "id": "conflitos",
-              "label": "Conflitos de merge",
-              "severity": "medium",
-              "mitigation": "Sincronizar branches diariamente e usar feature flags."
-            }
-          ],
-          "checkpoints": ["Rotas principais funcionais"]
-        },
-        {
-          "id": "validacao",
-          "title": "Validação",
-          "summary": "Revisar acessibilidade e deep linking.",
-          "owners": ["Grupo"],
-          "durationHours": 1,
-          "activities": [
-            {
-              "id": "testes",
-              "label": "Rodar testes",
-              "description": "Executar script `npm run lint` e testar deep links."
+              "text": "Implementação | Codificar rotas e componentes. | Responsáveis: Grupo | Duração: 4h | Atividades: Criar Stack principal; Configurar Tabs | Entregáveis: Pull request aberto | Riscos: Conflitos de merge (Sincronizar branches diariamente e usar feature flags.) | Checkpoints: Rotas principais funcionais"
             },
             {
-              "id": "feedback",
-              "label": "Solicitar revisão",
-              "description": "Registrar feedback com colega de outra equipe."
+              "text": "Validação | Revisar acessibilidade e deep linking. | Responsáveis: Grupo | Duração: 1h | Atividades: Rodar testes; Solicitar revisão | Entregáveis: Checklist de acessibilidade | Riscos: Itens não conformes (Usar leitores de tela e ajustes sugeridos na aula.) | Checkpoints: Deep link ok, Checklist aprovado"
             }
-          ],
-          "deliverables": [
-            {
-              "id": "checklist",
-              "label": "Checklist de acessibilidade",
-              "description": "Formulário assinado e anexado ao PR."
-            }
-          ],
-          "risks": [
-            {
-              "id": "acessibilidade",
-              "label": "Itens não conformes",
-              "severity": "high",
-              "mitigation": "Usar leitores de tela e ajustes sugeridos na aula."
-            }
-          ],
-          "checkpoints": ["Deep link ok", "Checklist aprovado"]
+          ]
         }
       ]
     },
@@ -287,8 +212,8 @@
           "text": "O código reforça os padrões de navegação modular discutidos em Navegação com React Navigation usando Expo e React Navigation."
         },
         {
-          "type": "code",
-          "language": "tsx",
+          "type": "codeBlock",
+          "language": "c",
           "code": "import { useEffect } from 'react'\nimport { NavigationContainer } from '@react-navigation/native'\nimport { createNativeStackNavigator } from '@react-navigation/native-stack'\n\nconst Stack = createNativeStackNavigator()\n\nexport function App() {\n  useEffect(() => {\n    console.log('Navegação com React Navigation: stack pronto')\n  }, [])\n\n  return (\n    <NavigationContainer>\n      <Stack.Navigator>\n        <Stack.Screen name=\"Home\" component={HomeScreen} />\n      </Stack.Navigator>\n    </NavigationContainer>\n  )\n}\n// Referência: REACT NAVIGATION (2024)"
         },
         {

--- a/src/content/courses/ddm/lessons/lesson-32.json
+++ b/src/content/courses/ddm/lessons/lesson-32.json
@@ -70,14 +70,34 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (150 min)",
-      "items": [
-        "(15 min) Revisão dos fluxos de navegação implementados.",
-        "(35 min) Exposição: camadas de serviço, TanStack Query e estratégias offline-first.",
-        "(40 min) Live coding: hook `useTasks` consumindo endpoint REST protegido.",
-        "(40 min) Oficina: integração no app do grupo com feedback visual MD3.",
-        "(20 min) Alinhamento da TED: testes de resiliência e documentação da API."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "15 min",
+          "content": "Revisão dos fluxos de navegação implementados."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(35 min) Exposição",
+          "content": "camadas de serviço, TanStack Query e estratégias offline-first."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(40 min) Live coding",
+          "content": "hook `useTasks` consumindo endpoint REST protegido."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(40 min) Oficina",
+          "content": "integração no app do grupo com feedback visual MD3."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(20 min) Alinhamento da TED",
+          "content": "testes de resiliência e documentação da API."
+        }
       ]
     },
     {
@@ -113,165 +133,73 @@
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Checklist de integração",
-      "columns": 3,
-      "cards": [
+      "items": [
         {
           "title": "Configuração",
-          "tone": "info",
-          "items": [
-            "Instalar Axios/TanStack Query.",
-            "Criar cliente HTTP com interceptors.",
-            "Configurar QueryClientProvider no root."
-          ]
+          "content": "Instalar Axios/TanStack Query.",
+          "language": "plaintext",
+          "code": "- Instalar Axios/TanStack Query.\n- Criar cliente HTTP com interceptors.\n- Configurar QueryClientProvider no root."
         },
         {
           "title": "Implementação",
-          "tone": "primary",
-          "items": [
-            "Hook customizado com tipagem forte.",
-            "Feedback visual para loading/erro usando componentes MD3.",
-            "Uso de `invalidateQueries` após mutações."
-          ]
+          "content": "Hook customizado com tipagem forte.",
+          "language": "plaintext",
+          "code": "- Hook customizado com tipagem forte.\n- Feedback visual para loading/erro usando componentes MD3.\n- Uso de `invalidateQueries` após mutações."
         },
         {
           "title": "Offline",
-          "tone": "secondary",
+          "content": "PersistQueryClientProvider com AsyncStorage.",
+          "language": "plaintext",
+          "code": "- PersistQueryClientProvider com AsyncStorage.\n- Fallback para dados em cache quando offline.\n- Monitoramento de conectividade com `expo-network`."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Fluxo de dados",
+      "content": [
+        {
+          "type": "orderedList",
           "items": [
-            "PersistQueryClientProvider com AsyncStorage.",
-            "Fallback para dados em cache quando offline.",
-            "Monitoramento de conectividade com `expo-network`."
+            {
+              "text": "Requisição – Cliente HTTP envia request com headers configurados (token, idioma)."
+            },
+            {
+              "text": "Resposta – Hook recebe dados, processa transformações e atualiza cache."
+            },
+            {
+              "text": "Sincronização – Dados persistidos localmente e atualizados quando houver conectividade."
+            },
+            {
+              "text": "Monitoramento – Logs e métricas coletados via Sentry/Expo para análise posterior."
+            }
           ]
         }
       ]
     },
     {
-      "type": "timeline",
-      "title": "Fluxo de dados",
-      "steps": [
-        {
-          "title": "Requisição",
-          "content": "Cliente HTTP envia request com headers configurados (token, idioma)."
-        },
-        {
-          "title": "Resposta",
-          "content": "Hook recebe dados, processa transformações e atualiza cache."
-        },
-        {
-          "title": "Sincronização",
-          "content": "Dados persistidos localmente e atualizados quando houver conectividade."
-        },
-        {
-          "title": "Monitoramento",
-          "content": "Logs e métricas coletados via Sentry/Expo para análise posterior."
-        }
-      ]
-    },
-    {
-      "type": "pipelineCanvas",
+      "type": "contentBlock",
       "title": "Pipeline da TED – Integração de API",
-      "summary": "Entrega obrigatória que valida a competência de integração remota.",
-      "stages": [
+      "content": [
         {
-          "id": "briefing",
-          "title": "Briefing com o backend",
-          "summary": "Entender contratos e limites.",
-          "owners": ["Grupo"],
-          "durationHours": 1,
-          "activities": [
-            {
-              "id": "reuniao",
-              "label": "Reunião com squad backend",
-              "description": "Alinhar endpoints, autenticação e limites de uso."
-            }
-          ],
-          "deliverables": [
-            {
-              "id": "notas",
-              "label": "Notas compartilhadas",
-              "description": "Documento com endpoints, payloads e SLA."
-            }
-          ],
-          "risks": [
-            {
-              "id": "mudanca",
-              "label": "Mudança de contrato",
-              "severity": "medium",
-              "mitigation": "Registrar versão e acompanhar change log do backend."
-            }
-          ],
-          "checkpoints": ["Contratos confirmados"]
+          "type": "paragraph",
+          "text": "Entrega obrigatória que valida a competência de integração remota."
         },
         {
-          "id": "desenvolvimento",
-          "title": "Desenvolvimento",
-          "summary": "Codificar hooks, componentes e estados.",
-          "owners": ["Grupo"],
-          "durationHours": 4,
-          "activities": [
+          "type": "unorderedList",
+          "items": [
             {
-              "id": "hook",
-              "label": "Criar hook",
-              "description": "Implementar `useTasks`/`useUsers` com caching e retries."
+              "text": "Briefing com o backend | Entender contratos e limites. | Responsáveis: Grupo | Duração: 1h | Atividades: Reunião com squad backend | Entregáveis: Notas compartilhadas | Riscos: Mudança de contrato (Registrar versão e acompanhar change log do backend.) | Checkpoints: Contratos confirmados"
             },
             {
-              "id": "ui",
-              "label": "Atualizar UI",
-              "description": "Renderizar estados loading/empty/error com componentes MD3."
-            }
-          ],
-          "deliverables": [
-            {
-              "id": "branch",
-              "label": "Branch `feature/api-integration`",
-              "description": "Código versionado com testes básicos."
-            }
-          ],
-          "risks": [
-            {
-              "id": "erros-api",
-              "label": "Instabilidade da API",
-              "severity": "high",
-              "mitigation": "Configurar retries exponenciais e mocks locais."
-            }
-          ],
-          "checkpoints": ["Hook funcional", "UI atualizada"]
-        },
-        {
-          "id": "qualidade",
-          "title": "Qualidade",
-          "summary": "Testes e documentação.",
-          "owners": ["Grupo"],
-          "durationHours": 1.5,
-          "activities": [
-            {
-              "id": "testes",
-              "label": "Rodar testes",
-              "description": "Executar `npm run test`/`npm run lint` e simular offline."
+              "text": "Desenvolvimento | Codificar hooks, componentes e estados. | Responsáveis: Grupo | Duração: 4h | Atividades: Criar hook; Atualizar UI | Entregáveis: Branch `feature/api-integration` | Riscos: Instabilidade da API (Configurar retries exponenciais e mocks locais.) | Checkpoints: Hook funcional, UI atualizada"
             },
             {
-              "id": "documentar",
-              "label": "Atualizar docs",
-              "description": "Adicionar README com instruções e limites da API."
+              "text": "Qualidade | Testes e documentação. | Responsáveis: Grupo | Duração: 1.5h | Atividades: Rodar testes; Atualizar docs | Entregáveis: Relatório de integração | Riscos: Atraso na documentação (Designar responsável específico para documentação desde o início.) | Checkpoints: Testes rodados, Relatório anexado"
             }
-          ],
-          "deliverables": [
-            {
-              "id": "relatorio",
-              "label": "Relatório de integração",
-              "description": "Checklist preenchido e arquivo PDF submetido até domingo."
-            }
-          ],
-          "risks": [
-            {
-              "id": "prazo-curto",
-              "label": "Atraso na documentação",
-              "severity": "medium",
-              "mitigation": "Designar responsável específico para documentação desde o início."
-            }
-          ],
-          "checkpoints": ["Testes rodados", "Relatório anexado"]
+          ]
         }
       ]
     },
@@ -284,8 +212,8 @@
           "text": "O código reforça os padrões de navegação modular discutidos em Consumo de APIs e Estado no React Native usando Expo e React Navigation."
         },
         {
-          "type": "code",
-          "language": "tsx",
+          "type": "codeBlock",
+          "language": "c",
           "code": "import { useEffect } from 'react'\nimport { NavigationContainer } from '@react-navigation/native'\nimport { createNativeStackNavigator } from '@react-navigation/native-stack'\n\nconst Stack = createNativeStackNavigator()\n\nexport function App() {\n  useEffect(() => {\n    console.log('Consumo de APIs e Estado no React Native: stack pronto')\n  }, [])\n\n  return (\n    <NavigationContainer>\n      <Stack.Navigator>\n        <Stack.Screen name=\"Home\" component={HomeScreen} />\n      </Stack.Navigator>\n    </NavigationContainer>\n  )\n}\n// Referência: TANSTACK (2024)"
         },
         {

--- a/src/content/courses/ddm/lessons/lesson-33.json
+++ b/src/content/courses/ddm/lessons/lesson-33.json
@@ -70,14 +70,34 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (150 min)",
-      "items": [
-        "(20 min) Retomada dos critérios da entrega final e análise do cronograma.",
-        "(30 min) Rodada de code review cruzado (duplas trocadas).",
-        "(40 min) Testes guiados: cenários críticos de navegação, API e offline.",
-        "(30 min) Oficina de storytelling e apresentação técnica.",
-        "(30 min) Planejamento do backlog final e definição de responsáveis."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "20 min",
+          "content": "Retomada dos critérios da entrega final e análise do cronograma."
+        },
+        {
+          "icon": "check-circle",
+          "title": "30 min",
+          "content": "Rodada de code review cruzado (duplas trocadas)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(40 min) Testes guiados",
+          "content": "cenários críticos de navegação, API e offline."
+        },
+        {
+          "icon": "check-circle",
+          "title": "30 min",
+          "content": "Oficina de storytelling e apresentação técnica."
+        },
+        {
+          "icon": "check-circle",
+          "title": "30 min",
+          "content": "Planejamento do backlog final e definição de responsáveis."
+        }
       ]
     },
     {
@@ -113,160 +133,73 @@
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Checklist multidisciplinar",
-      "columns": 3,
-      "cards": [
+      "items": [
         {
           "title": "Experiência",
-          "tone": "primary",
-          "items": [
-            "Fluxos principais sem bloqueios.",
-            "Feedback visual consistente com MD3.",
-            "Acessibilidade validada (TalkBack/VoiceOver)."
-          ]
+          "content": "Fluxos principais sem bloqueios.",
+          "language": "plaintext",
+          "code": "- Fluxos principais sem bloqueios.\n- Feedback visual consistente com MD3.\n- Acessibilidade validada (TalkBack/VoiceOver)."
         },
         {
           "title": "Tecnologia",
-          "tone": "secondary",
-          "items": [
-            "Cobertura de testes mínimos (unitário + integração).",
-            "Integrações com API monitoradas e com logs significativos.",
-            "Uso de variáveis de ambiente seguro."
-          ]
+          "content": "Cobertura de testes mínimos (unitário + integração).",
+          "language": "plaintext",
+          "code": "- Cobertura de testes mínimos (unitário + integração).\n- Integrações com API monitoradas e com logs significativos.\n- Uso de variáveis de ambiente seguro."
         },
         {
           "title": "Gestão",
-          "tone": "neutral",
+          "content": "Backlog priorizado com critérios MoSCoW.",
+          "language": "plaintext",
+          "code": "- Backlog priorizado com critérios MoSCoW.\n- Board atualizado com responsáveis e prazos.\n- Comunicação com stakeholders registrada."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Ciclo da revisão",
+      "content": [
+        {
+          "type": "orderedList",
           "items": [
-            "Backlog priorizado com critérios MoSCoW.",
-            "Board atualizado com responsáveis e prazos.",
-            "Comunicação com stakeholders registrada."
+            {
+              "text": "Diagnóstico – Analisar indicadores (burndown, bugs abertos, cobertura de testes)."
+            },
+            {
+              "text": "Planejamento – Definir prioridades, estimar esforço e distribuir responsáveis."
+            },
+            {
+              "text": "Execução – Implementar correções prioritárias e registrar progresso no board."
+            },
+            {
+              "text": "Follow-up – Revisar ações concluídas e atualizar plano conforme feedback do professor."
+            }
           ]
         }
       ]
     },
     {
-      "type": "timeline",
-      "title": "Ciclo da revisão",
-      "steps": [
-        {
-          "title": "Diagnóstico",
-          "content": "Analisar indicadores (burndown, bugs abertos, cobertura de testes)."
-        },
-        {
-          "title": "Planejamento",
-          "content": "Definir prioridades, estimar esforço e distribuir responsáveis."
-        },
-        {
-          "title": "Execução",
-          "content": "Implementar correções prioritárias e registrar progresso no board."
-        },
-        {
-          "title": "Follow-up",
-          "content": "Revisar ações concluídas e atualizar plano conforme feedback do professor."
-        }
-      ]
-    },
-    {
-      "type": "pipelineCanvas",
+      "type": "contentBlock",
       "title": "Pipeline da TED – Plano de melhoria",
-      "summary": "Atividade avaliativa que consolida ações para a entrega final.",
-      "stages": [
+      "content": [
         {
-          "id": "avaliacao",
-          "title": "Avaliação",
-          "summary": "Concluir checklist multidisciplinar.",
-          "owners": ["Grupo"],
-          "durationHours": 2,
-          "activities": [
-            {
-              "id": "checklist",
-              "label": "Preencher checklist",
-              "description": "Marcar status de cada item e anexar evidências."
-            }
-          ],
-          "deliverables": [
-            {
-              "id": "documento",
-              "label": "Checklist consolidado",
-              "description": "Arquivo compartilhado no drive do curso."
-            }
-          ],
-          "risks": [
-            {
-              "id": "subjetividade",
-              "label": "Avaliação superficial",
-              "severity": "medium",
-              "mitigation": "Utilizar critérios objetivos e evidências (prints, logs)."
-            }
-          ],
-          "checkpoints": ["Checklist validado"]
+          "type": "paragraph",
+          "text": "Atividade avaliativa que consolida ações para a entrega final."
         },
         {
-          "id": "planejamento",
-          "title": "Planejamento",
-          "summary": "Transformar achados em backlog.",
-          "owners": ["Grupo"],
-          "durationHours": 1.5,
-          "activities": [
+          "type": "unorderedList",
+          "items": [
             {
-              "id": "priorizar",
-              "label": "Priorizar itens",
-              "description": "Aplicar matriz MoSCoW e definir responsáveis."
-            }
-          ],
-          "deliverables": [
-            {
-              "id": "board",
-              "label": "Board atualizado",
-              "description": "Kanban/Trello com tarefas, responsáveis e prazos."
-            }
-          ],
-          "risks": [
-            {
-              "id": "overload",
-              "label": "Sobrecarga de tarefas",
-              "severity": "medium",
-              "mitigation": "Balancear carga entre integrantes e negociar escopo."
-            }
-          ],
-          "checkpoints": ["Backlog priorizado"]
-        },
-        {
-          "id": "apresentacao",
-          "title": "Apresentação",
-          "summary": "Preparar storytelling para banca.",
-          "owners": ["Grupo"],
-          "durationHours": 1,
-          "activities": [
-            {
-              "id": "roteiro",
-              "label": "Construir roteiro",
-              "description": "Estruturar discurso com problema, solução, resultados e próximos passos."
+              "text": "Avaliação | Concluir checklist multidisciplinar. | Responsáveis: Grupo | Duração: 2h | Atividades: Preencher checklist | Entregáveis: Checklist consolidado | Riscos: Avaliação superficial (Utilizar critérios objetivos e evidências (prints, logs).) | Checkpoints: Checklist validado"
             },
             {
-              "id": "ensaio",
-              "label": "Ensaiar",
-              "description": "Simular apresentação com tempo cronometrado."
-            }
-          ],
-          "deliverables": [
+              "text": "Planejamento | Transformar achados em backlog. | Responsáveis: Grupo | Duração: 1.5h | Atividades: Priorizar itens | Entregáveis: Board atualizado | Riscos: Sobrecarga de tarefas (Balancear carga entre integrantes e negociar escopo.) | Checkpoints: Backlog priorizado"
+            },
             {
-              "id": "pitch",
-              "label": "Pitch gravado",
-              "description": "Vídeo curto anexado ao mural para feedback."
+              "text": "Apresentação | Preparar storytelling para banca. | Responsáveis: Grupo | Duração: 1h | Atividades: Construir roteiro; Ensaiar | Entregáveis: Pitch gravado | Riscos: Discurso desalinhado (Revisar script com professor antes do envio.) | Checkpoints: Pitch enviado"
             }
-          ],
-          "risks": [
-            {
-              "id": "desalinhado",
-              "label": "Discurso desalinhado",
-              "severity": "low",
-              "mitigation": "Revisar script com professor antes do envio."
-            }
-          ],
-          "checkpoints": ["Pitch enviado"]
+          ]
         }
       ]
     },
@@ -279,8 +212,8 @@
           "text": "O código reforça os padrões de navegação modular discutidos em Revisão Prática Integrada usando Expo e React Navigation."
         },
         {
-          "type": "code",
-          "language": "tsx",
+          "type": "codeBlock",
+          "language": "c",
           "code": "import { useEffect } from 'react'\nimport { NavigationContainer } from '@react-navigation/native'\nimport { createNativeStackNavigator } from '@react-navigation/native-stack'\n\nconst Stack = createNativeStackNavigator()\n\nexport function App() {\n  useEffect(() => {\n    console.log('Revisão Prática Integrada: stack pronto')\n  }, [])\n\n  return (\n    <NavigationContainer>\n      <Stack.Navigator>\n        <Stack.Screen name=\"Home\" component={HomeScreen} />\n      </Stack.Navigator>\n    </NavigationContainer>\n  )\n}\n// Referência: GOOGLE (2024)"
         },
         {

--- a/src/content/courses/ddm/lessons/lesson-34.json
+++ b/src/content/courses/ddm/lessons/lesson-34.json
@@ -70,14 +70,34 @@
       ]
     },
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo (180 min)",
-      "items": [
-        "(20 min) Visão geral do ecossistema Firebase e requisitos de segurança.",
-        "(40 min) Configuração guiada: criação de projeto, app web e variáveis ambiente.",
-        "(50 min) Implementação: Authentication com email/senha e providers sociais.",
-        "(50 min) Firestore em ação: coleções, listeners e sincronização offline.",
-        "(20 min) Consolidação: checklist de segurança, testes e planejamento da TED."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "20 min",
+          "content": "Visão geral do ecossistema Firebase e requisitos de segurança."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(40 min) Configuração guiada",
+          "content": "criação de projeto, app web e variáveis ambiente."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(50 min) Implementação",
+          "content": "Authentication com email/senha e providers sociais."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(50 min) Firestore em ação",
+          "content": "coleções, listeners e sincronização offline."
+        },
+        {
+          "icon": "check-circle",
+          "title": "(20 min) Consolidação",
+          "content": "checklist de segurança, testes e planejamento da TED."
+        }
       ]
     },
     {
@@ -113,170 +133,73 @@
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Checklist de integração cloud",
-      "columns": 3,
-      "cards": [
+      "items": [
         {
           "title": "Setup",
-          "tone": "info",
-          "items": [
-            "Projeto Firebase criado com usuários registrados.",
-            "Credenciais armazenadas em `.env` e `app.config.ts`.",
-            "SDKs instalados e configurados no Expo."
-          ]
+          "content": "Projeto Firebase criado com usuários registrados.",
+          "language": "plaintext",
+          "code": "- Projeto Firebase criado com usuários registrados.\n- Credenciais armazenadas em `.env` e `app.config.ts`.\n- SDKs instalados e configurados no Expo."
         },
         {
           "title": "Autenticação",
-          "tone": "primary",
-          "items": [
-            "Fluxo de login/cadastro com feedback MD3.",
-            "Reset de senha e verificação de email opcional.",
-            "Proteção de rotas autenticadas no React Navigation."
-          ]
+          "content": "Fluxo de login/cadastro com feedback MD3.",
+          "language": "plaintext",
+          "code": "- Fluxo de login/cadastro com feedback MD3.\n- Reset de senha e verificação de email opcional.\n- Proteção de rotas autenticadas no React Navigation."
         },
         {
           "title": "Firestore",
-          "tone": "secondary",
+          "content": "Coleções com índices e regras baseadas em usuário.",
+          "language": "plaintext",
+          "code": "- Coleções com índices e regras baseadas em usuário.\n- Sync offline habilitado com `enableIndexedDbPersistence`.\n- Listeners removidos corretamente para evitar vazamentos."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Fluxo de dados com Firebase",
+      "content": [
+        {
+          "type": "orderedList",
           "items": [
-            "Coleções com índices e regras baseadas em usuário.",
-            "Sync offline habilitado com `enableIndexedDbPersistence`.",
-            "Listeners removidos corretamente para evitar vazamentos."
+            {
+              "text": "Autenticar – Usuário envia credenciais, Firebase Auth valida e retorna token."
+            },
+            {
+              "text": "Autorizar – Aplicativo injeta token em cabeçalhos e aplica regras de segurança."
+            },
+            {
+              "text": "Sincronizar – Listeners atualizam UI em tempo real e persistem dados offline."
+            },
+            {
+              "text": "Monitorar – Logar atividades com Firebase Analytics/Crashlytics para auditoria."
+            }
           ]
         }
       ]
     },
     {
-      "type": "timeline",
-      "title": "Fluxo de dados com Firebase",
-      "steps": [
-        {
-          "title": "Autenticar",
-          "content": "Usuário envia credenciais, Firebase Auth valida e retorna token."
-        },
-        {
-          "title": "Autorizar",
-          "content": "Aplicativo injeta token em cabeçalhos e aplica regras de segurança."
-        },
-        {
-          "title": "Sincronizar",
-          "content": "Listeners atualizam UI em tempo real e persistem dados offline."
-        },
-        {
-          "title": "Monitorar",
-          "content": "Logar atividades com Firebase Analytics/Crashlytics para auditoria."
-        }
-      ]
-    },
-    {
-      "type": "pipelineCanvas",
+      "type": "contentBlock",
       "title": "Pipeline da TED – Integração Firebase",
-      "summary": "Atividade avaliativa que valida segurança e sincronização em nuvem.",
-      "stages": [
+      "content": [
         {
-          "id": "configuracao",
-          "title": "Configuração",
-          "summary": "Preparar projeto e chaves.",
-          "owners": ["Grupo"],
-          "durationHours": 2,
-          "activities": [
-            {
-              "id": "console",
-              "label": "Configurar console",
-              "description": "Criar projeto Firebase, app web e ativar Authentication/Firestore."
-            },
-            {
-              "id": "variaveis",
-              "label": "Gerenciar chaves",
-              "description": "Adicionar variáveis em `.env` e configurar `app.config.ts`."
-            }
-          ],
-          "deliverables": [
-            {
-              "id": "credenciais",
-              "label": "Credenciais seguras",
-              "description": "Arquivo `.env` armazenado com segurança e compartilhado via cofre institucional."
-            }
-          ],
-          "risks": [
-            {
-              "id": "vazamento",
-              "label": "Vazamento de chaves",
-              "severity": "high",
-              "mitigation": "Usar gitignore, secrets do GitHub e revisão dupla antes de commits."
-            }
-          ],
-          "checkpoints": ["Projeto criado", "Chaves seguras"]
+          "type": "paragraph",
+          "text": "Atividade avaliativa que valida segurança e sincronização em nuvem."
         },
         {
-          "id": "implementacao",
-          "title": "Implementação",
-          "summary": "Desenvolver fluxo de autenticação e persistência.",
-          "owners": ["Grupo"],
-          "durationHours": 4,
-          "activities": [
+          "type": "unorderedList",
+          "items": [
             {
-              "id": "auth",
-              "label": "Implementar Auth",
-              "description": "Cadastrar/login usuário, tratar erros e proteger rotas."
+              "text": "Configuração | Preparar projeto e chaves. | Responsáveis: Grupo | Duração: 2h | Atividades: Configurar console; Gerenciar chaves | Entregáveis: Credenciais seguras | Riscos: Vazamento de chaves (Usar gitignore, secrets do GitHub e revisão dupla antes de commits.) | Checkpoints: Projeto criado, Chaves seguras"
             },
             {
-              "id": "crud",
-              "label": "CRUD Firestore",
-              "description": "Criar/atualizar documentos com listeners em tempo real."
-            }
-          ],
-          "deliverables": [
-            {
-              "id": "branch",
-              "label": "Branch `feature/firebase`",
-              "description": "Push com código funcional e testes básicos."
-            }
-          ],
-          "risks": [
-            {
-              "id": "quota",
-              "label": "Limite de quota",
-              "severity": "medium",
-              "mitigation": "Configurar regras para evitar escritas excessivas e usar mocks em testes."
-            }
-          ],
-          "checkpoints": ["Auth funcionando", "Firestore sincronizando"]
-        },
-        {
-          "id": "validacao",
-          "title": "Validação",
-          "summary": "Testes, segurança e documentação.",
-          "owners": ["Grupo"],
-          "durationHours": 1.5,
-          "activities": [
-            {
-              "id": "regras",
-              "label": "Testar regras",
-              "description": "Usar Firebase Emulator Suite para validar permissões."
+              "text": "Implementação | Desenvolver fluxo de autenticação e persistência. | Responsáveis: Grupo | Duração: 4h | Atividades: Implementar Auth; CRUD Firestore | Entregáveis: Branch `feature/firebase` | Riscos: Limite de quota (Configurar regras para evitar escritas excessivas e usar mocks em testes.) | Checkpoints: Auth funcionando, Firestore sincronizando"
             },
             {
-              "id": "video",
-              "label": "Gravar walkthrough",
-              "description": "Vídeo curto demonstrando fluxo de login e sincronização."
+              "text": "Validação | Testes, segurança e documentação. | Responsáveis: Grupo | Duração: 1.5h | Atividades: Testar regras; Gravar walkthrough | Entregáveis: Checklist de segurança | Riscos: Regras permissivas (Revisão cruzada e uso de simulador antes de publicar.) | Checkpoints: Regras aprovadas, Vídeo enviado"
             }
-          ],
-          "deliverables": [
-            {
-              "id": "checklist",
-              "label": "Checklist de segurança",
-              "description": "Documento anexado no AVA com resultados dos testes."
-            }
-          ],
-          "risks": [
-            {
-              "id": "falha-seguranca",
-              "label": "Regras permissivas",
-              "severity": "high",
-              "mitigation": "Revisão cruzada e uso de simulador antes de publicar."
-            }
-          ],
-          "checkpoints": ["Regras aprovadas", "Vídeo enviado"]
+          ]
         }
       ]
     },
@@ -289,8 +212,8 @@
           "text": "O código reforça os padrões de navegação modular discutidos em Oficina React Native + Firebase usando Expo e React Navigation."
         },
         {
-          "type": "code",
-          "language": "tsx",
+          "type": "codeBlock",
+          "language": "c",
           "code": "import { useEffect } from 'react'\nimport { NavigationContainer } from '@react-navigation/native'\nimport { createNativeStackNavigator } from '@react-navigation/native-stack'\n\nconst Stack = createNativeStackNavigator()\n\nexport function App() {\n  useEffect(() => {\n    console.log('Oficina React Native + Firebase: stack pronto')\n  }, [])\n\n  return (\n    <NavigationContainer>\n      <Stack.Navigator>\n        <Stack.Screen name=\"Home\" component={HomeScreen} />\n      </Stack.Navigator>\n    </NavigationContainer>\n  )\n}\n// Referência: FIREBASE (2024)"
         },
         {

--- a/src/content/courses/ddm/lessons/lesson-35.json
+++ b/src/content/courses/ddm/lessons/lesson-35.json
@@ -54,15 +54,39 @@
   },
   "content": [
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo da aula",
-      "items": [
-        "Contextualização: objetivos do projeto integrador e critérios de avaliação finais.",
-        "Revisão de backlog e priorização com foco em valor mínimo viável.",
-        "Matriz de riscos e definição de ações mitigadoras.",
-        "Planejamento de sprints de acompanhamento (Aulas 36 e 37).",
-        "Checklist de documentação e integração com Moodle.",
-        "Síntese e definição de próximos passos."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "Contextualização",
+          "content": "objetivos do projeto integrador e critérios de avaliação finais."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Revisão de backlog e priorização com foco em valor mínimo...",
+          "content": "Revisão de backlog e priorização com foco em valor mínimo viável."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Matriz de riscos e definição de ações mitigadoras.",
+          "content": "Matriz de riscos e definição de ações mitigadoras."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Planejamento de sprints de acompanhamento (Aulas 36 e 37).",
+          "content": "Planejamento de sprints de acompanhamento (Aulas 36 e 37)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Checklist de documentação e integração com Moodle.",
+          "content": "Checklist de documentação e integração com Moodle."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Síntese e definição de próximos passos.",
+          "content": "Síntese e definição de próximos passos."
+        }
       ]
     },
     {

--- a/src/content/courses/ddm/lessons/lesson-36.json
+++ b/src/content/courses/ddm/lessons/lesson-36.json
@@ -50,15 +50,39 @@
   },
   "content": [
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo da aula",
-      "items": [
-        "Daily meeting estendida para alinhamento de prioridades.",
-        "Hands-on: implementação dos itens críticos do sprint.",
-        "Mentorias em pares focadas em integração contínua e testes automatizados.",
-        "Revisão de código orientada por checklist técnico.",
-        "Registro de evidências e atualização do relatório semanal.",
-        "Agendamento de pendências para o Ciclo 2 (Aula 37)."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "Daily meeting estendida para alinhamento de prioridades.",
+          "content": "Daily meeting estendida para alinhamento de prioridades."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Hands-on",
+          "content": "implementação dos itens críticos do sprint."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Mentorias em pares focadas em integração contínua e teste...",
+          "content": "Mentorias em pares focadas em integração contínua e testes automatizados."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Revisão de código orientada por checklist técnico.",
+          "content": "Revisão de código orientada por checklist técnico."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Registro de evidências e atualização do relatório semanal.",
+          "content": "Registro de evidências e atualização do relatório semanal."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Agendamento de pendências para o Ciclo 2 (Aula 37).",
+          "content": "Agendamento de pendências para o Ciclo 2 (Aula 37)."
+        }
       ]
     },
     {

--- a/src/content/courses/ddm/lessons/lesson-37.json
+++ b/src/content/courses/ddm/lessons/lesson-37.json
@@ -54,15 +54,39 @@
   },
   "content": [
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo da aula",
-      "items": [
-        "Retrospectiva rápida do Ciclo 1 e ajustes incorporados.",
-        "Execução assistida de testes integrados e instrumentados.",
-        "Sessões de UX review com heurísticas e feedback entre pares.",
-        "Construção de métricas e storytelling com dashboards.",
-        "Atualização da documentação e materiais de apresentação.",
-        "Planejamento da Aula 38 (ensaio de pitch e documentação final)."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "Retrospectiva rápida do Ciclo 1 e ajustes incorporados.",
+          "content": "Retrospectiva rápida do Ciclo 1 e ajustes incorporados."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Execução assistida de testes integrados e instrumentados.",
+          "content": "Execução assistida de testes integrados e instrumentados."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Sessões de UX review com heurísticas e feedback entre pares.",
+          "content": "Sessões de UX review com heurísticas e feedback entre pares."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Construção de métricas e storytelling com dashboards.",
+          "content": "Construção de métricas e storytelling com dashboards."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Atualização da documentação e materiais de apresentação.",
+          "content": "Atualização da documentação e materiais de apresentação."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Planejamento da Aula 38 (ensaio de pitch e documentação f...",
+          "content": "Planejamento da Aula 38 (ensaio de pitch e documentação final)."
+        }
       ]
     },
     {

--- a/src/content/courses/ddm/lessons/lesson-38.json
+++ b/src/content/courses/ddm/lessons/lesson-38.json
@@ -54,15 +54,39 @@
   },
   "content": [
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano de voo da aula",
-      "items": [
-        "Kick-off: alinhamento das regras da banca e critérios NP3.",
-        "Construção colaborativa do roteiro (Pitch Canvas).",
-        "Mentorias sobre slides, demo e materiais de apoio.",
-        "Ensaio cronometrado com registro em vídeo.",
-        "Feedback 360° (colegas, docentes, mentores).",
-        "Checklist final de documentação e submissão Moodle."
+      "cards": [
+        {
+          "icon": "check-circle",
+          "title": "Kick-off",
+          "content": "alinhamento das regras da banca e critérios NP3."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Construção colaborativa do roteiro (Pitch Canvas).",
+          "content": "Construção colaborativa do roteiro (Pitch Canvas)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Mentorias sobre slides, demo e materiais de apoio.",
+          "content": "Mentorias sobre slides, demo e materiais de apoio."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Ensaio cronometrado com registro em vídeo.",
+          "content": "Ensaio cronometrado com registro em vídeo."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Feedback 360° (colegas, docentes, mentores).",
+          "content": "Feedback 360° (colegas, docentes, mentores)."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Checklist final de documentação e submissão Moodle.",
+          "content": "Checklist final de documentação e submissão Moodle."
+        }
       ]
     },
     {

--- a/src/content/courses/tgs/lessons/lesson-22.json
+++ b/src/content/courses/tgs/lessons/lesson-22.json
@@ -25,61 +25,58 @@
       ]
     },
     {
-      "type": "md3Table",
+      "type": "contentBlock",
       "title": "Domínios de dados mestres",
-      "headers": ["Domínio", "Exemplos", "Riscos de baixa qualidade", "Controles sugeridos"],
-      "rows": [
-        [
-          "Produtos",
-          "SKU, unidade, impostos",
-          "Tributação incorreta, estoque divergente",
-          "Revisão fiscal, validação automática"
-        ],
-        [
-          "Clientes",
-          "CNPJ/CPF, crédito, endereço",
-          "Faturamento rejeitado, inadimplência",
-          "Consulta a bureaus, SLA de atualização"
-        ],
-        [
-          "Fornecedores",
-          "Dados bancários, condições",
-          "Pagamentos indevidos, compras bloqueadas",
-          "Validação bancária, segregação"
-        ],
-        [
-          "Localidades",
-          "Centros, armazéns",
-          "Logística ineficiente, relatórios errados",
-          "Checklist de abertura, auditoria"
-        ],
-        [
-          "Recursos humanos",
-          "Colaboradores, cargos",
-          "Erro em folha, acesso inadequado",
-          "Integração com SSO, dupla aprovação"
-        ]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Domínio: Produtos | Exemplos: SKU, unidade, impostos | Riscos de baixa qualidade: Tributação incorreta, estoque divergente | Controles sugeridos: Revisão fiscal, validação automática"
+            },
+            {
+              "text": "Domínio: Clientes | Exemplos: CNPJ/CPF, crédito, endereço | Riscos de baixa qualidade: Faturamento rejeitado, inadimplência | Controles sugeridos: Consulta a bureaus, SLA de atualização"
+            },
+            {
+              "text": "Domínio: Fornecedores | Exemplos: Dados bancários, condições | Riscos de baixa qualidade: Pagamentos indevidos, compras bloqueadas | Controles sugeridos: Validação bancária, segregação"
+            },
+            {
+              "text": "Domínio: Localidades | Exemplos: Centros, armazéns | Riscos de baixa qualidade: Logística ineficiente, relatórios errados | Controles sugeridos: Checklist de abertura, auditoria"
+            },
+            {
+              "text": "Domínio: Recursos humanos | Exemplos: Colaboradores, cargos | Riscos de baixa qualidade: Erro em folha, acesso inadequado | Controles sugeridos: Integração com SSO, dupla aprovação"
+            }
+          ]
+        }
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Papéis na governança",
-      "cards": [
+      "items": [
         {
           "title": "Data owner",
-          "content": "Responsável por políticas, indicadores e aprovação final."
+          "content": "Responsável por políticas, indicadores e aprovação final.",
+          "language": "plaintext",
+          "code": "Responsável por políticas, indicadores e aprovação final."
         },
         {
           "title": "Data steward",
-          "content": "Orquestra cadastros, conduz limpezas e monitora qualidade."
+          "content": "Orquestra cadastros, conduz limpezas e monitora qualidade.",
+          "language": "plaintext",
+          "code": "Orquestra cadastros, conduz limpezas e monitora qualidade."
         },
         {
           "title": "Usuário chave",
-          "content": "Solicita alterações e valida aderência ao processo."
+          "content": "Solicita alterações e valida aderência ao processo.",
+          "language": "plaintext",
+          "code": "Solicita alterações e valida aderência ao processo."
         },
         {
           "title": "TI/Segurança",
-          "content": "Mantém controles de acesso, logs e trilhas de auditoria."
+          "content": "Mantém controles de acesso, logs e trilhas de auditoria.",
+          "language": "plaintext",
+          "code": "Mantém controles de acesso, logs e trilhas de auditoria."
         }
       ]
     },
@@ -183,19 +180,26 @@
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Resposta a incidentes de dados",
-      "steps": [
+      "content": [
         {
-          "title": "Detecção",
-          "content": "Monitor identifica ruptura de qualidade ou violação de acesso."
-        },
-        { "title": "Comunicação", "content": "Data steward notifica stakeholders e abre chamado." },
-        {
-          "title": "Correção",
-          "content": "Equipe executa plano de remediação priorizando processos críticos."
-        },
-        { "title": "Prevenção", "content": "Revisão das políticas e atualização de treinamentos." }
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Detecção – Monitor identifica ruptura de qualidade ou violação de acesso."
+            },
+            {
+              "text": "Comunicação – Data steward notifica stakeholders e abre chamado."
+            },
+            {
+              "text": "Correção – Equipe executa plano de remediação priorizando processos críticos."
+            },
+            {
+              "text": "Prevenção – Revisão das políticas e atualização de treinamentos."
+            }
+          ]
+        }
       ]
     },
     {

--- a/src/content/courses/tgs/lessons/lesson-23.json
+++ b/src/content/courses/tgs/lessons/lesson-23.json
@@ -25,61 +25,82 @@
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Fases de implantação",
-      "steps": [
+      "content": [
         {
-          "title": "Descoberta",
-          "content": "Alinhamento estratégico, levantamento de processos atuais."
-        },
-        { "title": "Desenho", "content": "To-be, configurações, integrações planejadas." },
-        {
-          "title": "Construção",
-          "content": "Parametrização, desenvolvimentos complementares, testes unitários."
-        },
-        { "title": "Validação", "content": "Testes integrados, migração piloto, treinamento." },
-        { "title": "Cutover", "content": "Plano de virada, estabilização, suporte hiper-care." }
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Descoberta – Alinhamento estratégico, levantamento de processos atuais."
+            },
+            {
+              "text": "Desenho – To-be, configurações, integrações planejadas."
+            },
+            {
+              "text": "Construção – Parametrização, desenvolvimentos complementares, testes unitários."
+            },
+            {
+              "text": "Validação – Testes integrados, migração piloto, treinamento."
+            },
+            {
+              "text": "Cutover – Plano de virada, estabilização, suporte hiper-care."
+            }
+          ]
+        }
       ]
     },
     {
-      "type": "md3Table",
+      "type": "contentBlock",
       "title": "Comparativo de abordagens",
-      "headers": ["Abordagem", "Vantagens", "Riscos", "Quando usar"],
-      "rows": [
-        [
-          "Big bang",
-          "Transição única, simplifica interfaces temporárias",
-          "Maior impacto caso ocorra falha",
-          "Organizações com alta disciplina e forte patrocínio"
-        ],
-        [
-          "Ondas",
-          "Permite aprendizado incremental",
-          "Integrações temporárias e custo prolongado",
-          "Empresas multinegócio ou com alta complexidade"
-        ],
-        [
-          "Greenfield",
-          "Revisão completa de processos",
-          "Esforço elevado de gestão da mudança",
-          "Cenários com legado obsoleto"
-        ],
-        [
-          "Brownfield",
-          "Aproveita configurações existentes",
-          "Risco de carregar problemas antigos",
-          "Quando há boa aderência ao template global"
-        ]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Abordagem: Big bang | Vantagens: Transição única, simplifica interfaces temporárias | Riscos: Maior impacto caso ocorra falha | Quando usar: Organizações com alta disciplina e forte patrocínio"
+            },
+            {
+              "text": "Abordagem: Ondas | Vantagens: Permite aprendizado incremental | Riscos: Integrações temporárias e custo prolongado | Quando usar: Empresas multinegócio ou com alta complexidade"
+            },
+            {
+              "text": "Abordagem: Greenfield | Vantagens: Revisão completa de processos | Riscos: Esforço elevado de gestão da mudança | Quando usar: Cenários com legado obsoleto"
+            },
+            {
+              "text": "Abordagem: Brownfield | Vantagens: Aproveita configurações existentes | Riscos: Risco de carregar problemas antigos | Quando usar: Quando há boa aderência ao template global"
+            }
+          ]
+        }
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Riscos prioritários",
-      "cards": [
-        { "title": "Dados", "content": "Migração incompleta pode interromper faturamento." },
-        { "title": "Processos", "content": "Workflows não testados geram filas e retrabalho." },
-        { "title": "Pessoas", "content": "Usuários resistentes atrasam adoção." },
-        { "title": "Tecnologia", "content": "Infraestrutura insuficiente afeta performance." }
+      "items": [
+        {
+          "title": "Dados",
+          "content": "Migração incompleta pode interromper faturamento.",
+          "language": "plaintext",
+          "code": "Migração incompleta pode interromper faturamento."
+        },
+        {
+          "title": "Processos",
+          "content": "Workflows não testados geram filas e retrabalho.",
+          "language": "plaintext",
+          "code": "Workflows não testados geram filas e retrabalho."
+        },
+        {
+          "title": "Pessoas",
+          "content": "Usuários resistentes atrasam adoção.",
+          "language": "plaintext",
+          "code": "Usuários resistentes atrasam adoção."
+        },
+        {
+          "title": "Tecnologia",
+          "content": "Infraestrutura insuficiente afeta performance.",
+          "language": "plaintext",
+          "code": "Infraestrutura insuficiente afeta performance."
+        }
       ]
     },
     {

--- a/src/content/courses/tgs/lessons/lesson-24.json
+++ b/src/content/courses/tgs/lessons/lesson-24.json
@@ -25,66 +25,81 @@
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Agenda do sábado letivo",
-      "steps": [
-        { "title": "08h00 — Kick-off", "content": "Briefing do caso, papéis e entregáveis." },
+      "content": [
         {
-          "title": "09h00 — Deep dive",
-          "content": "Análise de documentos de blueprint, matriz de integrações e plano de testes."
-        },
-        {
-          "title": "10h30 — Simulação",
-          "content": "War room com incidentes simulados envolvendo SAP PP, MM e PM."
-        },
-        {
-          "title": "11h30 — Recomendações",
-          "content": "Elaboração de plano de estabilização e lições aprendidas."
-        },
-        {
-          "title": "12h15 — Pitch final",
-          "content": "Apresentação de sínteses para banca avaliadora."
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "08h00 — Kick-off – Briefing do caso, papéis e entregáveis."
+            },
+            {
+              "text": "09h00 — Deep dive – Análise de documentos de blueprint, matriz de integrações e plano de testes."
+            },
+            {
+              "text": "10h30 — Simulação – War room com incidentes simulados envolvendo SAP PP, MM e PM."
+            },
+            {
+              "text": "11h30 — Recomendações – Elaboração de plano de estabilização e lições aprendidas."
+            },
+            {
+              "text": "12h15 — Pitch final – Apresentação de sínteses para banca avaliadora."
+            }
+          ]
         }
       ]
     },
     {
-      "type": "md3Table",
+      "type": "contentBlock",
       "title": "Artefatos fornecidos",
-      "headers": ["Documento", "Descrição", "Uso durante a imersão"],
-      "rows": [
-        [
-          "Blueprint PP",
-          "Processos de planejamento e execução da produção",
-          "Identificar dependências com manutenção"
-        ],
-        ["Matriz de integrações", "Fluxos entre SAP, MES e sensores IoT", "Mapear pontos de falha"],
-        [
-          "Plano de testes",
-          "Roteiros de cenários críticos",
-          "Distribuir entre squads e avaliar cobertura"
-        ],
-        ["Dashboard de incidentes", "Registros pós-go-live", "Priorizar ações de estabilização"]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Documento: Blueprint PP | Descrição: Processos de planejamento e execução da produção | Uso durante a imersão: Identificar dependências com manutenção"
+            },
+            {
+              "text": "Documento: Matriz de integrações | Descrição: Fluxos entre SAP, MES e sensores IoT | Uso durante a imersão: Mapear pontos de falha"
+            },
+            {
+              "text": "Documento: Plano de testes | Descrição: Roteiros de cenários críticos | Uso durante a imersão: Distribuir entre squads e avaliar cobertura"
+            },
+            {
+              "text": "Documento: Dashboard de incidentes | Descrição: Registros pós-go-live | Uso durante a imersão: Priorizar ações de estabilização"
+            }
+          ]
+        }
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Desafios para os squads",
-      "cards": [
+      "items": [
         {
           "title": "Squad Produção",
-          "content": "Avaliar sincronização PP ↔ MES e gargalos de ordens."
+          "content": "Avaliar sincronização PP ↔ MES e gargalos de ordens.",
+          "language": "plaintext",
+          "code": "Avaliar sincronização PP ↔ MES e gargalos de ordens."
         },
         {
           "title": "Squad Manutenção",
-          "content": "Analisar integração PM com sensores e estoque de peças."
+          "content": "Analisar integração PM com sensores e estoque de peças.",
+          "language": "plaintext",
+          "code": "Analisar integração PM com sensores e estoque de peças."
         },
         {
           "title": "Squad Qualidade",
-          "content": "Checar rastreabilidade e registros de não conformidade."
+          "content": "Checar rastreabilidade e registros de não conformidade.",
+          "language": "plaintext",
+          "code": "Checar rastreabilidade e registros de não conformidade."
         },
         {
           "title": "Squad Governança",
-          "content": "Definir indicadores e ritos de acompanhamento pós-go-live."
+          "content": "Definir indicadores e ritos de acompanhamento pós-go-live.",
+          "language": "plaintext",
+          "code": "Definir indicadores e ritos de acompanhamento pós-go-live."
         }
       ]
     },

--- a/src/content/courses/tgs/lessons/lesson-28.json
+++ b/src/content/courses/tgs/lessons/lesson-28.json
@@ -4,53 +4,87 @@
   "objective": "Mensurar a capacidade de aplicar pensamento sistêmico na análise de organizações complexas.",
   "content": [
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Plano da avaliação",
-      "items": [
-        "Data e duração: Prova NP2 presencial com 110 minutos de duração.",
-        "Foco: Aplicar pensamento sistêmico em estudos de caso envolvendo homeostase, feedback e fronteiras.",
-        "Formato: Questões discursivas e análise de diagramas fornecidos.",
-        "Preparação: Revisar aulas 6 a 10, anotações de laboratório e discussões no fórum.",
-        "Pós-prova: Registrar percepções e dúvidas para a devolutiva coletiva."
-      ]
-    },
-    {
-      "type": "cardGrid",
-      "title": "Competências avaliadas",
       "cards": [
         {
-          "title": "Modelagem",
-          "content": "Representar fluxos e loops de feedback destacando variáveis críticas."
+          "icon": "check-circle",
+          "title": "Data e duração",
+          "content": "Prova NP2 presencial com 110 minutos de duração."
         },
         {
-          "title": "Diagnóstico",
-          "content": "Identificar causas raiz e pontos de ruptura em sistemas abertos."
+          "icon": "check-circle",
+          "title": "Foco",
+          "content": "Aplicar pensamento sistêmico em estudos de caso envolvendo homeostase, feedback e fronteiras."
         },
         {
-          "title": "Intervenção",
-          "content": "Propor ações que preservem homeostase ou conduzam à transformação desejada."
+          "icon": "check-circle",
+          "title": "Formato",
+          "content": "Questões discursivas e análise de diagramas fornecidos."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Preparação",
+          "content": "Revisar aulas 6 a 10, anotações de laboratório e discussões no fórum."
+        },
+        {
+          "icon": "check-circle",
+          "title": "Pós-prova",
+          "content": "Registrar percepções e dúvidas para a devolutiva coletiva."
         }
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
+      "title": "Competências avaliadas",
+      "items": [
+        {
+          "title": "Modelagem",
+          "content": "Representar fluxos e loops de feedback destacando variáveis críticas.",
+          "language": "plaintext",
+          "code": "Representar fluxos e loops de feedback destacando variáveis críticas."
+        },
+        {
+          "title": "Diagnóstico",
+          "content": "Identificar causas raiz e pontos de ruptura em sistemas abertos.",
+          "language": "plaintext",
+          "code": "Identificar causas raiz e pontos de ruptura em sistemas abertos."
+        },
+        {
+          "title": "Intervenção",
+          "content": "Propor ações que preservem homeostase ou conduzam à transformação desejada.",
+          "language": "plaintext",
+          "code": "Propor ações que preservem homeostase ou conduzam à transformação desejada."
+        }
+      ]
+    },
+    {
+      "type": "representations",
       "title": "Backlog preventivo pré-avaliação",
-      "cards": [
+      "items": [
         {
           "title": "Loops de feedback",
-          "content": "Revisar mapas produzidos, verificar polaridade e indicadores associados."
+          "content": "Revisar mapas produzidos, verificar polaridade e indicadores associados.",
+          "language": "plaintext",
+          "code": "Revisar mapas produzidos, verificar polaridade e indicadores associados."
         },
         {
           "title": "Homeostase",
-          "content": "Listar exemplos e contraexemplos em cada estudo de caso trabalhado."
+          "content": "Listar exemplos e contraexemplos em cada estudo de caso trabalhado.",
+          "language": "plaintext",
+          "code": "Listar exemplos e contraexemplos em cada estudo de caso trabalhado."
         },
         {
           "title": "Fronteiras",
-          "content": "Checar delimitações do sistema, atores e fluxos externos relevantes."
+          "content": "Checar delimitações do sistema, atores e fluxos externos relevantes.",
+          "language": "plaintext",
+          "code": "Checar delimitações do sistema, atores e fluxos externos relevantes."
         },
         {
           "title": "Riscos & mitigação",
-          "content": "Registrar hipóteses de ruptura e contramedidas no quadro colaborativo."
+          "content": "Registrar hipóteses de ruptura e contramedidas no quadro colaborativo.",
+          "language": "plaintext",
+          "code": "Registrar hipóteses de ruptura e contramedidas no quadro colaborativo."
         }
       ]
     },
@@ -82,24 +116,25 @@
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Oficina de revisão (véspera da NP2)",
-      "steps": [
+      "content": [
         {
-          "title": "Bloco 1 — Diagnóstico",
-          "content": "15 min para avaliar rubric score da aula 25-27 e definir lacunas prioritárias."
-        },
-        {
-          "title": "Bloco 2 — Troca entre duplas",
-          "content": "20 min de revisão cruzada utilizando o board de pares para comentar mapas sistêmicos."
-        },
-        {
-          "title": "Bloco 3 — Mini-simulado",
-          "content": "30 min respondendo questão inédita e comparando com gabarito comentado."
-        },
-        {
-          "title": "Bloco 4 — Ações preventivas",
-          "content": "15 min para atualizar backlog preventivo, definir métricas de acompanhamento e próximos passos."
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Bloco 1 — Diagnóstico – 15 min para avaliar rubric score da aula 25-27 e definir lacunas prioritárias."
+            },
+            {
+              "text": "Bloco 2 — Troca entre duplas – 20 min de revisão cruzada utilizando o board de pares para comentar mapas sistêmicos."
+            },
+            {
+              "text": "Bloco 3 — Mini-simulado – 30 min respondendo questão inédita e comparando com gabarito comentado."
+            },
+            {
+              "text": "Bloco 4 — Ações preventivas – 15 min para atualizar backlog preventivo, definir métricas de acompanhamento e próximos passos."
+            }
+          ]
         }
       ]
     },

--- a/src/content/courses/tgs/lessons/lesson-30.json
+++ b/src/content/courses/tgs/lessons/lesson-30.json
@@ -4,61 +4,77 @@
   "objective": "Aplicar ferramentas de diagnóstico para mapear forças, fraquezas, oportunidades e ameaças do ambiente de SI.",
   "content": [
     {
-      "type": "flightPlan",
+      "type": "lessonPlan",
       "title": "Agenda",
-      "items": [
-        "Revisão de fontes de dados para diagnóstico interno e externo.",
-        "Construção colaborativa da matriz SWOT específica para SI.",
-        "Priorização de riscos e vantagens competitivas."
-      ]
-    },
-    {
-      "type": "cardGrid",
-      "title": "Fontes essenciais do diagnóstico",
       "cards": [
         {
-          "title": "Inventário de ativos",
-          "content": "Lista de sistemas, contratos, integrações e custos associados."
+          "icon": "check-circle",
+          "title": "Revisão de fontes de dados para diagnóstico interno e ext...",
+          "content": "Revisão de fontes de dados para diagnóstico interno e externo."
         },
         {
-          "title": "Mapa de processos",
-          "content": "Fluxos ponta a ponta com indicadores de desempenho e gargalos."
+          "icon": "check-circle",
+          "title": "Construção colaborativa da matriz SWOT específica para SI.",
+          "content": "Construção colaborativa da matriz SWOT específica para SI."
         },
         {
-          "title": "Pesquisa com stakeholders",
-          "content": "Entrevistas, workshops e NPS de áreas usuárias para captar expectativas."
-        },
-        {
-          "title": "Análise de tendências",
-          "content": "Relatórios de mercado, concorrentes e benchmarks regulatórios."
+          "icon": "check-circle",
+          "title": "Priorização de riscos e vantagens competitivas.",
+          "content": "Priorização de riscos e vantagens competitivas."
         }
       ]
     },
     {
-      "type": "md3Table",
+      "type": "representations",
+      "title": "Fontes essenciais do diagnóstico",
+      "items": [
+        {
+          "title": "Inventário de ativos",
+          "content": "Lista de sistemas, contratos, integrações e custos associados.",
+          "language": "plaintext",
+          "code": "Lista de sistemas, contratos, integrações e custos associados."
+        },
+        {
+          "title": "Mapa de processos",
+          "content": "Fluxos ponta a ponta com indicadores de desempenho e gargalos.",
+          "language": "plaintext",
+          "code": "Fluxos ponta a ponta com indicadores de desempenho e gargalos."
+        },
+        {
+          "title": "Pesquisa com stakeholders",
+          "content": "Entrevistas, workshops e NPS de áreas usuárias para captar expectativas.",
+          "language": "plaintext",
+          "code": "Entrevistas, workshops e NPS de áreas usuárias para captar expectativas."
+        },
+        {
+          "title": "Análise de tendências",
+          "content": "Relatórios de mercado, concorrentes e benchmarks regulatórios.",
+          "language": "plaintext",
+          "code": "Relatórios de mercado, concorrentes e benchmarks regulatórios."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
       "title": "Matriz SWOT orientada a SI",
-      "headers": ["Quadrante", "Perguntas de apoio", "Exemplos de achados"],
-      "rows": [
-        [
-          "Forças",
-          "Quais capacidades tecnológicas já diferenciam o negócio?",
-          "Time ágil maduro, arquitetura em microserviços, governança de dados consolidada"
-        ],
-        [
-          "Fraquezas",
-          "Onde estão os principais gargalos internos?",
-          "Backlog represado, dependência de fornecedor único, automação limitada"
-        ],
-        [
-          "Oportunidades",
-          "Que movimentos de mercado podem ser acelerados com SI?",
-          "Open finance, parcerias com startups, analytics avançado"
-        ],
-        [
-          "Ameaças",
-          "Que riscos externos podem comprometer resultados?",
-          "Novos entrantes digitais, ataques cibernéticos, mudanças regulatórias"
-        ]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Quadrante: Forças | Perguntas de apoio: Quais capacidades tecnológicas já diferenciam o negócio? | Exemplos de achados: Time ágil maduro, arquitetura em microserviços, governança de dados consolidada"
+            },
+            {
+              "text": "Quadrante: Fraquezas | Perguntas de apoio: Onde estão os principais gargalos internos? | Exemplos de achados: Backlog represado, dependência de fornecedor único, automação limitada"
+            },
+            {
+              "text": "Quadrante: Oportunidades | Perguntas de apoio: Que movimentos de mercado podem ser acelerados com SI? | Exemplos de achados: Open finance, parcerias com startups, analytics avançado"
+            },
+            {
+              "text": "Quadrante: Ameaças | Perguntas de apoio: Que riscos externos podem comprometer resultados? | Exemplos de achados: Novos entrantes digitais, ataques cibernéticos, mudanças regulatórias"
+            }
+          ]
+        }
       ]
     },
     {
@@ -114,18 +130,25 @@
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Roteiro de diagnóstico em 4 semanas",
-      "steps": [
+      "content": [
         {
-          "title": "Semana 1",
-          "content": "Coleta dados internos: inventários, custos e indicadores."
-        },
-        { "title": "Semana 2", "content": "Realiza entrevistas e jornadas com áreas de negócio." },
-        { "title": "Semana 3", "content": "Analisa tendências, concorrentes e riscos externos." },
-        {
-          "title": "Semana 4",
-          "content": "Consolida SWOT, prioriza achados e prepara workshop de validação."
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Semana 1 – Coleta dados internos: inventários, custos e indicadores."
+            },
+            {
+              "text": "Semana 2 – Realiza entrevistas e jornadas com áreas de negócio."
+            },
+            {
+              "text": "Semana 3 – Analisa tendências, concorrentes e riscos externos."
+            },
+            {
+              "text": "Semana 4 – Consolida SWOT, prioriza achados e prepara workshop de validação."
+            }
+          ]
         }
       ]
     },

--- a/src/content/courses/tgs/lessons/lesson-31.json
+++ b/src/content/courses/tgs/lessons/lesson-31.json
@@ -4,42 +4,59 @@
   "objective": "Avaliar capacidades internas de SI para orientar decisões do portfólio estratégico.",
   "content": [
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Dimensões da capacidade digital",
-      "cards": [
+      "items": [
         {
           "title": "Arquitetura",
-          "content": "Sistemas, integrações, dados e padrões que sustentam entregas."
+          "content": "Sistemas, integrações, dados e padrões que sustentam entregas.",
+          "language": "plaintext",
+          "code": "Sistemas, integrações, dados e padrões que sustentam entregas."
         },
         {
           "title": "Talentos",
-          "content": "Competências técnicas, soft skills e estruturas de squads."
+          "content": "Competências técnicas, soft skills e estruturas de squads.",
+          "language": "plaintext",
+          "code": "Competências técnicas, soft skills e estruturas de squads."
         },
         {
           "title": "Processos",
-          "content": "Ritos, governança de mudanças e automação de fluxos."
+          "content": "Ritos, governança de mudanças e automação de fluxos.",
+          "language": "plaintext",
+          "code": "Ritos, governança de mudanças e automação de fluxos."
         },
         {
           "title": "Cultura",
-          "content": "Abertura à experimentação, colaboração e aprendizado contínuo."
+          "content": "Abertura à experimentação, colaboração e aprendizado contínuo.",
+          "language": "plaintext",
+          "code": "Abertura à experimentação, colaboração e aprendizado contínuo."
         }
       ]
     },
     {
-      "type": "md3Table",
+      "type": "contentBlock",
       "title": "Matriz de criticidade dos processos",
-      "headers": ["Processo", "Impacto no negócio", "Saúde atual", "Observações"],
-      "rows": [
-        ["Onboarding de clientes", "Alta", "Baixa", "Integrações manuais geram atrasos de 48h"],
-        ["Fechamento financeiro", "Alta", "Média", "Dependência de planilhas fora do ERP"],
-        ["Gestão de estoque", "Média", "Alta", "Automação consolidada com IoT e WMS"],
-        [
-          "Suporte ao cliente",
-          "Alta",
-          "Baixa",
-          "Falta visão 360° e base de conhecimento unificada"
-        ],
-        ["Gestão de campanhas", "Média", "Média", "Ferramentas diversas sem governança comum"]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Processo: Onboarding de clientes | Impacto no negócio: Alta | Saúde atual: Baixa | Observações: Integrações manuais geram atrasos de 48h"
+            },
+            {
+              "text": "Processo: Fechamento financeiro | Impacto no negócio: Alta | Saúde atual: Média | Observações: Dependência de planilhas fora do ERP"
+            },
+            {
+              "text": "Processo: Gestão de estoque | Impacto no negócio: Média | Saúde atual: Alta | Observações: Automação consolidada com IoT e WMS"
+            },
+            {
+              "text": "Processo: Suporte ao cliente | Impacto no negócio: Alta | Saúde atual: Baixa | Observações: Falta visão 360° e base de conhecimento unificada"
+            },
+            {
+              "text": "Processo: Gestão de campanhas | Impacto no negócio: Média | Saúde atual: Média | Observações: Ferramentas diversas sem governança comum"
+            }
+          ]
+        }
       ]
     },
     {
@@ -100,21 +117,25 @@
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Sprint de imersão nas capacidades",
-      "steps": [
+      "content": [
         {
-          "title": "Dia 1",
-          "content": "Workshop com líderes de negócio para mapear processos críticos."
-        },
-        {
-          "title": "Dia 2",
-          "content": "Avaliação técnica de sistemas e integrações prioritárias."
-        },
-        { "title": "Dia 3", "content": "Análise de competências e dimensionamento de equipes." },
-        {
-          "title": "Dia 4",
-          "content": "Consolidação dos gaps e oportunidades em relatório executivo."
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Dia 1 – Workshop com líderes de negócio para mapear processos críticos."
+            },
+            {
+              "text": "Dia 2 – Avaliação técnica de sistemas e integrações prioritárias."
+            },
+            {
+              "text": "Dia 3 – Análise de competências e dimensionamento de equipes."
+            },
+            {
+              "text": "Dia 4 – Consolidação dos gaps e oportunidades em relatório executivo."
+            }
+          ]
         }
       ]
     },

--- a/src/content/courses/tgs/lessons/lesson-32.json
+++ b/src/content/courses/tgs/lessons/lesson-32.json
@@ -238,24 +238,25 @@
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Workshop de formulação do BSC",
-      "steps": [
+      "content": [
         {
-          "title": "Pré-work",
-          "content": "Consolide SWOT e matriz de capacidades como insumo."
-        },
-        {
-          "title": "Sessão 1",
-          "content": "Definir objetivos por perspectiva com patrocínio executivo."
-        },
-        {
-          "title": "Sessão 2",
-          "content": "Selecionar indicadores e metas realistas."
-        },
-        {
-          "title": "Sessão 3",
-          "content": "Priorizar iniciativas estratégicas e donos dos objetivos."
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Pré-work – Consolide SWOT e matriz de capacidades como insumo."
+            },
+            {
+              "text": "Sessão 1 – Definir objetivos por perspectiva com patrocínio executivo."
+            },
+            {
+              "text": "Sessão 2 – Selecionar indicadores e metas realistas."
+            },
+            {
+              "text": "Sessão 3 – Priorizar iniciativas estratégicas e donos dos objetivos."
+            }
+          ]
         }
       ]
     },

--- a/src/content/courses/tgs/lessons/lesson-33.json
+++ b/src/content/courses/tgs/lessons/lesson-33.json
@@ -4,62 +4,84 @@
   "objective": "Transformar objetivos estratégicos em um roadmap priorizado de iniciativas de SI.",
   "content": [
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Critérios de priorização",
-      "cards": [
+      "items": [
         {
           "title": "Valor estratégico",
-          "content": "Contribuição direta aos objetivos do BSC e KPIs corporativos."
+          "content": "Contribuição direta aos objetivos do BSC e KPIs corporativos.",
+          "language": "plaintext",
+          "code": "Contribuição direta aos objetivos do BSC e KPIs corporativos."
         },
         {
           "title": "Urgência regulatória",
-          "content": "Prazos legais ou riscos de continuidade se não executar."
+          "content": "Prazos legais ou riscos de continuidade se não executar.",
+          "language": "plaintext",
+          "code": "Prazos legais ou riscos de continuidade se não executar."
         },
         {
           "title": "Viabilidade",
-          "content": "Disponibilidade de recursos, maturidade tecnológica e complexidade."
+          "content": "Disponibilidade de recursos, maturidade tecnológica e complexidade.",
+          "language": "plaintext",
+          "code": "Disponibilidade de recursos, maturidade tecnológica e complexidade."
         },
         {
           "title": "Dependências",
-          "content": "Sequência lógica entre iniciativas e impactos em programas correlatos."
+          "content": "Sequência lógica entre iniciativas e impactos em programas correlatos.",
+          "language": "plaintext",
+          "code": "Sequência lógica entre iniciativas e impactos em programas correlatos."
         }
       ]
     },
     {
-      "type": "md3Table",
+      "type": "contentBlock",
       "title": "Matriz de pontuação",
-      "headers": ["Iniciativa", "Valor", "Urgência", "Esforço", "Score ponderado"],
-      "rows": [
-        ["Plataforma de dados corporativos", "5", "4", "3", "4,4"],
-        ["Portal omnicanal", "4", "5", "4", "4,2"],
-        ["Automação de backoffice", "3", "3", "2", "3,2"],
-        ["Programa de cibersegurança", "5", "5", "4", "4,8"],
-        ["ERP financeiro-cloud", "4", "4", "5", "4,0"]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Iniciativa: Plataforma de dados corporativos | Valor: 5 | Urgência: 4 | Esforço: 3 | Score ponderado: 4,4"
+            },
+            {
+              "text": "Iniciativa: Portal omnicanal | Valor: 4 | Urgência: 5 | Esforço: 4 | Score ponderado: 4,2"
+            },
+            {
+              "text": "Iniciativa: Automação de backoffice | Valor: 3 | Urgência: 3 | Esforço: 2 | Score ponderado: 3,2"
+            },
+            {
+              "text": "Iniciativa: Programa de cibersegurança | Valor: 5 | Urgência: 5 | Esforço: 4 | Score ponderado: 4,8"
+            },
+            {
+              "text": "Iniciativa: ERP financeiro-cloud | Valor: 4 | Urgência: 4 | Esforço: 5 | Score ponderado: 4,0"
+            }
+          ]
+        }
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Roadmap macro (12 trimestres)",
-      "steps": [
+      "content": [
         {
-          "title": "T1-T2",
-          "content": "Quick wins regulatórios e fundação de governança de dados."
-        },
-        {
-          "title": "T3-T4",
-          "content": "Entrega da primeira onda da plataforma de dados e pilotos omnicanal."
-        },
-        {
-          "title": "T5-T6",
-          "content": "Implantação do programa de cibersegurança e automações críticas."
-        },
-        {
-          "title": "T7-T8",
-          "content": "Rollout do ERP financeiro-cloud e expansão dos casos de analytics."
-        },
-        {
-          "title": "T9-T12",
-          "content": "Escala das jornadas digitais e revisão estratégica do portfólio."
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "T1-T2 – Quick wins regulatórios e fundação de governança de dados."
+            },
+            {
+              "text": "T3-T4 – Entrega da primeira onda da plataforma de dados e pilotos omnicanal."
+            },
+            {
+              "text": "T5-T6 – Implantação do programa de cibersegurança e automações críticas."
+            },
+            {
+              "text": "T7-T8 – Rollout do ERP financeiro-cloud e expansão dos casos de analytics."
+            },
+            {
+              "text": "T9-T12 – Escala das jornadas digitais e revisão estratégica do portfólio."
+            }
+          ]
         }
       ]
     },

--- a/src/content/courses/tgs/lessons/lesson-34.json
+++ b/src/content/courses/tgs/lessons/lesson-34.json
@@ -4,53 +4,56 @@
   "objective": "Estabelecer mecanismos de governança que sustentem o alinhamento contínuo entre SI e estratégia corporativa.",
   "content": [
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Pilares de governança",
-      "cards": [
-        { "title": "Estruturas", "content": "Comitês, fóruns e papéis que conectam negócio e TI." },
+      "items": [
+        {
+          "title": "Estruturas",
+          "content": "Comitês, fóruns e papéis que conectam negócio e TI.",
+          "language": "plaintext",
+          "code": "Comitês, fóruns e papéis que conectam negócio e TI."
+        },
         {
           "title": "Processos",
-          "content": "Ritos de priorização, gestão de demanda e avaliação de benefícios."
+          "content": "Ritos de priorização, gestão de demanda e avaliação de benefícios.",
+          "language": "plaintext",
+          "code": "Ritos de priorização, gestão de demanda e avaliação de benefícios."
         },
         {
           "title": "Pessoas",
-          "content": "Patrocinadores, product owners e gestores de relacionamento."
+          "content": "Patrocinadores, product owners e gestores de relacionamento.",
+          "language": "plaintext",
+          "code": "Patrocinadores, product owners e gestores de relacionamento."
         },
         {
           "title": "Tecnologia",
-          "content": "Plataformas colaborativas, OKRs e dashboards compartilhados."
+          "content": "Plataformas colaborativas, OKRs e dashboards compartilhados.",
+          "language": "plaintext",
+          "code": "Plataformas colaborativas, OKRs e dashboards compartilhados."
         }
       ]
     },
     {
-      "type": "md3Table",
+      "type": "contentBlock",
       "title": "Fóruns de decisão",
-      "headers": ["Fórum", "Periodicidade", "Decisões", "Indicadores"],
-      "rows": [
-        [
-          "Conselho Digital",
-          "Mensal",
-          "Direcionadores estratégicos e investimentos",
-          "ROI carteira, risco tecnológico"
-        ],
-        [
-          "Comitê de Portfólio",
-          "Quinzenal",
-          "Priorização e balanceamento da carteira",
-          "Valor entregue, capacidade disponível"
-        ],
-        [
-          "Tribo de Produto",
-          "Semanal",
-          "Status das iniciativas e impedimentos",
-          "Lead time, valor gerado"
-        ],
-        [
-          "Fórum de Operações",
-          "Diário",
-          "Gestão de incidentes e disponibilidade",
-          "SLA, backlog crítico"
-        ]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Fórum: Conselho Digital | Periodicidade: Mensal | Decisões: Direcionadores estratégicos e investimentos | Indicadores: ROI carteira, risco tecnológico"
+            },
+            {
+              "text": "Fórum: Comitê de Portfólio | Periodicidade: Quinzenal | Decisões: Priorização e balanceamento da carteira | Indicadores: Valor entregue, capacidade disponível"
+            },
+            {
+              "text": "Fórum: Tribo de Produto | Periodicidade: Semanal | Decisões: Status das iniciativas e impedimentos | Indicadores: Lead time, valor gerado"
+            },
+            {
+              "text": "Fórum: Fórum de Operações | Periodicidade: Diário | Decisões: Gestão de incidentes e disponibilidade | Indicadores: SLA, backlog crítico"
+            }
+          ]
+        }
       ]
     },
     {
@@ -111,19 +114,26 @@
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Ritos de relacionamento SI-negócio",
-      "steps": [
+      "content": [
         {
-          "title": "Diariamente",
-          "content": "Dailies operacionais com presença de representantes de negócio."
-        },
-        {
-          "title": "Semanalmente",
-          "content": "Revisão de backlog integrado e indicadores de squads."
-        },
-        { "title": "Mensalmente", "content": "Comitê executivo revisa roadmap e aprova ajustes." },
-        { "title": "Trimestralmente", "content": "Planejamento integrado e recalibração dos OKRs." }
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Diariamente – Dailies operacionais com presença de representantes de negócio."
+            },
+            {
+              "text": "Semanalmente – Revisão de backlog integrado e indicadores de squads."
+            },
+            {
+              "text": "Mensalmente – Comitê executivo revisa roadmap e aprova ajustes."
+            },
+            {
+              "text": "Trimestralmente – Planejamento integrado e recalibração dos OKRs."
+            }
+          ]
+        }
       ]
     },
     {

--- a/src/content/courses/tgs/lessons/lesson-35.json
+++ b/src/content/courses/tgs/lessons/lesson-35.json
@@ -4,50 +4,59 @@
   "objective": "Definir métricas e ritos de monitoramento que assegurem a execução do planejamento estratégico de SI.",
   "content": [
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Painéis essenciais",
-      "cards": [
-        { "title": "Valor entregue", "content": "Indicadores de benefícios, adoção e satisfação." },
-        { "title": "Saúde operacional", "content": "SLA, disponibilidade, backlog e incidentes." },
-        { "title": "Capacidade", "content": "Velocidade das equipes, alocação e burn-down." },
-        { "title": "Inovação", "content": "Experimentos, pilotos em andamento e taxa de sucesso." }
+      "items": [
+        {
+          "title": "Valor entregue",
+          "content": "Indicadores de benefícios, adoção e satisfação.",
+          "language": "plaintext",
+          "code": "Indicadores de benefícios, adoção e satisfação."
+        },
+        {
+          "title": "Saúde operacional",
+          "content": "SLA, disponibilidade, backlog e incidentes.",
+          "language": "plaintext",
+          "code": "SLA, disponibilidade, backlog e incidentes."
+        },
+        {
+          "title": "Capacidade",
+          "content": "Velocidade das equipes, alocação e burn-down.",
+          "language": "plaintext",
+          "code": "Velocidade das equipes, alocação e burn-down."
+        },
+        {
+          "title": "Inovação",
+          "content": "Experimentos, pilotos em andamento e taxa de sucesso.",
+          "language": "plaintext",
+          "code": "Experimentos, pilotos em andamento e taxa de sucesso."
+        }
       ]
     },
     {
-      "type": "md3Table",
+      "type": "contentBlock",
       "title": "OKRs exemplo",
-      "headers": ["Objetivo", "Resultado-chave", "Indicador", "Frequência"],
-      "rows": [
-        [
-          "Maximizar valor das soluções digitais",
-          "Aumentar NPS digital de 58 para 70",
-          "NPS",
-          "Mensal"
-        ],
-        [
-          "Maximizar valor das soluções digitais",
-          "Elevar adoção ativa para 80% dos clientes",
-          "% clientes ativos",
-          "Mensal"
-        ],
-        [
-          "Garantir estabilidade crítica",
-          "Reduzir incidentes severos de 12 para 4",
-          "Incidentes críticos",
-          "Semanal"
-        ],
-        [
-          "Acelerar entregas",
-          "Reduzir lead time médio de 16 para 12 dias",
-          "Lead time",
-          "Quinzenal"
-        ],
-        [
-          "Fortalecer inovação",
-          "Executar 8 pilotos com ROI validado",
-          "Pilotos concluídos",
-          "Trimestral"
-        ]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Objetivo: Maximizar valor das soluções digitais | Resultado-chave: Aumentar NPS digital de 58 para 70 | Indicador: NPS | Frequência: Mensal"
+            },
+            {
+              "text": "Objetivo: Maximizar valor das soluções digitais | Resultado-chave: Elevar adoção ativa para 80% dos clientes | Indicador: % clientes ativos | Frequência: Mensal"
+            },
+            {
+              "text": "Objetivo: Garantir estabilidade crítica | Resultado-chave: Reduzir incidentes severos de 12 para 4 | Indicador: Incidentes críticos | Frequência: Semanal"
+            },
+            {
+              "text": "Objetivo: Acelerar entregas | Resultado-chave: Reduzir lead time médio de 16 para 12 dias | Indicador: Lead time | Frequência: Quinzenal"
+            },
+            {
+              "text": "Objetivo: Fortalecer inovação | Resultado-chave: Executar 8 pilotos com ROI validado | Indicador: Pilotos concluídos | Frequência: Trimestral"
+            }
+          ]
+        }
       ]
     },
     {
@@ -108,16 +117,26 @@
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Ritos de acompanhamento",
-      "steps": [
-        { "title": "Semanal", "content": "Squads atualizam progresso dos resultados-chave." },
-        { "title": "Quinzenal", "content": "Review de portfólio verifica capacidade e riscos." },
+      "content": [
         {
-          "title": "Mensal",
-          "content": "Comitê executivo avalia desvios e aprova ajustes de roadmap."
-        },
-        { "title": "Trimestral", "content": "Replanejamento de OKRs e lições aprendidas." }
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Semanal – Squads atualizam progresso dos resultados-chave."
+            },
+            {
+              "text": "Quinzenal – Review de portfólio verifica capacidade e riscos."
+            },
+            {
+              "text": "Mensal – Comitê executivo avalia desvios e aprova ajustes de roadmap."
+            },
+            {
+              "text": "Trimestral – Replanejamento de OKRs e lições aprendidas."
+            }
+          ]
+        }
       ]
     },
     {

--- a/src/content/courses/tgs/lessons/lesson-36.json
+++ b/src/content/courses/tgs/lessons/lesson-36.json
@@ -35,185 +35,155 @@
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Macro tendências 2025-2028",
-      "cards": [
+      "items": [
         {
           "title": "Plataformas de dados confiáveis",
-          "content": "Zero trust, governança automatizada e mesh de dados."
+          "content": "Zero trust, governança automatizada e mesh de dados.",
+          "language": "plaintext",
+          "code": "Zero trust, governança automatizada e mesh de dados."
         },
         {
           "title": "IA generativa aplicada",
-          "content": "Automação de decisões, copilotos e interfaces conversacionais."
+          "content": "Automação de decisões, copilotos e interfaces conversacionais.",
+          "language": "plaintext",
+          "code": "Automação de decisões, copilotos e interfaces conversacionais."
         },
         {
           "title": "Experiências imersivas",
-          "content": "Metaverso corporativo, realidade aumentada em operações."
+          "content": "Metaverso corporativo, realidade aumentada em operações.",
+          "language": "plaintext",
+          "code": "Metaverso corporativo, realidade aumentada em operações."
         },
         {
           "title": "Sustentabilidade digital",
-          "content": "Green IT, medição de carbono e circularidade de hardware."
+          "content": "Green IT, medição de carbono e circularidade de hardware.",
+          "language": "plaintext",
+          "code": "Green IT, medição de carbono e circularidade de hardware."
         }
       ]
     },
     {
-      "type": "md3Flowchart",
+      "type": "contentBlock",
       "title": "Fluxo de avaliação de tendência",
-      "nodes": [
-        { "id": "start", "type": "start", "label": "Início" },
-        { "id": "scan", "type": "process", "label": "Consolidar sinais e drivers" },
-        { "id": "fit", "type": "decision", "label": "Aderência ao PESI?" },
-        { "id": "priorizar", "type": "process", "label": "Classificar impacto × esforço" },
-        { "id": "risco", "type": "decision", "label": "Risco crítico identificado?" },
-        { "id": "mitigar", "type": "process", "label": "Definir salvaguardas e owners" },
-        { "id": "pipeline", "type": "process", "label": "Inserir na esteira de experimentos" },
-        { "id": "forum", "type": "process", "label": "Apresentar ao comitê" },
-        { "id": "end", "type": "end", "label": "Decisão" }
-      ],
-      "edges": [
-        ["start", "scan"],
-        ["scan", "fit"],
-        ["fit", "priorizar", "sim"],
-        ["fit", "end", "não"],
-        ["priorizar", "risco"],
-        ["risco", "mitigar", "sim"],
-        ["risco", "pipeline", "não"],
-        ["mitigar", "pipeline"],
-        ["pipeline", "forum"],
-        ["forum", "end"]
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Início – tipo: start"
+            },
+            {
+              "text": "Consolidar sinais e drivers – tipo: process"
+            },
+            {
+              "text": "Aderência ao PESI? – tipo: decision"
+            },
+            {
+              "text": "Classificar impacto × esforço – tipo: process"
+            },
+            {
+              "text": "Risco crítico identificado? – tipo: decision"
+            },
+            {
+              "text": "Definir salvaguardas e owners – tipo: process"
+            },
+            {
+              "text": "Inserir na esteira de experimentos – tipo: process"
+            },
+            {
+              "text": "Apresentar ao comitê – tipo: process"
+            },
+            {
+              "text": "Decisão – tipo: end"
+            }
+          ]
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "start → scan"
+            },
+            {
+              "text": "scan → fit"
+            },
+            {
+              "text": "fit → priorizar – sim"
+            },
+            {
+              "text": "fit → end – não"
+            },
+            {
+              "text": "priorizar → risco"
+            },
+            {
+              "text": "risco → mitigar – sim"
+            },
+            {
+              "text": "risco → pipeline – não"
+            },
+            {
+              "text": "mitigar → pipeline"
+            },
+            {
+              "text": "pipeline → forum"
+            },
+            {
+              "text": "forum → end"
+            }
+          ]
+        }
       ]
     },
     {
-      "type": "md3Table",
+      "type": "contentBlock",
       "title": "Radar tecnológico",
-      "headers": ["Tendência", "Horizonte", "Oportunidades", "Riscos"],
-      "rows": [
-        [
-          "IA generativa",
-          "0-18 meses",
-          "Automação de atendimento, suporte a desenvolvedores",
-          "Viés algorítmico, segurança de dados"
-        ],
-        [
-          "Digital twin de operações",
-          "18-36 meses",
-          "Otimização de ativos físicos, simulação",
-          "Investimento alto, integração complexa"
-        ],
-        [
-          "Realidade aumentada",
-          "18-36 meses",
-          "Treinamento imersivo, manutenção remota",
-          "Adoção cultural, devices"
-        ],
-        [
-          "Computação quântica",
-          "36-60 meses",
-          "Criptografia pós-quântica, novas capacidades analíticas",
-          "Imaturidade tecnológica, custos"
-        ],
-        [
-          "Green cloud",
-          "0-24 meses",
-          "Redução de carbono, compliance ESG",
-          "Necessidade de métricas confiáveis"
-        ]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Tendência: IA generativa | Horizonte: 0-18 meses | Oportunidades: Automação de atendimento, suporte a desenvolvedores | Riscos: Viés algorítmico, segurança de dados"
+            },
+            {
+              "text": "Tendência: Digital twin de operações | Horizonte: 18-36 meses | Oportunidades: Otimização de ativos físicos, simulação | Riscos: Investimento alto, integração complexa"
+            },
+            {
+              "text": "Tendência: Realidade aumentada | Horizonte: 18-36 meses | Oportunidades: Treinamento imersivo, manutenção remota | Riscos: Adoção cultural, devices"
+            },
+            {
+              "text": "Tendência: Computação quântica | Horizonte: 36-60 meses | Oportunidades: Criptografia pós-quântica, novas capacidades analíticas | Riscos: Imaturidade tecnológica, custos"
+            },
+            {
+              "text": "Tendência: Green cloud | Horizonte: 0-24 meses | Oportunidades: Redução de carbono, compliance ESG | Riscos: Necessidade de métricas confiáveis"
+            }
+          ]
+        }
       ]
     },
     {
-      "type": "pipelineCanvas",
+      "type": "contentBlock",
       "title": "Pipeline de experimentação de tendências",
-      "summary": "Sequência para transformar sinais em iniciativas priorizadas.",
-      "stages": [
+      "content": [
         {
-          "id": "scouting",
-          "title": "Scouting",
-          "summary": "Monitorar relatórios, startups e benchmarks.",
-          "owners": ["Analista de inovação"],
-          "durationHours": 8,
-          "activities": [
-            {
-              "id": "scan",
-              "label": "Scan mensal",
-              "description": "Consolidar sinais e atualizar backlog."
-            },
-            {
-              "id": "catalog",
-              "label": "Catalogar sinais",
-              "description": "Registrar em planilha oficial."
-            }
-          ],
-          "deliverables": [{ "id": "catalogo", "label": "Catálogo de sinais priorizados" }],
-          "risks": [
-            {
-              "id": "overload",
-              "label": "Excesso de fontes",
-              "severity": "medium",
-              "mitigation": "Definir curadoria trimestral."
-            }
-          ],
-          "checkpoints": ["Painel de sinais atualizado"]
+          "type": "paragraph",
+          "text": "Sequência para transformar sinais em iniciativas priorizadas."
         },
         {
-          "id": "experiment",
-          "title": "Experimentação",
-          "summary": "Testar hipótese com prova de conceito controlada.",
-          "owners": ["Product manager", "Tech lead"],
-          "durationHours": 24,
-          "activities": [
+          "type": "unorderedList",
+          "items": [
             {
-              "id": "poc",
-              "label": "Prova de conceito",
-              "description": "Criar script automatizado ou mock."
+              "text": "Scouting | Monitorar relatórios, startups e benchmarks. | Responsáveis: Analista de inovação | Duração: 8h | Atividades: Scan mensal; Catalogar sinais | Entregáveis: Catálogo de sinais priorizados | Riscos: Excesso de fontes (Definir curadoria trimestral.) | Checkpoints: Painel de sinais atualizado"
             },
             {
-              "id": "test-plan",
-              "label": "Plano de testes",
-              "description": "Executar casos e registrar logs."
-            }
-          ],
-          "deliverables": [
-            { "id": "script", "label": "Script automatizado" },
-            { "id": "relatorio", "label": "Relatório de testes" }
-          ],
-          "risks": [
-            {
-              "id": "dados",
-              "label": "Exposição de dados",
-              "severity": "high",
-              "mitigation": "Aplicar mascaramento e controles de auditoria."
-            }
-          ],
-          "checkpoints": ["Critérios de sucesso mensurados"]
-        },
-        {
-          "id": "decision",
-          "title": "Decisão",
-          "summary": "Apresentar resultado ao comitê e atualizar roadmap.",
-          "owners": ["Comitê de inovação"],
-          "durationHours": 6,
-          "activities": [
-            {
-              "id": "forum",
-              "label": "Fórum executivo",
-              "description": "Avaliar risco, valor e dependências."
+              "text": "Experimentação | Testar hipótese com prova de conceito controlada. | Responsáveis: Product manager, Tech lead | Duração: 24h | Atividades: Prova de conceito; Plano de testes | Entregáveis: Script automatizado; Relatório de testes | Riscos: Exposição de dados (Aplicar mascaramento e controles de auditoria.) | Checkpoints: Critérios de sucesso mensurados"
             },
             {
-              "id": "roadmap",
-              "label": "Atualizar roadmap",
-              "description": "Incluir iniciativa e salvaguardas."
+              "text": "Decisão | Apresentar resultado ao comitê e atualizar roadmap. | Responsáveis: Comitê de inovação | Duração: 6h | Atividades: Fórum executivo; Atualizar roadmap | Entregáveis: Ata com deliberação | Riscos: Falta de patrocínio (Engajar sponsors nas etapas anteriores.) | Checkpoints: Roadmap atualizado"
             }
-          ],
-          "deliverables": [{ "id": "ata", "label": "Ata com deliberação" }],
-          "risks": [
-            {
-              "id": "alinhamento",
-              "label": "Falta de patrocínio",
-              "severity": "medium",
-              "mitigation": "Engajar sponsors nas etapas anteriores."
-            }
-          ],
-          "checkpoints": ["Roadmap atualizado"]
+          ]
         }
       ]
     },
@@ -275,24 +245,25 @@
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Trilha de maturidade digital",
-      "steps": [
+      "content": [
         {
-          "title": "Fase 1",
-          "content": "Explorar tendências com pilotos controlados e métricas claras."
-        },
-        {
-          "title": "Fase 2",
-          "content": "Escalar soluções com arquitetura modular e governança."
-        },
-        {
-          "title": "Fase 3",
-          "content": "Integrar novas capacidades ao core e às jornadas do cliente."
-        },
-        {
-          "title": "Fase 4",
-          "content": "Realizar revisão estratégica para novas ondas de inovação."
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Fase 1 – Explorar tendências com pilotos controlados e métricas claras."
+            },
+            {
+              "text": "Fase 2 – Escalar soluções com arquitetura modular e governança."
+            },
+            {
+              "text": "Fase 3 – Integrar novas capacidades ao core e às jornadas do cliente."
+            },
+            {
+              "text": "Fase 4 – Realizar revisão estratégica para novas ondas de inovação."
+            }
+          ]
         }
       ]
     },
@@ -324,9 +295,15 @@
         {
           "type": "unorderedList",
           "items": [
-            { "text": "Script automatizado (YAML/JSON/notebook) com critérios de classificação." },
-            { "text": "Relatório de testes contendo métricas de impacto, esforço e riscos." },
-            { "text": "Log de auditoria consolidando acessos e salvaguardas." }
+            {
+              "text": "Script automatizado (YAML/JSON/notebook) com critérios de classificação."
+            },
+            {
+              "text": "Relatório de testes contendo métricas de impacto, esforço e riscos."
+            },
+            {
+              "text": "Log de auditoria consolidando acessos e salvaguardas."
+            }
           ]
         },
         {

--- a/src/content/courses/tgs/lessons/lesson-37.json
+++ b/src/content/courses/tgs/lessons/lesson-37.json
@@ -35,178 +35,149 @@
       ]
     },
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Elementos do foresight",
-      "cards": [
+      "items": [
         {
           "title": "Sinais fracos",
-          "content": "Indícios emergentes que sugerem mudanças futuras."
+          "content": "Indícios emergentes que sugerem mudanças futuras.",
+          "language": "plaintext",
+          "code": "Indícios emergentes que sugerem mudanças futuras."
         },
         {
           "title": "Forças motrizes",
-          "content": "Tendências macroeconômicas, tecnológicas e sociais."
+          "content": "Tendências macroeconômicas, tecnológicas e sociais.",
+          "language": "plaintext",
+          "code": "Tendências macroeconômicas, tecnológicas e sociais."
         },
         {
           "title": "Incertezas críticas",
-          "content": "Variáveis de alto impacto e difícil previsão."
+          "content": "Variáveis de alto impacto e difícil previsão.",
+          "language": "plaintext",
+          "code": "Variáveis de alto impacto e difícil previsão."
         },
         {
           "title": "Narrativas",
-          "content": "Histórias que conectam eventos e guiam decisões estratégicas."
+          "content": "Histórias que conectam eventos e guiam decisões estratégicas.",
+          "language": "plaintext",
+          "code": "Histórias que conectam eventos e guiam decisões estratégicas."
         }
       ]
     },
     {
-      "type": "md3Flowchart",
+      "type": "contentBlock",
       "title": "Fluxo de construção de cenários",
-      "nodes": [
-        { "id": "start", "type": "start", "label": "Início" },
-        { "id": "dados", "type": "process", "label": "Coletar sinais e dados" },
-        { "id": "drivers", "type": "process", "label": "Identificar forças motrizes" },
-        { "id": "incertezas", "type": "decision", "label": "Incerteza crítica?" },
-        { "id": "matriz", "type": "process", "label": "Montar matriz 2×2" },
-        { "id": "narrativa", "type": "process", "label": "Criar narrativa e storyline" },
-        { "id": "implicacoes", "type": "process", "label": "Derivar implicações para SI" },
-        { "id": "sinais", "type": "process", "label": "Definir sinais de alerta" },
-        { "id": "end", "type": "end", "label": "Cenário pronto" }
-      ],
-      "edges": [
-        ["start", "dados"],
-        ["dados", "drivers"],
-        ["drivers", "incertezas"],
-        ["incertezas", "matriz", "sim"],
-        ["incertezas", "drivers", "não"],
-        ["matriz", "narrativa"],
-        ["narrativa", "implicacoes"],
-        ["implicacoes", "sinais"],
-        ["sinais", "end"]
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Início – tipo: start"
+            },
+            {
+              "text": "Coletar sinais e dados – tipo: process"
+            },
+            {
+              "text": "Identificar forças motrizes – tipo: process"
+            },
+            {
+              "text": "Incerteza crítica? – tipo: decision"
+            },
+            {
+              "text": "Montar matriz 2×2 – tipo: process"
+            },
+            {
+              "text": "Criar narrativa e storyline – tipo: process"
+            },
+            {
+              "text": "Derivar implicações para SI – tipo: process"
+            },
+            {
+              "text": "Definir sinais de alerta – tipo: process"
+            },
+            {
+              "text": "Cenário pronto – tipo: end"
+            }
+          ]
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "start → dados"
+            },
+            {
+              "text": "dados → drivers"
+            },
+            {
+              "text": "drivers → incertezas"
+            },
+            {
+              "text": "incertezas → matriz – sim"
+            },
+            {
+              "text": "incertezas → drivers – não"
+            },
+            {
+              "text": "matriz → narrativa"
+            },
+            {
+              "text": "narrativa → implicacoes"
+            },
+            {
+              "text": "implicacoes → sinais"
+            },
+            {
+              "text": "sinais → end"
+            }
+          ]
+        }
       ]
     },
     {
-      "type": "md3Table",
+      "type": "contentBlock",
       "title": "Matriz 2x2 de cenários",
-      "headers": ["Cenário", "Descrição", "Implicações para SI", "Alertas precoces"],
-      "rows": [
-        [
-          "Regulado & Estável",
-          "Mercado com regulação forte e baixa disrupção",
-          "Foco em compliance e eficiência",
-          "Novas normas, auditorias frequentes"
-        ],
-        [
-          "Regulado & Disruptivo",
-          "Regulação rígida e mudanças tecnológicas rápidas",
-          "Necessidade de inovação segura",
-          "Sandbox regulatórios, startups licenciadas"
-        ],
-        [
-          "Livre & Estável",
-          "Ambiente competitivo com poucas barreiras",
-          "Escala de produtos digitais",
-          "Entrada de players globais"
-        ],
-        [
-          "Livre & Disruptivo",
-          "Mercado aberto e alta velocidade de inovação",
-          "Portfólio flexível e parcerias",
-          "Investimentos massivos em IA e dados"
-        ]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Cenário: Regulado & Estável | Descrição: Mercado com regulação forte e baixa disrupção | Implicações para SI: Foco em compliance e eficiência | Alertas precoces: Novas normas, auditorias frequentes"
+            },
+            {
+              "text": "Cenário: Regulado & Disruptivo | Descrição: Regulação rígida e mudanças tecnológicas rápidas | Implicações para SI: Necessidade de inovação segura | Alertas precoces: Sandbox regulatórios, startups licenciadas"
+            },
+            {
+              "text": "Cenário: Livre & Estável | Descrição: Ambiente competitivo com poucas barreiras | Implicações para SI: Escala de produtos digitais | Alertas precoces: Entrada de players globais"
+            },
+            {
+              "text": "Cenário: Livre & Disruptivo | Descrição: Mercado aberto e alta velocidade de inovação | Implicações para SI: Portfólio flexível e parcerias | Alertas precoces: Investimentos massivos em IA e dados"
+            }
+          ]
+        }
       ]
     },
     {
-      "type": "pipelineCanvas",
+      "type": "contentBlock",
       "title": "Pipeline de respostas a cenários",
-      "summary": "Fluxo para monitorar gatilhos e acionar planos adaptativos.",
-      "stages": [
+      "content": [
         {
-          "id": "monitor",
-          "title": "Monitorar",
-          "summary": "Coletar sinais de alerta e validar hipóteses.",
-          "owners": ["PMO", "Analista de riscos"],
-          "durationHours": 6,
-          "activities": [
-            {
-              "id": "dash",
-              "label": "Dashboard de sinais",
-              "description": "Atualizar indicadores críticos semanalmente."
-            },
-            {
-              "id": "auditar",
-              "label": "Auditar logs",
-              "description": "Revisar logs de auditoria de eventos-chave."
-            }
-          ],
-          "deliverables": [{ "id": "log", "label": "Log consolidado de gatilhos" }],
-          "risks": [
-            {
-              "id": "latencia",
-              "label": "Latência de dados",
-              "severity": "medium",
-              "mitigation": "Automatizar ingestão e alertas."
-            }
-          ],
-          "checkpoints": ["Sinais atualizados no painel"]
+          "type": "paragraph",
+          "text": "Fluxo para monitorar gatilhos e acionar planos adaptativos."
         },
         {
-          "id": "responder",
-          "title": "Responder",
-          "summary": "Executar scripts e planos de mitigação.",
-          "owners": ["Squad de contingência"],
-          "durationHours": 16,
-          "activities": [
+          "type": "unorderedList",
+          "items": [
             {
-              "id": "script",
-              "label": "Rodar scripts",
-              "description": "Acionar playbooks automatizados."
+              "text": "Monitorar | Coletar sinais de alerta e validar hipóteses. | Responsáveis: PMO, Analista de riscos | Duração: 6h | Atividades: Dashboard de sinais; Auditar logs | Entregáveis: Log consolidado de gatilhos | Riscos: Latência de dados (Automatizar ingestão e alertas.) | Checkpoints: Sinais atualizados no painel"
             },
             {
-              "id": "testes",
-              "label": "Testar mudanças",
-              "description": "Validar resultados e registrar relatório."
-            }
-          ],
-          "deliverables": [
-            { "id": "script-out", "label": "Scripts executados" },
-            { "id": "relatorio", "label": "Relatório de testes" }
-          ],
-          "risks": [
-            {
-              "id": "falha",
-              "label": "Falha em rollback",
-              "severity": "high",
-              "mitigation": "Definir plano B e monitoramento contínuo."
-            }
-          ],
-          "checkpoints": ["Testes aprovados"]
-        },
-        {
-          "id": "replanejar",
-          "title": "Replanejar",
-          "summary": "Atualizar roadmap e comunicar stakeholders.",
-          "owners": ["Comitê de estratégia", "Product manager"],
-          "durationHours": 8,
-          "activities": [
-            {
-              "id": "portfolio",
-              "label": "Repriorizar portfólio",
-              "description": "Ajustar iniciativas conforme cenário."
+              "text": "Responder | Executar scripts e planos de mitigação. | Responsáveis: Squad de contingência | Duração: 16h | Atividades: Rodar scripts; Testar mudanças | Entregáveis: Scripts executados; Relatório de testes | Riscos: Falha em rollback (Definir plano B e monitoramento contínuo.) | Checkpoints: Testes aprovados"
             },
             {
-              "id": "comunicacao",
-              "label": "Comunicar mudanças",
-              "description": "Registrar ata e avisos."
+              "text": "Replanejar | Atualizar roadmap e comunicar stakeholders. | Responsáveis: Comitê de estratégia, Product manager | Duração: 8h | Atividades: Repriorizar portfólio; Comunicar mudanças | Entregáveis: Roadmap revisado | Riscos: Falta de adesão (Envolver sponsors em simulações.) | Checkpoints: Roadmap publicado"
             }
-          ],
-          "deliverables": [{ "id": "roadmap", "label": "Roadmap revisado" }],
-          "risks": [
-            {
-              "id": "alinhamento",
-              "label": "Falta de adesão",
-              "severity": "medium",
-              "mitigation": "Envolver sponsors em simulações."
-            }
-          ],
-          "checkpoints": ["Roadmap publicado"]
+          ]
         }
       ]
     },
@@ -268,13 +239,26 @@
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Sequência de construção de cenários",
-      "steps": [
-        { "title": "Etapa 1", "content": "Coleta sinais e tendências com especialistas." },
-        { "title": "Etapa 2", "content": "Define forças motrizes e incertezas críticas." },
-        { "title": "Etapa 3", "content": "Constrói matrizes de cenários e narrativas." },
-        { "title": "Etapa 4", "content": "Extrai implicações para portfólio e riscos." }
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Etapa 1 – Coleta sinais e tendências com especialistas."
+            },
+            {
+              "text": "Etapa 2 – Define forças motrizes e incertezas críticas."
+            },
+            {
+              "text": "Etapa 3 – Constrói matrizes de cenários e narrativas."
+            },
+            {
+              "text": "Etapa 4 – Extrai implicações para portfólio e riscos."
+            }
+          ]
+        }
       ]
     },
     {
@@ -305,9 +289,15 @@
         {
           "type": "unorderedList",
           "items": [
-            { "text": "Script de simulação com parametrizações dos cenários." },
-            { "text": "Relatório de testes validando respostas e riscos residuais." },
-            { "text": "Log de auditoria com gatilhos e decisões tomadas." }
+            {
+              "text": "Script de simulação com parametrizações dos cenários."
+            },
+            {
+              "text": "Relatório de testes validando respostas e riscos residuais."
+            },
+            {
+              "text": "Log de auditoria com gatilhos e decisões tomadas."
+            }
           ]
         },
         {

--- a/src/content/courses/tgs/lessons/lesson-38.json
+++ b/src/content/courses/tgs/lessons/lesson-38.json
@@ -4,33 +4,56 @@
   "objective": "Conectar roadmap estratégico à gestão de mudança e comunicação executiva do PESI.",
   "content": [
     {
-      "type": "cardGrid",
+      "type": "representations",
       "title": "Alavancas de mudança",
-      "cards": [
+      "items": [
         {
           "title": "Patrocínio visível",
-          "content": "Executivos comunicam visão e desbloqueiam recursos."
+          "content": "Executivos comunicam visão e desbloqueiam recursos.",
+          "language": "plaintext",
+          "code": "Executivos comunicam visão e desbloqueiam recursos."
         },
         {
           "title": "Gestão de impactos",
-          "content": "Mapeamento de processos, personas e riscos de adoção."
+          "content": "Mapeamento de processos, personas e riscos de adoção.",
+          "language": "plaintext",
+          "code": "Mapeamento de processos, personas e riscos de adoção."
         },
-        { "title": "Capacitação", "content": "Trilhas de aprendizagem e suporte contínuo." },
+        {
+          "title": "Capacitação",
+          "content": "Trilhas de aprendizagem e suporte contínuo.",
+          "language": "plaintext",
+          "code": "Trilhas de aprendizagem e suporte contínuo."
+        },
         {
           "title": "Comunicação segmentada",
-          "content": "Mensagens personalizadas por stakeholder."
+          "content": "Mensagens personalizadas por stakeholder.",
+          "language": "plaintext",
+          "code": "Mensagens personalizadas por stakeholder."
         }
       ]
     },
     {
-      "type": "md3Table",
+      "type": "contentBlock",
       "title": "Plano de comunicação",
-      "headers": ["Stakeholder", "Mensagem-chave", "Canal", "Frequência"],
-      "rows": [
-        ["Conselho", "Status do roadmap e resultados", "Relatório executivo", "Mensal"],
-        ["Gestores", "Impactos operacionais e decisões", "Reuniões de liderança", "Quinzenal"],
-        ["Colaboradores", "Benefícios e suporte", "Intranet, newsletters", "Semanal"],
-        ["Parceiros", "Integrações e mudanças contratuais", "Workshops dedicados", "Trimestral"]
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Stakeholder: Conselho | Mensagem-chave: Status do roadmap e resultados | Canal: Relatório executivo | Frequência: Mensal"
+            },
+            {
+              "text": "Stakeholder: Gestores | Mensagem-chave: Impactos operacionais e decisões | Canal: Reuniões de liderança | Frequência: Quinzenal"
+            },
+            {
+              "text": "Stakeholder: Colaboradores | Mensagem-chave: Benefícios e suporte | Canal: Intranet, newsletters | Frequência: Semanal"
+            },
+            {
+              "text": "Stakeholder: Parceiros | Mensagem-chave: Integrações e mudanças contratuais | Canal: Workshops dedicados | Frequência: Trimestral"
+            }
+          ]
+        }
       ]
     },
     {
@@ -91,13 +114,26 @@
       ]
     },
     {
-      "type": "timeline",
+      "type": "contentBlock",
       "title": "Cronograma da oficina",
-      "steps": [
-        { "title": "Bloco 1", "content": "Atualização do roadmap e dependências críticas." },
-        { "title": "Bloco 2", "content": "Mapeamento de impactos e stakeholders." },
-        { "title": "Bloco 3", "content": "Definição de mensagens e canais por segmento." },
-        { "title": "Bloco 4", "content": "Plano de capacitação e métricas de adoção." }
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Bloco 1 – Atualização do roadmap e dependências críticas."
+            },
+            {
+              "text": "Bloco 2 – Mapeamento de impactos e stakeholders."
+            },
+            {
+              "text": "Bloco 3 – Definição de mensagens e canais por segmento."
+            },
+            {
+              "text": "Bloco 4 – Plano de capacitação e métricas de adoção."
+            }
+          ]
+        }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- replace unsupported MD3 blocks with lessonPlan/contentBlock equivalents across ALGI lessons 22-38
- normalize DDM lessons 22-38 by converting card grids, timelines, and pipelines to supported representations and content blocks
- update TGS lessons 22-38 to supported block types and add a conversion script to automate future updates

## Testing
- npm run validate:content

------
https://chatgpt.com/codex/tasks/task_e_68dd9472e568832c8c050262274a9c1e