### PR TITLE
feat: add lesson and exercise block suite for new manifests

### DIFF
--- a/docs/content/lesson-schema.md
+++ b/docs/content/lesson-schema.md
@@ -42,6 +42,35 @@ O schema `md3.lesson.v1` garante que todas as disciplinas compartilhem o mesmo c
 | `metadata.owners`    | `string[]`                              | Recomendado | Responsáveis pedagógicos/tecnológicos. |
 | `metadata.sources`   | `string[]`                              | Opcional    | Fontes externas utilizadas na aula.    |
 
+## Novos blocos declarativos (2024-09)
+
+Os manifests de aulas e exercícios agora contam com vinte blocos inéditos que atendem a cenários de exposição e prática. Todos já estão descritos no schema (`schemas/lesson.schema.json`) e no renderer (`src/components/lesson/blockRegistry.ts`). A tabela abaixo resume os campos mínimos esperados:
+
+| Tipo (`type`)      | Campos obrigatórios                                   | Campos opcionais relevantes                                                    |
+| ------------------ | ----------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `definitionCard`   | `term`, `definition`                                  | `source`, `sourceUrl`                                                          |
+| `comparativeTable` | `headers`, `rows[].{label, values[]}`                 | `title`, `description`                                                         |
+| `systemDiagram`    | `nodes[].{id,label}`                                  | `connections[]`, `legend`                                                      |
+| `codeChallenge`    | `prompt`                                              | `code`, `question`, `options[]`, `answerExplanation`                           |
+| `memoryVisualizer` | —                                                     | `stack[]`, `heap[]`, `notes`                                                   |
+| `caseStudy`        | `scenario`                                            | `title`, `dataPoints[]`, `questions[]`, `tasks[]`                              |
+| `statCard`         | `label`, `value`                                      | `context`, `source`, `trend`                                                   |
+| `knowledgeCheck`   | `prompt`, `options[].{id,text}`                       | `title`, `explanation`, `allowMultiple`                                        |
+| `interactiveDemo`  | `url`                                                 | `title`, `description`, `height`                                               |
+| `pedagogicalNote`  | `content`                                             | `title`, `audience`                                                            |
+| `codeSubmission`   | `prompt`                                              | `language`, `boilerplate`, `tests[]`, `tips[]`                                 |
+| `dragAndDrop`      | `steps[].{id,label}`                                  | `title`, `instructions`                                                        |
+| `conceptMapper`    | `nodes[].{id,label}`                                  | `description`, `relationships[]`                                               |
+| `bugFixChallenge`  | `code`                                                | `language`, `hints[]`, `guidance[]`                                            |
+| `dataEntryForm`    | `fields[].{id,label}`                                 | `submitLabel`, `description`, `fields[].{type,required,options[],placeholder}` |
+| `scenarioBuilder`  | `inputs[]`, `processes[]`, `outputs[]`                | `description`, `guidingQuestions[]`                                            |
+| `peerReviewTask`   | `criteria[].{id,label}`                               | `description`, `dueDate`, `steps[]`                                            |
+| `testGenerator`    | `tags[]`                                              | `description`, `difficulties[]`                                                |
+| `rubricDisplay`    | `criteria[].{criterion,levels[].{level,description}}` | `title`, `description`                                                         |
+| `selfAssessment`   | `prompts[].{id,label}`                                | `description`, `prompts[].placeholder`                                         |
+
+> Os blocos de exercícios reutilizam o mesmo schema das aulas, permitindo que `LessonRenderer` trate ambos os contextos de maneira unificada. 【F:schemas/lesson.schema.json†L1-L431】【F:src/components/lesson/blockRegistry.ts†L1-L305】
+
 ## Relacionados
 
 - `schemas/lessons-index.schema.json`: índice canônico das aulas disponíveis em cada curso. 【F:schemas/lessons-index.schema.json†L1-L34】

--- a/schemas/lesson.schema.json
+++ b/schemas/lesson.schema.json
@@ -162,16 +162,7 @@
       "minItems": 1,
       "description": "Blocos semânticos renderizados pelos componentes MD3.",
       "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": ["type"],
-        "properties": {
-          "type": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Identificador do componente responsável por renderizar o bloco."
-          }
-        }
+        "$ref": "#/$defs/contentBlock"
       }
     },
     "metadata": {
@@ -205,6 +196,570 @@
         }
       },
       "description": "Metadados operacionais usados por governança e pipelines."
+    }
+  },
+  "$defs": {
+    "contentBlock": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Identificador do componente responsável por renderizar o bloco."
+        }
+      },
+      "allOf": [
+        { "$ref": "#/$defs/definitionCardBlock" },
+        { "$ref": "#/$defs/comparativeTableBlock" },
+        { "$ref": "#/$defs/systemDiagramBlock" },
+        { "$ref": "#/$defs/codeChallengeBlock" },
+        { "$ref": "#/$defs/memoryVisualizerBlock" },
+        { "$ref": "#/$defs/caseStudyBlock" },
+        { "$ref": "#/$defs/statCardBlock" },
+        { "$ref": "#/$defs/knowledgeCheckBlock" },
+        { "$ref": "#/$defs/interactiveDemoBlock" },
+        { "$ref": "#/$defs/pedagogicalNoteBlock" },
+        { "$ref": "#/$defs/codeSubmissionBlock" },
+        { "$ref": "#/$defs/dragAndDropBlock" },
+        { "$ref": "#/$defs/conceptMapperBlock" },
+        { "$ref": "#/$defs/bugFixChallengeBlock" },
+        { "$ref": "#/$defs/dataEntryFormBlock" },
+        { "$ref": "#/$defs/scenarioBuilderBlock" },
+        { "$ref": "#/$defs/peerReviewTaskBlock" },
+        { "$ref": "#/$defs/testGeneratorBlock" },
+        { "$ref": "#/$defs/rubricDisplayBlock" },
+        { "$ref": "#/$defs/selfAssessmentBlock" }
+      ]
+    },
+    "definitionCardBlock": {
+      "if": {
+        "properties": { "type": { "const": "definitionCard" } }
+      },
+      "then": {
+        "required": ["term", "definition"],
+        "properties": {
+          "term": { "type": "string", "minLength": 1 },
+          "definition": { "type": "string", "minLength": 1 },
+          "source": { "type": "string", "minLength": 1 },
+          "sourceUrl": { "type": "string", "format": "uri" }
+        }
+      }
+    },
+    "comparativeTableBlock": {
+      "if": {
+        "properties": { "type": { "const": "comparativeTable" } }
+      },
+      "then": {
+        "required": ["headers", "rows"],
+        "properties": {
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "caption": { "type": "string" },
+          "leadingColumnLabel": { "type": "string" },
+          "headers": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "rows": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["label", "values"],
+              "properties": {
+                "label": { "type": "string", "minLength": 1 },
+                "values": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": { "type": "string" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "systemDiagramBlock": {
+      "if": {
+        "properties": { "type": { "const": "systemDiagram" } }
+      },
+      "then": {
+        "required": ["nodes"],
+        "properties": {
+          "title": { "type": "string" },
+          "summary": { "type": "string" },
+          "nodes": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["id", "label"],
+              "properties": {
+                "id": { "type": "string", "minLength": 1 },
+                "label": { "type": "string", "minLength": 1 },
+                "description": { "type": "string" }
+              }
+            }
+          },
+          "connections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["from", "to"],
+              "properties": {
+                "from": { "type": "string", "minLength": 1 },
+                "to": { "type": "string", "minLength": 1 },
+                "label": { "type": "string" }
+              }
+            }
+          },
+          "legend": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
+    "codeChallengeBlock": {
+      "if": {
+        "properties": { "type": { "const": "codeChallenge" } }
+      },
+      "then": {
+        "required": ["prompt"],
+        "properties": {
+          "title": { "type": "string" },
+          "prompt": { "type": "string", "minLength": 1 },
+          "code": { "type": "string" },
+          "language": { "type": "string" },
+          "question": { "type": "string" },
+          "options": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["id", "text"],
+              "properties": {
+                "id": { "type": "string", "minLength": 1 },
+                "text": { "type": "string", "minLength": 1 }
+              }
+            }
+          },
+          "answerExplanation": { "type": "string" }
+        }
+      }
+    },
+    "memoryVisualizerBlock": {
+      "if": {
+        "properties": { "type": { "const": "memoryVisualizer" } }
+      },
+      "then": {
+        "properties": {
+          "title": { "type": "string" },
+          "summary": { "type": "string" },
+          "stack": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["label", "value"],
+              "properties": {
+                "label": { "type": "string" },
+                "value": { "type": "string" }
+              }
+            }
+          },
+          "heap": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["label", "value"],
+              "properties": {
+                "label": { "type": "string" },
+                "value": { "type": "string" }
+              }
+            }
+          },
+          "notes": { "type": "string" }
+        }
+      }
+    },
+    "caseStudyBlock": {
+      "if": {
+        "properties": { "type": { "const": "caseStudy" } }
+      },
+      "then": {
+        "required": ["scenario"],
+        "properties": {
+          "title": { "type": "string" },
+          "scenario": { "type": "string", "minLength": 1 },
+          "background": { "type": "string" },
+          "dataPoints": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["label", "value"],
+              "properties": {
+                "label": { "type": "string" },
+                "value": { "type": "string" }
+              }
+            }
+          },
+          "questions": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "tasks": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
+    "statCardBlock": {
+      "if": {
+        "properties": { "type": { "const": "statCard" } }
+      },
+      "then": {
+        "required": ["label", "value"],
+        "properties": {
+          "label": { "type": "string" },
+          "value": { "type": "string" },
+          "context": { "type": "string" },
+          "source": { "type": "string" },
+          "trend": { "type": "string", "enum": ["up", "down", "neutral"] }
+        }
+      }
+    },
+    "knowledgeCheckBlock": {
+      "if": {
+        "properties": { "type": { "const": "knowledgeCheck" } }
+      },
+      "then": {
+        "required": ["prompt", "options"],
+        "properties": {
+          "title": { "type": "string" },
+          "prompt": { "type": "string" },
+          "options": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["id", "text"],
+              "properties": {
+                "id": { "type": "string", "minLength": 1 },
+                "text": { "type": "string", "minLength": 1 }
+              }
+            }
+          },
+          "explanation": { "type": "string" },
+          "allowMultiple": { "type": "boolean" }
+        }
+      }
+    },
+    "interactiveDemoBlock": {
+      "if": {
+        "properties": { "type": { "const": "interactiveDemo" } }
+      },
+      "then": {
+        "required": ["url"],
+        "properties": {
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "url": { "type": "string", "format": "uri" },
+          "height": { "type": "number", "exclusiveMinimum": 0 }
+        }
+      }
+    },
+    "pedagogicalNoteBlock": {
+      "if": {
+        "properties": { "type": { "const": "pedagogicalNote" } }
+      },
+      "then": {
+        "required": ["content"],
+        "properties": {
+          "title": { "type": "string" },
+          "content": { "type": "string", "minLength": 1 },
+          "audience": { "type": "string", "enum": ["teacher", "student", "team"] }
+        }
+      }
+    },
+    "codeSubmissionBlock": {
+      "if": {
+        "properties": { "type": { "const": "codeSubmission" } }
+      },
+      "then": {
+        "required": ["prompt"],
+        "properties": {
+          "title": { "type": "string" },
+          "prompt": { "type": "string", "minLength": 1 },
+          "language": { "type": "string" },
+          "boilerplate": { "type": "string" },
+          "tests": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["name"],
+              "properties": {
+                "name": { "type": "string", "minLength": 1 },
+                "input": { "type": "string" },
+                "expectedOutput": { "type": "string" }
+              }
+            }
+          },
+          "tips": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
+    "dragAndDropBlock": {
+      "if": {
+        "properties": { "type": { "const": "dragAndDrop" } }
+      },
+      "then": {
+        "required": ["steps"],
+        "properties": {
+          "title": { "type": "string" },
+          "instructions": { "type": "string" },
+          "steps": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["id", "label"],
+              "properties": {
+                "id": { "type": "string", "minLength": 1 },
+                "label": { "type": "string", "minLength": 1 },
+                "description": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "conceptMapperBlock": {
+      "if": {
+        "properties": { "type": { "const": "conceptMapper" } }
+      },
+      "then": {
+        "required": ["nodes"],
+        "properties": {
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "nodes": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["id", "label"],
+              "properties": {
+                "id": { "type": "string" },
+                "label": { "type": "string" },
+                "category": { "type": "string" },
+                "details": { "type": "string" }
+              }
+            }
+          },
+          "relationships": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["from", "to"],
+              "properties": {
+                "from": { "type": "string" },
+                "to": { "type": "string" },
+                "label": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "bugFixChallengeBlock": {
+      "if": {
+        "properties": { "type": { "const": "bugFixChallenge" } }
+      },
+      "then": {
+        "required": ["code"],
+        "properties": {
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "code": { "type": "string", "minLength": 1 },
+          "language": { "type": "string" },
+          "hints": {
+            "type": "array",
+            "items": { "type": "number" }
+          },
+          "guidance": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
+    "dataEntryFormBlock": {
+      "if": {
+        "properties": { "type": { "const": "dataEntryForm" } }
+      },
+      "then": {
+        "required": ["fields"],
+        "properties": {
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "submitLabel": { "type": "string" },
+          "fields": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["id", "label"],
+              "properties": {
+                "id": { "type": "string", "minLength": 1 },
+                "label": { "type": "string", "minLength": 1 },
+                "type": {
+                  "type": "string",
+                  "enum": ["text", "number", "email", "date", "select"]
+                },
+                "required": { "type": "boolean" },
+                "options": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
+                "placeholder": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "scenarioBuilderBlock": {
+      "if": {
+        "properties": { "type": { "const": "scenarioBuilder" } }
+      },
+      "then": {
+        "required": ["inputs", "processes", "outputs"],
+        "properties": {
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "inputs": { "type": "array", "items": { "type": "string" } },
+          "processes": { "type": "array", "items": { "type": "string" } },
+          "outputs": { "type": "array", "items": { "type": "string" } },
+          "guidingQuestions": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "peerReviewTaskBlock": {
+      "if": {
+        "properties": { "type": { "const": "peerReviewTask" } }
+      },
+      "then": {
+        "required": ["criteria"],
+        "properties": {
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "dueDate": { "type": "string" },
+          "criteria": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["id", "label"],
+              "properties": {
+                "id": { "type": "string" },
+                "label": { "type": "string" },
+                "description": { "type": "string" }
+              }
+            }
+          },
+          "steps": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "testGeneratorBlock": {
+      "if": {
+        "properties": { "type": { "const": "testGenerator" } }
+      },
+      "then": {
+        "required": ["tags"],
+        "properties": {
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "tags": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "difficulties": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["easy", "medium", "hard"]
+            }
+          }
+        }
+      }
+    },
+    "rubricDisplayBlock": {
+      "if": {
+        "properties": { "type": { "const": "rubricDisplay" } }
+      },
+      "then": {
+        "required": ["criteria"],
+        "properties": {
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "criteria": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["criterion", "levels"],
+              "properties": {
+                "criterion": { "type": "string", "minLength": 1 },
+                "levels": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "object",
+                    "required": ["level", "description"],
+                    "properties": {
+                      "level": { "type": "string" },
+                      "description": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "selfAssessmentBlock": {
+      "if": {
+        "properties": { "type": { "const": "selfAssessment" } }
+      },
+      "then": {
+        "required": ["prompts"],
+        "properties": {
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "prompts": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["id", "label"],
+              "properties": {
+                "id": { "type": "string", "minLength": 1 },
+                "label": { "type": "string", "minLength": 1 },
+                "placeholder": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/components/exercise/BugFixChallenge.vue
+++ b/src/components/exercise/BugFixChallenge.vue
@@ -1,0 +1,60 @@
+<template>
+  <article class="bug-fix card md-stack md-stack-4">
+    <header class="md-stack md-stack-2">
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p v-if="data.description" class="text-body-medium text-on-surface-variant">
+        {{ data.description }}
+      </p>
+    </header>
+
+    <CodeBlock :code="data.code" :language="data.language" :plainText="!data.language" />
+
+    <p v-if="data.hints?.length" class="text-body-small text-on-surface-variant">
+      Linhas suspeitas: {{ data.hints.join(', ') }}
+    </p>
+
+    <section v-if="data.guidance?.length" class="bug-fix__guidance">
+      <h4 class="text-title-small font-semibold text-on-surface">Dicas de depuração</h4>
+      <ul class="md-stack md-stack-1" role="list">
+        <li
+          v-for="(hint, index) in data.guidance"
+          :key="index"
+          class="text-body-medium text-on-surface"
+        >
+          {{ hint }}
+        </li>
+      </ul>
+    </section>
+  </article>
+</template>
+
+<script setup lang="ts">
+import CodeBlock from '@/components/lesson/CodeBlock.vue';
+
+export interface BugFixChallengeBlockData {
+  title?: string;
+  description?: string;
+  code: string;
+  language?: string;
+  hints?: number[];
+  guidance?: string[];
+}
+
+defineProps<{ data: BugFixChallengeBlockData }>();
+</script>
+
+<style scoped>
+.bug-fix {
+  border-radius: 1.5rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface-container);
+}
+
+.bug-fix__guidance {
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+  padding-top: 1rem;
+}
+</style>

--- a/src/components/exercise/CodeSubmission.vue
+++ b/src/components/exercise/CodeSubmission.vue
@@ -1,0 +1,126 @@
+<template>
+  <article class="code-submission card md-stack md-stack-4">
+    <header class="md-stack md-stack-2">
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p class="text-body-medium text-on-surface">{{ data.prompt }}</p>
+    </header>
+
+    <section class="md-stack md-stack-2">
+      <label class="code-submission__label">
+        <span class="text-label-medium uppercase text-on-surface-variant">Seu código</span>
+        <textarea
+          v-model="code"
+          class="code-submission__editor"
+          :placeholder="
+            data.language ? `Escreva o código em ${data.language}` : 'Insira sua solução'
+          "
+          rows="12"
+        ></textarea>
+      </label>
+      <p v-if="data.language" class="text-body-small text-on-surface-variant">
+        Linguagem esperada: {{ data.language }}
+      </p>
+    </section>
+
+    <section v-if="data.tests?.length" class="code-submission__tests" aria-label="Testes unitários">
+      <h4 class="text-title-small font-semibold text-on-surface">Casos de teste previstos</h4>
+      <ul class="md-stack md-stack-1" role="list">
+        <li v-for="(test, index) in data.tests" :key="index" class="code-submission__test">
+          <p class="text-body-medium text-on-surface">{{ test.name }}</p>
+          <p v-if="test.input" class="text-body-small text-on-surface-variant">
+            Entrada: {{ test.input }}
+          </p>
+          <p v-if="test.expectedOutput" class="text-body-small text-on-surface-variant">
+            Saída esperada: {{ test.expectedOutput }}
+          </p>
+        </li>
+      </ul>
+    </section>
+
+    <section v-if="data.tips?.length" class="code-submission__tips" aria-label="Dicas">
+      <h4 class="text-title-small font-semibold text-on-surface">Dicas</h4>
+      <ul class="md-stack md-stack-1" role="list">
+        <li
+          v-for="(tip, index) in data.tips"
+          :key="index"
+          class="text-body-small text-on-surface-variant"
+        >
+          {{ tip }}
+        </li>
+      </ul>
+    </section>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+
+export interface CodeSubmissionTestCase {
+  name: string;
+  input?: string;
+  expectedOutput?: string;
+}
+
+export interface CodeSubmissionBlockData {
+  title?: string;
+  prompt: string;
+  language?: string;
+  boilerplate?: string;
+  tests?: CodeSubmissionTestCase[];
+  tips?: string[];
+}
+
+const props = defineProps<{ data: CodeSubmissionBlockData }>();
+
+const code = ref<string>(props.data.boilerplate ?? '');
+
+watch(
+  () => props.data.boilerplate,
+  (value) => {
+    if (value) {
+      code.value = value;
+    }
+  }
+);
+</script>
+
+<style scoped>
+.code-submission {
+  border-radius: 1.5rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface);
+}
+
+.code-submission__label {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.code-submission__editor {
+  width: 100%;
+  border-radius: 1rem;
+  border: 1px solid var(--md-sys-color-outline);
+  padding: 1rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.95rem;
+  min-height: 12rem;
+  background: var(--md-sys-color-surface-container-low);
+  color: var(--md-sys-color-on-surface);
+}
+
+.code-submission__tests,
+.code-submission__tips {
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+  padding-top: 1rem;
+}
+
+.code-submission__test {
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface-container-low);
+}
+</style>

--- a/src/components/exercise/ConceptMapper.vue
+++ b/src/components/exercise/ConceptMapper.vue
@@ -1,0 +1,125 @@
+<template>
+  <article class="concept-mapper card md-stack md-stack-4">
+    <header class="md-stack md-stack-2">
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p v-if="data.description" class="text-body-medium text-on-surface-variant">
+        {{ data.description }}
+      </p>
+    </header>
+
+    <div class="concept-mapper__grid">
+      <section v-for="group in groupedEntries" :key="group.category" class="concept-mapper__column">
+        <h4 class="text-title-small font-semibold text-on-surface">{{ group.category }}</h4>
+        <ul class="md-stack md-stack-1" role="list">
+          <li v-for="node in group.nodes" :key="node.id" class="concept-mapper__node">
+            <p class="text-body-medium text-on-surface">{{ node.label }}</p>
+            <p v-if="node.details" class="text-body-small text-on-surface-variant">
+              {{ node.details }}
+            </p>
+          </li>
+        </ul>
+      </section>
+    </div>
+
+    <section
+      v-if="data.relationships?.length"
+      class="concept-mapper__relationships"
+      aria-label="Relações"
+    >
+      <h4 class="text-title-small font-semibold text-on-surface">Relações</h4>
+      <ul class="md-stack md-stack-1" role="list">
+        <li
+          v-for="(relation, index) in data.relationships"
+          :key="index"
+          class="text-body-medium text-on-surface"
+        >
+          <span class="font-semibold">{{ resolveNodeLabel(relation.from) }}</span>
+          <span class="text-on-surface-variant"> → </span>
+          <span class="font-semibold">{{ resolveNodeLabel(relation.to) }}</span>
+          <span v-if="relation.label" class="text-on-surface-variant"> — {{ relation.label }}</span>
+        </li>
+      </ul>
+    </section>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+export interface ConceptMapperNode {
+  id: string;
+  label: string;
+  category?: string;
+  details?: string;
+}
+
+export interface ConceptMapperRelationship {
+  from: string;
+  to: string;
+  label?: string;
+}
+
+export interface ConceptMapperBlockData {
+  title?: string;
+  description?: string;
+  nodes: ConceptMapperNode[];
+  relationships?: ConceptMapperRelationship[];
+}
+
+const props = defineProps<{ data: ConceptMapperBlockData }>();
+
+const groupedEntries = computed(() => {
+  const groups = new Map<string, ConceptMapperNode[]>();
+  props.data.nodes.forEach((node) => {
+    const category = node.category ?? 'Conceitos';
+    const bucket = groups.get(category) ?? [];
+    bucket.push(node);
+    groups.set(category, bucket);
+  });
+  return Array.from(groups.entries()).map(([category, nodes]) => ({ category, nodes }));
+});
+
+const nodeMap = computed(() => {
+  const map = new Map<string, string>();
+  props.data.nodes.forEach((node) => map.set(node.id, node.label));
+  return map;
+});
+
+function resolveNodeLabel(id: string) {
+  return nodeMap.value.get(id) ?? id;
+}
+</script>
+
+<style scoped>
+.concept-mapper {
+  border-radius: 1.5rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface);
+}
+
+.concept-mapper__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.concept-mapper__column {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.concept-mapper__node {
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface-container-low);
+}
+
+.concept-mapper__relationships {
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+  padding-top: 1rem;
+}
+</style>

--- a/src/components/exercise/DataEntryForm.vue
+++ b/src/components/exercise/DataEntryForm.vue
@@ -1,0 +1,167 @@
+<template>
+  <article class="data-entry card md-stack md-stack-4">
+    <header class="md-stack md-stack-2">
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p v-if="data.description" class="text-body-medium text-on-surface-variant">
+        {{ data.description }}
+      </p>
+    </header>
+
+    <form class="md-stack md-stack-3" @submit.prevent="handleSubmit">
+      <div v-for="field in data.fields" :key="field.id" class="data-entry__field">
+        <label class="text-label-medium text-on-surface" :for="field.id">
+          {{ field.label }}
+          <span v-if="field.required" class="text-error">*</span>
+        </label>
+        <component
+          :is="resolveFieldComponent(field)"
+          v-model="form[field.id]"
+          :id="field.id"
+          class="data-entry__input"
+          :type="field.type || 'text'"
+          :placeholder="field.placeholder"
+          :options="field.options"
+        />
+        <p v-if="errors[field.id]" class="data-entry__error">{{ errors[field.id] }}</p>
+      </div>
+
+      <Md3Button type="submit" variant="filled">{{ data.submitLabel || 'Registrar' }}</Md3Button>
+    </form>
+
+    <p v-if="submitted" class="data-entry__success">Dados simulados registrados com sucesso.</p>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { PropType, defineComponent, h, reactive, ref } from 'vue';
+import Md3Button from '@/components/Md3Button.vue';
+
+export type DataEntryFieldType = 'text' | 'number' | 'email' | 'date' | 'select';
+
+export interface DataEntryField {
+  id: string;
+  label: string;
+  type?: DataEntryFieldType;
+  required?: boolean;
+  options?: string[];
+  placeholder?: string;
+}
+
+export interface DataEntryFormBlockData {
+  title?: string;
+  description?: string;
+  fields: DataEntryField[];
+  submitLabel?: string;
+}
+
+const props = defineProps<{ data: DataEntryFormBlockData }>();
+
+const form = reactive<Record<string, string>>({});
+const errors = reactive<Record<string, string>>({});
+const submitted = ref(false);
+
+props.data.fields.forEach((field) => {
+  form[field.id] = '';
+});
+
+function resolveFieldComponent(field: DataEntryField) {
+  if (field.type === 'select') {
+    return SelectField;
+  }
+  return 'input';
+}
+
+function validateField(field: DataEntryField): boolean {
+  if (!field.required) {
+    return true;
+  }
+  const value = form[field.id];
+  if (!value || value.trim().length === 0) {
+    errors[field.id] = 'Campo obrigatório.';
+    return false;
+  }
+  errors[field.id] = '';
+  return true;
+}
+
+function handleSubmit() {
+  submitted.value = false;
+  let isValid = true;
+  props.data.fields.forEach((field) => {
+    const valid = validateField(field);
+    if (!valid) {
+      isValid = false;
+    }
+  });
+
+  if (isValid) {
+    submitted.value = true;
+  }
+}
+
+const SelectField = defineComponent({
+  name: 'DataEntrySelectField',
+  props: {
+    modelValue: { type: String, default: '' },
+    options: { type: Array as PropType<string[]>, default: () => [] },
+    id: { type: String, required: true },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    function onChange(event: Event) {
+      emit('update:modelValue', (event.target as HTMLSelectElement).value);
+    }
+
+    return () =>
+      h(
+        'select',
+        {
+          id: props.id,
+          class: 'data-entry__input',
+          value: props.modelValue,
+          onChange,
+        },
+        [
+          h('option', { value: '', disabled: true }, 'Selecione uma opção'),
+          ...props.options.map((option) => h('option', { value: option }, option)),
+        ]
+      );
+  },
+});
+</script>
+
+<style scoped>
+.data-entry {
+  border-radius: 1.5rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface);
+}
+
+.data-entry__field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.data-entry__input {
+  border-radius: 1rem;
+  border: 1px solid var(--md-sys-color-outline);
+  padding: 0.75rem 1rem;
+  background: var(--md-sys-color-surface-container-low);
+  color: var(--md-sys-color-on-surface);
+}
+
+.data-entry__error {
+  color: var(--md-sys-color-error);
+  font-size: 0.85rem;
+}
+
+.data-entry__success {
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  background: var(--md-sys-color-tertiary-container);
+  color: var(--md-sys-color-on-tertiary-container);
+}
+</style>

--- a/src/components/exercise/DragAndDrop.vue
+++ b/src/components/exercise/DragAndDrop.vue
@@ -1,0 +1,130 @@
+<template>
+  <article class="drag-drop card md-stack md-stack-4">
+    <header class="md-stack md-stack-2">
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p v-if="data.instructions" class="text-body-medium text-on-surface">
+        {{ data.instructions }}
+      </p>
+    </header>
+
+    <ul class="drag-drop__list" role="list">
+      <li
+        v-for="(step, index) in orderedSteps"
+        :key="step.id"
+        class="drag-drop__item"
+        draggable="true"
+        @dragstart="onDragStart(step.id)"
+        @dragover.prevent="onDragOver(index)"
+        @drop.prevent="onDrop(index)"
+      >
+        <span class="drag-drop__index">{{ index + 1 }}</span>
+        <div class="drag-drop__content">
+          <p class="text-body-medium text-on-surface">{{ step.label }}</p>
+          <p v-if="step.description" class="text-body-small text-on-surface-variant">
+            {{ step.description }}
+          </p>
+        </div>
+      </li>
+    </ul>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+
+export interface DragAndDropStep {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+export interface DragAndDropBlockData {
+  title?: string;
+  instructions?: string;
+  steps: DragAndDropStep[];
+}
+
+const props = defineProps<{ data: DragAndDropBlockData }>();
+
+const steps = ref<DragAndDropStep[]>([...props.data.steps]);
+const draggingId = ref<string | null>(null);
+
+watch(
+  () => props.data.steps,
+  (value) => {
+    steps.value = [...value];
+  },
+  { deep: true }
+);
+
+const orderedSteps = computed(() => steps.value);
+
+function onDragStart(id: string) {
+  draggingId.value = id;
+}
+
+function onDragOver(index: number) {
+  // Mantido para acessibilidade; permite destacar possíveis alvos futuramente.
+  void index;
+}
+
+function onDrop(index: number) {
+  if (!draggingId.value) {
+    return;
+  }
+  const currentIndex = steps.value.findIndex((step) => step.id === draggingId.value);
+  if (currentIndex === -1) {
+    return;
+  }
+  const [moved] = steps.value.splice(currentIndex, 1);
+  steps.value.splice(index, 0, moved);
+  draggingId.value = null;
+}
+</script>
+
+<style scoped>
+.drag-drop {
+  border-radius: 1.5rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface-container);
+}
+
+.drag-drop__list {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+}
+
+.drag-drop__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: flex-start;
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface);
+  cursor: move;
+}
+
+.drag-drop__item:focus,
+.drag-drop__item:focus-visible {
+  outline: 2px solid var(--md-sys-color-primary);
+}
+
+.drag-drop__index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+  font-weight: 600;
+}
+</style>

--- a/src/components/exercise/PeerReviewTask.vue
+++ b/src/components/exercise/PeerReviewTask.vue
@@ -1,0 +1,81 @@
+<template>
+  <article class="peer-review card md-stack md-stack-4">
+    <header class="md-stack md-stack-2">
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p v-if="data.description" class="text-body-medium text-on-surface-variant">
+        {{ data.description }}
+      </p>
+      <p v-if="data.dueDate" class="text-body-small text-on-surface-variant">
+        Prazo: {{ data.dueDate }}
+      </p>
+    </header>
+
+    <section class="peer-review__section" aria-label="Critérios">
+      <h4 class="text-title-small font-semibold text-on-surface">Critérios de avaliação</h4>
+      <ul class="md-stack md-stack-1" role="list">
+        <li v-for="criterion in data.criteria" :key="criterion.id" class="peer-review__criterion">
+          <p class="text-body-medium text-on-surface">{{ criterion.label }}</p>
+          <p v-if="criterion.description" class="text-body-small text-on-surface-variant">
+            {{ criterion.description }}
+          </p>
+        </li>
+      </ul>
+    </section>
+
+    <section v-if="data.steps?.length" class="peer-review__section" aria-label="Fluxo sugerido">
+      <h4 class="text-title-small font-semibold text-on-surface">Fluxo sugerido</h4>
+      <ol class="md-stack md-stack-1" role="list">
+        <li
+          v-for="(step, index) in data.steps"
+          :key="index"
+          class="text-body-medium text-on-surface"
+        >
+          {{ step }}
+        </li>
+      </ol>
+    </section>
+  </article>
+</template>
+
+<script setup lang="ts">
+export interface PeerReviewCriterion {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+export interface PeerReviewTaskBlockData {
+  title?: string;
+  description?: string;
+  dueDate?: string;
+  criteria: PeerReviewCriterion[];
+  steps?: string[];
+}
+
+defineProps<{ data: PeerReviewTaskBlockData }>();
+</script>
+
+<style scoped>
+.peer-review {
+  border-radius: 1.5rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface-container);
+}
+
+.peer-review__section {
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+  padding-top: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.peer-review__criterion {
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface);
+}
+</style>

--- a/src/components/exercise/RubricDisplay.vue
+++ b/src/components/exercise/RubricDisplay.vue
@@ -1,0 +1,115 @@
+<template>
+  <article class="rubric card md-stack md-stack-4">
+    <header class="md-stack md-stack-2">
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p v-if="data.description" class="text-body-medium text-on-surface-variant">
+        {{ data.description }}
+      </p>
+    </header>
+
+    <div class="rubric__table" role="table" aria-label="Rúbrica avaliativa">
+      <div class="rubric__row rubric__row--header" role="row">
+        <div class="rubric__cell rubric__cell--header" role="columnheader">Critério</div>
+        <div
+          v-for="level in levels"
+          :key="level"
+          class="rubric__cell rubric__cell--header"
+          role="columnheader"
+        >
+          {{ level }}
+        </div>
+      </div>
+
+      <div
+        v-for="criterion in data.criteria"
+        :key="criterion.criterion"
+        class="rubric__row"
+        role="row"
+      >
+        <div class="rubric__cell rubric__cell--criterion" role="rowheader">
+          {{ criterion.criterion }}
+        </div>
+        <div
+          v-for="(descriptor, index) in criterion.levels"
+          :key="index"
+          class="rubric__cell"
+          role="cell"
+        >
+          {{ descriptor.description }}
+        </div>
+      </div>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+export interface RubricLevelDescriptor {
+  level: string;
+  description: string;
+}
+
+export interface RubricCriterion {
+  criterion: string;
+  levels: RubricLevelDescriptor[];
+}
+
+export interface RubricDisplayBlockData {
+  title?: string;
+  description?: string;
+  criteria: RubricCriterion[];
+}
+
+const props = defineProps<{ data: RubricDisplayBlockData }>();
+
+const levels = computed(() => {
+  if (props.data.criteria.length === 0) {
+    return [] as string[];
+  }
+  return props.data.criteria[0].levels.map((level) => level.level);
+});
+</script>
+
+<style scoped>
+.rubric {
+  border-radius: 1.5rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface);
+}
+
+.rubric__table {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.rubric__row {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(160px, 1fr) repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.rubric__row--header {
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.rubric__cell {
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface-container-low);
+}
+
+.rubric__cell--header {
+  background: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+}
+
+.rubric__cell--criterion {
+  font-weight: 600;
+}
+</style>

--- a/src/components/exercise/ScenarioBuilder.vue
+++ b/src/components/exercise/ScenarioBuilder.vue
@@ -1,0 +1,103 @@
+<template>
+  <article class="scenario-builder card md-stack md-stack-4">
+    <header class="md-stack md-stack-2">
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p v-if="data.description" class="text-body-medium text-on-surface-variant">
+        {{ data.description }}
+      </p>
+    </header>
+
+    <div class="scenario-builder__grid">
+      <section class="scenario-builder__column" aria-label="Entradas">
+        <h4 class="text-title-small font-semibold text-on-surface">Entradas</h4>
+        <ul class="md-stack md-stack-1" role="list">
+          <li v-for="(input, index) in data.inputs" :key="index" class="scenario-builder__item">
+            {{ input }}
+          </li>
+        </ul>
+      </section>
+
+      <section class="scenario-builder__column" aria-label="Processamentos">
+        <h4 class="text-title-small font-semibold text-on-surface">Processamentos</h4>
+        <ul class="md-stack md-stack-1" role="list">
+          <li
+            v-for="(process, index) in data.processes"
+            :key="index"
+            class="scenario-builder__item"
+          >
+            {{ process }}
+          </li>
+        </ul>
+      </section>
+
+      <section class="scenario-builder__column" aria-label="Saídas">
+        <h4 class="text-title-small font-semibold text-on-surface">Saídas</h4>
+        <ul class="md-stack md-stack-1" role="list">
+          <li v-for="(output, index) in data.outputs" :key="index" class="scenario-builder__item">
+            {{ output }}
+          </li>
+        </ul>
+      </section>
+    </div>
+
+    <section v-if="data.guidingQuestions?.length" class="scenario-builder__questions">
+      <h4 class="text-title-small font-semibold text-on-surface">Perguntas orientadoras</h4>
+      <ol class="md-stack md-stack-1" role="list">
+        <li
+          v-for="(question, index) in data.guidingQuestions"
+          :key="index"
+          class="text-body-medium text-on-surface"
+        >
+          {{ question }}
+        </li>
+      </ol>
+    </section>
+  </article>
+</template>
+
+<script setup lang="ts">
+export interface ScenarioBuilderBlockData {
+  title?: string;
+  description?: string;
+  inputs: string[];
+  processes: string[];
+  outputs: string[];
+  guidingQuestions?: string[];
+}
+
+defineProps<{ data: ScenarioBuilderBlockData }>();
+</script>
+
+<style scoped>
+.scenario-builder {
+  border-radius: 1.5rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface);
+}
+
+.scenario-builder__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.scenario-builder__column {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.scenario-builder__item {
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface-container-low);
+}
+
+.scenario-builder__questions {
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+  padding-top: 1rem;
+}
+</style>

--- a/src/components/exercise/SelfAssessment.vue
+++ b/src/components/exercise/SelfAssessment.vue
@@ -1,0 +1,84 @@
+<template>
+  <article class="self-assessment card md-stack md-stack-4">
+    <header class="md-stack md-stack-2">
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p v-if="data.description" class="text-body-medium text-on-surface-variant">
+        {{ data.description }}
+      </p>
+    </header>
+
+    <section class="md-stack md-stack-2" aria-label="Reflexões">
+      <div v-for="prompt in data.prompts" :key="prompt.id" class="self-assessment__prompt">
+        <label class="text-label-medium text-on-surface" :for="prompt.id">{{ prompt.label }}</label>
+        <textarea
+          :id="prompt.id"
+          v-model="responses[prompt.id]"
+          class="self-assessment__textarea"
+          :placeholder="prompt.placeholder || 'Escreva sua reflexão'"
+          rows="4"
+        ></textarea>
+      </div>
+    </section>
+
+    <p v-if="hasResponses" class="self-assessment__reminder">
+      Suas respostas ficam apenas neste dispositivo. Exporte se quiser compartilhar com o professor.
+    </p>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive } from 'vue';
+
+export interface SelfAssessmentPrompt {
+  id: string;
+  label: string;
+  placeholder?: string;
+}
+
+export interface SelfAssessmentBlockData {
+  title?: string;
+  description?: string;
+  prompts: SelfAssessmentPrompt[];
+}
+
+const props = defineProps<{ data: SelfAssessmentBlockData }>();
+
+const responses = reactive<Record<string, string>>({});
+
+props.data.prompts.forEach((prompt) => {
+  responses[prompt.id] = '';
+});
+
+const hasResponses = computed(() =>
+  Object.values(responses).some((value) => value.trim().length > 0)
+);
+</script>
+
+<style scoped>
+.self-assessment {
+  border-radius: 1.5rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface);
+}
+
+.self-assessment__prompt {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.self-assessment__textarea {
+  border-radius: 1rem;
+  border: 1px solid var(--md-sys-color-outline);
+  padding: 0.75rem 1rem;
+  background: var(--md-sys-color-surface-container-low);
+  color: var(--md-sys-color-on-surface);
+}
+
+.self-assessment__reminder {
+  font-size: 0.85rem;
+  color: var(--md-sys-color-on-surface-variant);
+}
+</style>

--- a/src/components/exercise/TestGenerator.vue
+++ b/src/components/exercise/TestGenerator.vue
@@ -1,0 +1,127 @@
+<template>
+  <article class="test-generator card md-stack md-stack-4">
+    <header class="md-stack md-stack-2">
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p v-if="data.description" class="text-body-medium text-on-surface-variant">
+        {{ data.description }}
+      </p>
+    </header>
+
+    <section class="md-stack md-stack-2" aria-label="Seleção de tópicos">
+      <h4 class="text-title-small font-semibold text-on-surface">Tags desejadas</h4>
+      <div class="test-generator__tags">
+        <label v-for="tag in data.tags" :key="tag" class="test-generator__chip">
+          <input type="checkbox" :value="tag" v-model="selectedTags" />
+          <span>#{{ tag }}</span>
+        </label>
+      </div>
+    </section>
+
+    <section class="md-stack md-stack-2" aria-label="Dificuldade">
+      <h4 class="text-title-small font-semibold text-on-surface">Dificuldade</h4>
+      <div class="test-generator__difficulty">
+        <label v-for="level in difficultyOptions" :key="level" class="test-generator__option">
+          <input
+            type="radio"
+            :name="difficultyGroupId"
+            :value="level"
+            v-model="selectedDifficulty"
+          />
+          <span>{{ difficultyLabels[level] }}</span>
+        </label>
+      </div>
+    </section>
+
+    <Md3Button variant="filled" @click="generate">Gerar roteiro de estudo</Md3Button>
+
+    <section v-if="output" class="test-generator__result" aria-live="polite">
+      <h4 class="text-title-small font-semibold text-on-surface">Sugestão gerada</h4>
+      <p class="text-body-medium text-on-surface">{{ output }}</p>
+    </section>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import Md3Button from '@/components/Md3Button.vue';
+
+export type TestGeneratorDifficulty = 'easy' | 'medium' | 'hard';
+
+export interface TestGeneratorBlockData {
+  title?: string;
+  description?: string;
+  tags: string[];
+  difficulties?: TestGeneratorDifficulty[];
+}
+
+const props = defineProps<{ data: TestGeneratorBlockData }>();
+
+const selectedTags = ref<string[]>([]);
+const selectedDifficulty = ref<TestGeneratorDifficulty>('medium');
+const output = ref('');
+const difficultyGroupId = `difficulty-${Math.random().toString(36).slice(2, 8)}`;
+
+const difficultyOptions = computed<TestGeneratorDifficulty[]>(
+  () => props.data.difficulties ?? ['easy', 'medium', 'hard']
+);
+
+const difficultyLabels: Record<TestGeneratorDifficulty, string> = {
+  easy: 'Básico',
+  medium: 'Intermediário',
+  hard: 'Avançado',
+};
+
+function generate() {
+  const tags = selectedTags.value.length ? selectedTags.value.join(', ') : 'todas as tags';
+  const difficulty = difficultyLabels[selectedDifficulty.value];
+  output.value = `Gerar 5 questões nível ${difficulty.toLowerCase()} cobrindo ${tags}. Inclua pelo menos uma questão discursiva.`;
+}
+</script>
+
+<style scoped>
+.test-generator {
+  border-radius: 1.5rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface);
+}
+
+.test-generator__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.test-generator__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface-container-low);
+}
+
+.test-generator__difficulty {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.test-generator__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface-container-low);
+}
+
+.test-generator__result {
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+  padding-top: 1rem;
+}
+</style>

--- a/src/components/lesson/CaseStudy.vue
+++ b/src/components/lesson/CaseStudy.vue
@@ -1,0 +1,101 @@
+<template>
+  <article class="case-study card md-stack md-stack-4">
+    <header class="md-stack md-stack-2">
+      <p class="text-label-medium uppercase tracking-[0.2em] text-on-surface-variant">
+        Estudo de caso
+      </p>
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p class="text-body-medium text-on-surface">{{ data.scenario }}</p>
+    </header>
+
+    <p v-if="data.background" class="text-body-medium text-on-surface-variant">
+      {{ data.background }}
+    </p>
+
+    <section v-if="data.dataPoints?.length" class="case-study__section" aria-label="Dados">
+      <h4 class="text-title-small font-semibold text-on-surface">Dados fornecidos</h4>
+      <dl class="case-study__data">
+        <div v-for="(item, index) in data.dataPoints" :key="index" class="case-study__data-item">
+          <dt class="text-label-medium uppercase text-on-surface-variant">{{ item.label }}</dt>
+          <dd class="text-body-large text-on-surface">{{ item.value }}</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section
+      v-if="data.questions?.length"
+      class="case-study__section"
+      aria-label="Perguntas para discussão"
+    >
+      <h4 class="text-title-small font-semibold text-on-surface">Perguntas para discussão</h4>
+      <ol class="md-stack md-stack-1" role="list">
+        <li
+          v-for="(question, index) in data.questions"
+          :key="index"
+          class="text-body-medium text-on-surface"
+        >
+          {{ question }}
+        </li>
+      </ol>
+    </section>
+
+    <section v-if="data.tasks?.length" class="case-study__section" aria-label="Tarefas">
+      <h4 class="text-title-small font-semibold text-on-surface">Tarefas sugeridas</h4>
+      <ul class="md-stack md-stack-1" role="list">
+        <li
+          v-for="(task, index) in data.tasks"
+          :key="index"
+          class="text-body-medium text-on-surface"
+        >
+          {{ task }}
+        </li>
+      </ul>
+    </section>
+  </article>
+</template>
+
+<script setup lang="ts">
+export interface CaseStudyDataPoint {
+  label: string;
+  value: string;
+}
+
+export interface CaseStudyBlockData {
+  title?: string;
+  scenario: string;
+  background?: string;
+  dataPoints?: CaseStudyDataPoint[];
+  questions?: string[];
+  tasks?: string[];
+}
+
+defineProps<{ data: CaseStudyBlockData }>();
+</script>
+
+<style scoped>
+.case-study {
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface-container);
+}
+
+.case-study__section {
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+  padding-top: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.case-study__data {
+  display: grid;
+  gap: 1rem;
+}
+
+.case-study__data-item {
+  display: grid;
+  gap: 0.25rem;
+}
+</style>

--- a/src/components/lesson/CodeChallenge.vue
+++ b/src/components/lesson/CodeChallenge.vue
@@ -1,0 +1,99 @@
+<template>
+  <article class="code-challenge card md-stack md-stack-4">
+    <header class="md-stack md-stack-2">
+      <p class="text-label-medium uppercase tracking-[0.2em] text-on-surface-variant">
+        Desafio rápido
+      </p>
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p class="text-body-medium text-on-surface">{{ data.prompt }}</p>
+    </header>
+
+    <CodeBlock
+      v-if="data.code"
+      :code="data.code"
+      :language="data.language"
+      :plainText="!data.language"
+    />
+
+    <section v-if="data.question" class="md-stack md-stack-2">
+      <h4 class="text-title-medium font-semibold text-on-surface">{{ data.question }}</h4>
+      <div class="code-challenge__options" role="group" :aria-label="data.question">
+        <label v-for="option in data.options" :key="option.id" class="code-challenge__option">
+          <input type="radio" :name="groupName" :value="option.id" v-model="selectedOption" />
+          <span>{{ option.text }}</span>
+        </label>
+      </div>
+    </section>
+
+    <p v-if="showExplanation" class="code-challenge__explanation">
+      {{ data.answerExplanation }}
+    </p>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import CodeBlock from './CodeBlock.vue';
+
+export interface CodeChallengeOption {
+  id: string;
+  text: string;
+}
+
+export interface CodeChallengeBlockData {
+  title?: string;
+  prompt: string;
+  code?: string;
+  language?: string;
+  question?: string;
+  options?: CodeChallengeOption[];
+  answerExplanation?: string;
+}
+
+const props = defineProps<{ data: CodeChallengeBlockData }>();
+
+const selectedOption = ref<string>('');
+const groupName = `code-challenge-${Math.random().toString(36).slice(2, 8)}`;
+
+const showExplanation = computed(
+  () => Boolean(props.data.answerExplanation) && Boolean(selectedOption.value)
+);
+</script>
+
+<style scoped>
+.code-challenge {
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface-container-low);
+}
+
+.code-challenge__options {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.code-challenge__option {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--md-sys-color-outline);
+  border-radius: 1rem;
+  cursor: pointer;
+  background: var(--md-sys-color-surface);
+}
+
+.code-challenge__option input {
+  margin-top: 0.25rem;
+}
+
+.code-challenge__explanation {
+  padding: 1rem;
+  border-radius: 1rem;
+  background: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+}
+</style>

--- a/src/components/lesson/ComparativeTable.vue
+++ b/src/components/lesson/ComparativeTable.vue
@@ -1,0 +1,94 @@
+<template>
+  <article class="comparative-table card md-stack md-stack-4">
+    <header v-if="data.title || data.description" class="md-stack md-stack-2">
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p v-if="data.description" class="text-body-medium text-on-surface-variant">
+        {{ data.description }}
+      </p>
+    </header>
+
+    <div class="overflow-x-auto">
+      <table class="min-w-full border-separate border-spacing-y-2 text-left">
+        <caption v-if="data.caption" class="text-label-medium text-on-surface-variant">
+          {{
+            data.caption
+          }}
+        </caption>
+        <thead>
+          <tr>
+            <th class="px-4 py-3 text-label-medium uppercase tracking-wide text-on-surface-variant">
+              {{ data.leadingColumnLabel || 'Comparativo' }}
+            </th>
+            <th
+              v-for="(header, index) in data.headers"
+              :key="index"
+              class="px-4 py-3 text-label-medium uppercase tracking-wide text-on-surface-variant"
+            >
+              {{ header }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="(row, rowIndex) in data.rows"
+            :key="rowIndex"
+            class="rounded-lg border border-outline-variant bg-surface"
+          >
+            <th
+              scope="row"
+              class="whitespace-nowrap px-4 py-3 text-body-medium font-semibold text-on-surface"
+            >
+              {{ row.label }}
+            </th>
+            <td
+              v-for="(cell, cellIndex) in row.values"
+              :key="cellIndex"
+              class="px-4 py-3 align-top text-body-medium text-on-surface"
+            >
+              {{ cell }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+export interface ComparativeTableRow {
+  label: string;
+  values: string[];
+}
+
+export interface ComparativeTableBlockData {
+  title?: string;
+  description?: string;
+  caption?: string;
+  leadingColumnLabel?: string;
+  headers: string[];
+  rows: ComparativeTableRow[];
+}
+
+defineProps<{ data: ComparativeTableBlockData }>();
+</script>
+
+<style scoped>
+.comparative-table {
+  padding: 1.5rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 1.5rem;
+  background: var(--md-sys-color-surface-container);
+}
+
+th,
+td {
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+}
+
+tbody tr:last-of-type th,
+tbody tr:last-of-type td {
+  border-bottom: none;
+}
+</style>

--- a/src/components/lesson/DefinitionCard.vue
+++ b/src/components/lesson/DefinitionCard.vue
@@ -1,0 +1,56 @@
+<template>
+  <article class="definition-card card md-stack md-stack-3">
+    <header class="md-stack md-stack-1">
+      <p class="text-label-medium uppercase tracking-[0.2em] text-on-surface-variant">Termo</p>
+      <h3 class="text-title-large font-semibold text-on-surface">{{ data.term }}</h3>
+    </header>
+
+    <p class="text-body-large leading-relaxed text-on-surface">{{ data.definition }}</p>
+
+    <footer v-if="hasSource" class="definition-card__footer">
+      <span class="text-label-small uppercase text-on-surface-variant">Fonte</span>
+      <a
+        v-if="data.sourceUrl"
+        class="text-body-small font-medium text-primary hover:underline"
+        :href="data.sourceUrl"
+        rel="noreferrer noopener"
+        target="_blank"
+      >
+        {{ data.source }}
+      </a>
+      <span v-else class="text-body-small text-on-surface-variant">{{ data.source }}</span>
+    </footer>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+export interface DefinitionCardBlockData {
+  term: string;
+  definition: string;
+  source?: string;
+  sourceUrl?: string;
+}
+
+const props = defineProps<{ data: DefinitionCardBlockData }>();
+
+const hasSource = computed(() => Boolean(props.data.source));
+</script>
+
+<style scoped>
+.definition-card {
+  border-radius: 1.5rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface);
+}
+
+.definition-card__footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+}
+</style>

--- a/src/components/lesson/InteractiveDemo.vue
+++ b/src/components/lesson/InteractiveDemo.vue
@@ -1,0 +1,87 @@
+<template>
+  <article class="interactive-demo card md-stack md-stack-4">
+    <header class="md-stack md-stack-2">
+      <p class="text-label-medium uppercase tracking-[0.2em] text-on-surface-variant">
+        Demo interativa
+      </p>
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p v-if="data.description" class="text-body-medium text-on-surface-variant">
+        {{ data.description }}
+      </p>
+    </header>
+
+    <div v-if="safeUrl" class="interactive-demo__frame" :style="frameStyle">
+      <iframe
+        :src="safeUrl"
+        :title="data.title || 'Demonstração interativa'"
+        loading="lazy"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        sandbox="allow-scripts allow-forms allow-popups allow-same-origin"
+      ></iframe>
+    </div>
+
+    <p v-else class="text-body-small text-on-surface-variant">
+      Não foi possível carregar o recurso externo informado.
+    </p>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+export interface InteractiveDemoBlockData {
+  title?: string;
+  description?: string;
+  url: string;
+  height?: number;
+}
+
+const props = defineProps<{ data: InteractiveDemoBlockData }>();
+
+const safeUrl = computed(() => {
+  try {
+    const parsed = new URL(props.data.url);
+    if (!['https:', 'http:'].includes(parsed.protocol)) {
+      return '';
+    }
+    return parsed.toString();
+  } catch (error) {
+    console.warn('[InteractiveDemo] Invalid URL provided', error);
+    return '';
+  }
+});
+
+const frameStyle = computed(() => {
+  if (!props.data.height) {
+    return {};
+  }
+  return {
+    minHeight: `${props.data.height}px`,
+  } as const;
+});
+</script>
+
+<style scoped>
+.interactive-demo {
+  border-radius: 1.5rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface);
+}
+
+.interactive-demo__frame {
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 1px solid var(--md-sys-color-outline);
+}
+
+.interactive-demo__frame iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+</style>

--- a/src/components/lesson/KnowledgeCheck.vue
+++ b/src/components/lesson/KnowledgeCheck.vue
@@ -1,0 +1,97 @@
+<template>
+  <article class="knowledge-check card md-stack md-stack-4">
+    <header class="md-stack md-stack-2">
+      <p class="text-label-medium uppercase tracking-[0.2em] text-on-surface-variant">
+        Checagem rápida
+      </p>
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p class="text-body-medium text-on-surface">{{ data.prompt }}</p>
+    </header>
+
+    <fieldset class="knowledge-check__options" :aria-label="data.prompt">
+      <legend class="sr-only">Respostas</legend>
+      <label v-for="option in data.options" :key="option.id" class="knowledge-check__option">
+        <input
+          :type="data.allowMultiple ? 'checkbox' : 'radio'"
+          :name="groupName"
+          :value="option.id"
+          v-model="selected"
+        />
+        <span>{{ option.text }}</span>
+      </label>
+    </fieldset>
+
+    <p v-if="data.explanation && hasSelection" class="knowledge-check__explanation">
+      {{ data.explanation }}
+    </p>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+
+export interface KnowledgeCheckOption {
+  id: string;
+  text: string;
+}
+
+export interface KnowledgeCheckBlockData {
+  title?: string;
+  prompt: string;
+  options: KnowledgeCheckOption[];
+  explanation?: string;
+  allowMultiple?: boolean;
+}
+
+const props = defineProps<{ data: KnowledgeCheckBlockData }>();
+
+const selected = ref<string | string[]>('');
+const groupName = `knowledge-check-${Math.random().toString(36).slice(2, 8)}`;
+
+const hasSelection = computed(() => {
+  if (props.data.allowMultiple) {
+    return Array.isArray(selected.value) && selected.value.length > 0;
+  }
+  return typeof selected.value === 'string' && selected.value.length > 0;
+});
+</script>
+
+<style scoped>
+.knowledge-check {
+  border-radius: 1.5rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface-container);
+}
+
+.knowledge-check__options {
+  border: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.knowledge-check__option {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface);
+}
+
+.knowledge-check__option input {
+  margin-top: 0.25rem;
+}
+
+.knowledge-check__explanation {
+  border-radius: 1rem;
+  padding: 1rem;
+  background: var(--md-sys-color-tertiary-container);
+  color: var(--md-sys-color-on-tertiary-container);
+}
+</style>

--- a/src/components/lesson/MemoryVisualizer.vue
+++ b/src/components/lesson/MemoryVisualizer.vue
@@ -1,0 +1,102 @@
+<template>
+  <article class="memory-visualizer card md-stack md-stack-4">
+    <header v-if="data.title || data.summary" class="md-stack md-stack-2">
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p v-if="data.summary" class="text-body-medium text-on-surface-variant">{{ data.summary }}</p>
+    </header>
+
+    <div class="memory-visualizer__grid">
+      <section class="memory-visualizer__column" aria-label="Stack">
+        <h4 class="text-title-small font-semibold text-on-surface">Stack</h4>
+        <ol class="memory-visualizer__stack" role="list">
+          <li v-for="(frame, index) in data.stack" :key="index" class="memory-visualizer__frame">
+            <span class="text-label-medium text-on-surface-variant">{{ frame.label }}</span>
+            <span class="text-body-large font-mono text-on-surface">{{ frame.value }}</span>
+          </li>
+          <li v-if="!data.stack?.length" class="memory-visualizer__empty">(vazio)</li>
+        </ol>
+      </section>
+
+      <section class="memory-visualizer__column" aria-label="Heap">
+        <h4 class="text-title-small font-semibold text-on-surface">Heap</h4>
+        <ul class="memory-visualizer__heap" role="list">
+          <li
+            v-for="(allocation, index) in data.heap"
+            :key="index"
+            class="memory-visualizer__allocation"
+          >
+            <span class="text-label-medium text-on-surface-variant">{{ allocation.label }}</span>
+            <span class="text-body-large font-mono text-on-surface">{{ allocation.value }}</span>
+          </li>
+          <li v-if="!data.heap?.length" class="memory-visualizer__empty">(sem alocações)</li>
+        </ul>
+      </section>
+    </div>
+
+    <p v-if="data.notes" class="text-body-small text-on-surface-variant">{{ data.notes }}</p>
+  </article>
+</template>
+
+<script setup lang="ts">
+export interface MemoryVisualizerEntry {
+  label: string;
+  value: string;
+}
+
+export interface MemoryVisualizerBlockData {
+  title?: string;
+  summary?: string;
+  stack?: MemoryVisualizerEntry[];
+  heap?: MemoryVisualizerEntry[];
+  notes?: string;
+}
+
+defineProps<{ data: MemoryVisualizerBlockData }>();
+</script>
+
+<style scoped>
+.memory-visualizer {
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface);
+}
+
+.memory-visualizer__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.memory-visualizer__column {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.memory-visualizer__stack,
+.memory-visualizer__heap {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+}
+
+.memory-visualizer__frame,
+.memory-visualizer__allocation {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface-container-low);
+}
+
+.memory-visualizer__empty {
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  border: 1px dashed var(--md-sys-color-outline);
+  color: var(--md-sys-color-on-surface-variant);
+}
+</style>

--- a/src/components/lesson/PedagogicalNote.vue
+++ b/src/components/lesson/PedagogicalNote.vue
@@ -1,0 +1,58 @@
+<template>
+  <TeacherModeGate>
+    <article class="pedagogical-note card md-stack md-stack-3">
+      <header class="md-stack md-stack-1">
+        <p class="text-label-medium uppercase tracking-[0.2em] text-on-surface-variant">
+          Nota pedagógica
+        </p>
+        <h3 v-if="data.title" class="text-title-medium font-semibold text-on-surface">
+          {{ data.title }}
+        </h3>
+      </header>
+      <p class="text-body-medium text-on-surface">{{ data.content }}</p>
+      <p v-if="data.audience" class="pedagogical-note__audience">Público: {{ audienceLabel }}</p>
+    </article>
+  </TeacherModeGate>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import TeacherModeGate from '../TeacherModeGate.vue';
+
+export type PedagogicalNoteAudience = 'teacher' | 'student' | 'team';
+
+export interface PedagogicalNoteBlockData {
+  title?: string;
+  content: string;
+  audience?: PedagogicalNoteAudience;
+}
+
+const props = defineProps<{ data: PedagogicalNoteBlockData }>();
+
+const audienceLabel = computed(() => {
+  switch (props.data.audience) {
+    case 'teacher':
+      return 'Docentes';
+    case 'team':
+      return 'Equipe de apoio';
+    case 'student':
+      return 'Estudantes';
+    default:
+      return 'Docentes';
+  }
+});
+</script>
+
+<style scoped>
+.pedagogical-note {
+  border: 1px dashed var(--md-sys-color-outline);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface-container-high);
+}
+
+.pedagogical-note__audience {
+  font-size: 0.875rem;
+  color: var(--md-sys-color-on-surface-variant);
+}
+</style>

--- a/src/components/lesson/StatCard.vue
+++ b/src/components/lesson/StatCard.vue
@@ -1,0 +1,89 @@
+<template>
+  <article class="stat-card" :class="trendClass">
+    <div class="stat-card__header">
+      <p class="text-label-medium uppercase tracking-[0.2em] text-on-surface-variant">
+        {{ data.label }}
+      </p>
+      <component :is="trendIcon" class="md-icon md-icon--lg" aria-hidden="true" />
+    </div>
+    <p class="stat-card__value">{{ data.value }}</p>
+    <p v-if="data.context" class="stat-card__context">{{ data.context }}</p>
+    <p v-if="data.source" class="stat-card__source">Fonte: {{ data.source }}</p>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { TrendingUp, TrendingDown, Minus } from 'lucide-vue-next';
+
+export type StatTrend = 'up' | 'down' | 'neutral';
+
+export interface StatCardBlockData {
+  label: string;
+  value: string;
+  context?: string;
+  source?: string;
+  trend?: StatTrend;
+}
+
+const props = defineProps<{ data: StatCardBlockData }>();
+
+const resolvedTrend = computed<StatTrend>(() => props.data.trend ?? 'neutral');
+
+const trendIcon = computed(() => {
+  switch (resolvedTrend.value) {
+    case 'up':
+      return TrendingUp;
+    case 'down':
+      return TrendingDown;
+    default:
+      return Minus;
+  }
+});
+
+const trendClass = computed(() => `stat-card--${resolvedTrend.value}`);
+</script>
+
+<style scoped>
+.stat-card {
+  display: grid;
+  gap: 0.5rem;
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  background: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
+}
+
+.stat-card--up {
+  border-color: var(--md-sys-color-tertiary);
+}
+
+.stat-card--down {
+  border-color: var(--md-sys-color-error);
+}
+
+.stat-card--neutral {
+  border-color: var(--md-sys-color-outline-variant);
+}
+
+.stat-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.stat-card__value {
+  font-size: 2.75rem;
+  font-weight: 700;
+}
+
+.stat-card__context {
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.stat-card__source {
+  font-size: 0.75rem;
+  color: var(--md-sys-color-on-surface-variant);
+}
+</style>

--- a/src/components/lesson/SystemDiagram.vue
+++ b/src/components/lesson/SystemDiagram.vue
@@ -1,0 +1,120 @@
+<template>
+  <article class="system-diagram card md-stack md-stack-4">
+    <header v-if="data.title || data.summary" class="md-stack md-stack-2">
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p v-if="data.summary" class="text-body-medium text-on-surface-variant">{{ data.summary }}</p>
+    </header>
+
+    <section class="system-diagram__grid" aria-label="Nós do sistema">
+      <article v-for="node in data.nodes" :key="node.id" class="system-diagram__node">
+        <h4 class="text-title-medium font-semibold text-on-surface">{{ node.label }}</h4>
+        <p v-if="node.description" class="text-body-medium text-on-surface-variant">
+          {{ node.description }}
+        </p>
+      </article>
+    </section>
+
+    <section
+      v-if="data.connections?.length"
+      class="system-diagram__connections"
+      aria-label="Conexões"
+    >
+      <h4 class="text-title-small font-semibold text-on-surface">Conexões</h4>
+      <ul class="md-stack md-stack-1" role="list">
+        <li
+          v-for="(connection, index) in data.connections"
+          :key="index"
+          class="text-body-medium text-on-surface"
+        >
+          <span class="font-semibold">{{ resolveNodeLabel(connection.from) }}</span>
+          <span class="text-on-surface-variant"> → </span>
+          <span class="font-semibold">{{ resolveNodeLabel(connection.to) }}</span>
+          <span v-if="connection.label" class="text-on-surface-variant">
+            — {{ connection.label }}</span
+          >
+        </li>
+      </ul>
+    </section>
+
+    <section v-if="data.legend?.length" class="system-diagram__legend" aria-label="Legenda">
+      <h4 class="text-title-small font-semibold text-on-surface">Legenda</h4>
+      <ul class="md-stack md-stack-1" role="list">
+        <li
+          v-for="(entry, index) in data.legend"
+          :key="index"
+          class="text-body-small text-on-surface-variant"
+        >
+          {{ entry }}
+        </li>
+      </ul>
+    </section>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+export interface SystemDiagramNode {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+export interface SystemDiagramConnection {
+  from: string;
+  to: string;
+  label?: string;
+}
+
+export interface SystemDiagramBlockData {
+  title?: string;
+  summary?: string;
+  nodes: SystemDiagramNode[];
+  connections?: SystemDiagramConnection[];
+  legend?: string[];
+}
+
+const props = defineProps<{ data: SystemDiagramBlockData }>();
+
+const nodeMap = computed(() => {
+  const entries = new Map<string, string>();
+  props.data.nodes.forEach((node) => {
+    entries.set(node.id, node.label);
+  });
+  return entries;
+});
+
+function resolveNodeLabel(id: string): string {
+  return nodeMap.value.get(id) ?? id;
+}
+</script>
+
+<style scoped>
+.system-diagram {
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface);
+}
+
+.system-diagram__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.system-diagram__node {
+  border: 1px solid var(--md-sys-color-outline);
+  border-radius: 1rem;
+  padding: 1rem;
+  background: var(--md-sys-color-surface-container-low);
+}
+
+.system-diagram__connections,
+.system-diagram__legend {
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+  padding-top: 1rem;
+}
+</style>

--- a/src/components/lesson/__tests__/NewExerciseBlocks.test.ts
+++ b/src/components/lesson/__tests__/NewExerciseBlocks.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import CodeSubmission from '@/components/exercise/CodeSubmission.vue';
+import DragAndDrop from '@/components/exercise/DragAndDrop.vue';
+import ConceptMapper from '@/components/exercise/ConceptMapper.vue';
+import BugFixChallenge from '@/components/exercise/BugFixChallenge.vue';
+import DataEntryForm from '@/components/exercise/DataEntryForm.vue';
+import ScenarioBuilder from '@/components/exercise/ScenarioBuilder.vue';
+import PeerReviewTask from '@/components/exercise/PeerReviewTask.vue';
+import TestGenerator from '@/components/exercise/TestGenerator.vue';
+import RubricDisplay from '@/components/exercise/RubricDisplay.vue';
+import SelfAssessment from '@/components/exercise/SelfAssessment.vue';
+
+describe('New exercise blocks', () => {
+  it('renders CodeSubmission with boilerplate', () => {
+    const wrapper = mount(CodeSubmission, {
+      props: {
+        data: {
+          prompt: 'Implemente a função soma',
+          boilerplate: 'int soma(int a, int b) {\n  return 0;\n}',
+          language: 'c',
+        },
+      },
+    });
+
+    const textarea = wrapper.find('textarea');
+    expect(textarea.element.value).toContain('int soma');
+  });
+
+  it('renders DragAndDrop with sortable items', () => {
+    const wrapper = mount(DragAndDrop, {
+      props: {
+        data: {
+          title: 'Ordene o algoritmo',
+          steps: [
+            { id: '1', label: 'Inicializar' },
+            { id: '2', label: 'Processar' },
+            { id: '3', label: 'Encerrar' },
+          ],
+        },
+      },
+    });
+
+    expect(wrapper.findAll('.drag-drop__item')).toHaveLength(3);
+  });
+
+  it('renders ConceptMapper grouping nodes por categoria', () => {
+    const wrapper = mount(ConceptMapper, {
+      props: {
+        data: {
+          title: 'Mapeie conceitos',
+          nodes: [
+            { id: '1', label: 'Entrada', category: 'E-P-S' },
+            { id: '2', label: 'Processamento', category: 'E-P-S' },
+            { id: '3', label: 'Indicador', category: 'Métricas' },
+          ],
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('E-P-S');
+    expect(wrapper.text()).toContain('Indicador');
+  });
+
+  it('renders BugFixChallenge with code snippet', () => {
+    const wrapper = mount(BugFixChallenge, {
+      props: {
+        data: {
+          code: 'printf("Hello");',
+          language: 'c',
+          guidance: ['Revise parênteses'],
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Hello');
+    expect(wrapper.text()).toContain('Revise parênteses');
+  });
+
+  it('validates DataEntryForm required fields', async () => {
+    const wrapper = mount(DataEntryForm, {
+      props: {
+        data: {
+          title: 'Cadastro',
+          fields: [
+            { id: 'nome', label: 'Nome', required: true },
+            { id: 'email', label: 'E-mail', type: 'email' },
+          ],
+        },
+      },
+    });
+
+    await wrapper.find('form').trigger('submit.prevent');
+    expect(wrapper.text()).toContain('Campo obrigatório');
+  });
+
+  it('renders ScenarioBuilder columns', () => {
+    const wrapper = mount(ScenarioBuilder, {
+      props: {
+        data: {
+          inputs: ['Dados brutos'],
+          processes: ['Limpeza'],
+          outputs: ['Dashboard'],
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Dados brutos');
+    expect(wrapper.text()).toContain('Dashboard');
+  });
+
+  it('renders PeerReviewTask with criteria and steps', () => {
+    const wrapper = mount(PeerReviewTask, {
+      props: {
+        data: {
+          criteria: [
+            { id: 'clarity', label: 'Clareza' },
+            { id: 'depth', label: 'Profundidade' },
+          ],
+          steps: ['Ler trabalho do colega', 'Enviar feedback'],
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Clareza');
+    expect(wrapper.text()).toContain('Enviar feedback');
+  });
+
+  it('generates output in TestGenerator', async () => {
+    const wrapper = mount(TestGenerator, {
+      props: {
+        data: {
+          tags: ['variaveis', 'loops'],
+        },
+      },
+    });
+
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.text()).toContain('Gerar 5 questões');
+  });
+
+  it('renders RubricDisplay com níveis', () => {
+    const wrapper = mount(RubricDisplay, {
+      props: {
+        data: {
+          criteria: [
+            {
+              criterion: 'Análise',
+              levels: [
+                { level: 'Excelente', description: 'Explora causas e efeitos.' },
+                { level: 'Suficiente', description: 'Identifica fatores principais.' },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Excelente');
+    expect(wrapper.text()).toContain('Explora causas');
+  });
+
+  it('renders SelfAssessment prompts', () => {
+    const wrapper = mount(SelfAssessment, {
+      props: {
+        data: {
+          prompts: [
+            { id: 'p1', label: 'O que aprendi hoje?' },
+            { id: 'p2', label: 'Quais dúvidas permanecem?' },
+          ],
+        },
+      },
+    });
+
+    expect(wrapper.findAll('textarea')).toHaveLength(2);
+    expect(wrapper.text()).toContain('O que aprendi hoje?');
+  });
+});

--- a/src/components/lesson/__tests__/NewLessonBlocks.test.ts
+++ b/src/components/lesson/__tests__/NewLessonBlocks.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import DefinitionCard from '../DefinitionCard.vue';
+import ComparativeTable from '../ComparativeTable.vue';
+import SystemDiagram from '../SystemDiagram.vue';
+import CodeChallenge from '../CodeChallenge.vue';
+import MemoryVisualizer from '../MemoryVisualizer.vue';
+import CaseStudy from '../CaseStudy.vue';
+import StatCard from '../StatCard.vue';
+import KnowledgeCheck from '../KnowledgeCheck.vue';
+import InteractiveDemo from '../InteractiveDemo.vue';
+import PedagogicalNote from '../PedagogicalNote.vue';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe('New lesson content blocks', () => {
+  it('renders DefinitionCard with term and definition', () => {
+    const wrapper = mount(DefinitionCard, {
+      props: { data: { term: 'Stack', definition: 'Estrutura LIFO', source: 'Cormen' } },
+    });
+
+    expect(wrapper.text()).toContain('Stack');
+    expect(wrapper.text()).toContain('Estrutura LIFO');
+    expect(wrapper.text()).toContain('Cormen');
+  });
+
+  it('renders ComparativeTable rows', () => {
+    const wrapper = mount(ComparativeTable, {
+      props: {
+        data: {
+          headers: ['For', 'While'],
+          rows: [
+            { label: 'Controle', values: ['Condicional', 'Condicional'] },
+            { label: 'Uso', values: ['Quando iterações conhecidas', 'Quando condição aberta'] },
+          ],
+        },
+      },
+    });
+
+    expect(wrapper.findAll('tbody tr')).toHaveLength(2);
+    expect(wrapper.text()).toContain('Controle');
+  });
+
+  it('renders SystemDiagram with nodes and connections', () => {
+    const wrapper = mount(SystemDiagram, {
+      props: {
+        data: {
+          nodes: [
+            { id: 'api', label: 'API' },
+            { id: 'db', label: 'Banco' },
+          ],
+          connections: [{ from: 'api', to: 'db', label: 'Persistência' }],
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('API');
+    expect(wrapper.text()).toContain('Persistência');
+  });
+
+  it('shows CodeChallenge options and explanation after selection', async () => {
+    const wrapper = mount(CodeChallenge, {
+      props: {
+        data: {
+          prompt: 'Qual saída?',
+          question: 'Resultado de 1 + 1',
+          options: [
+            { id: 'a', text: '1' },
+            { id: 'b', text: '2' },
+          ],
+          answerExplanation: 'A soma correta é 2.',
+        },
+      },
+    });
+
+    await wrapper.find('input[type="radio"]').setValue();
+    expect(wrapper.text()).toContain('A soma correta é 2.');
+  });
+
+  it('renders MemoryVisualizer with stack and heap placeholders', () => {
+    const wrapper = mount(MemoryVisualizer, {
+      props: {
+        data: {
+          stack: [
+            { label: 'main()', value: 'ret addr' },
+            { label: 'sum(a, b)', value: 'a=2, b=3' },
+          ],
+          heap: [{ label: 'buffer', value: '0x01ff' }],
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('main()');
+    expect(wrapper.text()).toContain('0x01ff');
+  });
+
+  it('renders CaseStudy with scenario and questions', () => {
+    const wrapper = mount(CaseStudy, {
+      props: {
+        data: {
+          scenario: 'Empresa SaaS com churn alto',
+          questions: ['Quais métricas acompanhar?'],
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Empresa SaaS com churn alto');
+    expect(wrapper.text()).toContain('Quais métricas acompanhar?');
+  });
+
+  it('renders StatCard with trend icon', () => {
+    const wrapper = mount(StatCard, {
+      props: {
+        data: { label: 'NPS', value: '78', trend: 'up', context: '+5pp vs trimestre anterior' },
+      },
+    });
+
+    expect(wrapper.text()).toContain('NPS');
+    expect(wrapper.text()).toContain('78');
+  });
+
+  it('renders KnowledgeCheck options', () => {
+    const wrapper = mount(KnowledgeCheck, {
+      props: {
+        data: {
+          prompt: 'Selecione conceitos OO',
+          options: [
+            { id: 'enc', text: 'Encapsulamento' },
+            { id: 'db', text: 'Banco de dados' },
+          ],
+          explanation: 'Encapsulamento, herança e polimorfismo são pilares.',
+        },
+      },
+    });
+
+    expect(wrapper.findAll('input').length).toBe(2);
+  });
+
+  it('renders InteractiveDemo iframe when URL is valid', () => {
+    const wrapper = mount(InteractiveDemo, {
+      props: {
+        data: {
+          url: 'https://example.com/demo',
+          title: 'Protótipo',
+        },
+      },
+    });
+
+    const iframe = wrapper.find('iframe');
+    expect(iframe.exists()).toBe(true);
+    expect(iframe.attributes('src')).toBe('https://example.com/demo');
+  });
+
+  it('renders PedagogicalNote when teacher mode is enabled', () => {
+    window.localStorage.setItem('teacherMode', 'true');
+    const wrapper = mount(PedagogicalNote, {
+      props: {
+        data: {
+          content: 'Lembrete de alinhamento com a coordenação.',
+          title: 'Orientação interna',
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Orientação interna');
+    expect(wrapper.text()).toContain('Lembrete de alinhamento');
+  });
+});

--- a/src/components/lesson/blockRegistry.ts
+++ b/src/components/lesson/blockRegistry.ts
@@ -36,6 +36,26 @@ import ScenarioMatrix from '@/components/lesson/ScenarioMatrix.vue';
 import SpriteSheetViewer from '@/components/lesson/SpriteSheetViewer.vue';
 import CRCCards from '@/components/lesson/CRCCards.vue';
 import ApiEndpoints from '@/components/lesson/ApiEndpoints.vue';
+import DefinitionCard from '@/components/lesson/DefinitionCard.vue';
+import ComparativeTable from '@/components/lesson/ComparativeTable.vue';
+import SystemDiagram from '@/components/lesson/SystemDiagram.vue';
+import CodeChallenge from '@/components/lesson/CodeChallenge.vue';
+import MemoryVisualizer from '@/components/lesson/MemoryVisualizer.vue';
+import CaseStudy from '@/components/lesson/CaseStudy.vue';
+import StatCard from '@/components/lesson/StatCard.vue';
+import KnowledgeCheck from '@/components/lesson/KnowledgeCheck.vue';
+import InteractiveDemo from '@/components/lesson/InteractiveDemo.vue';
+import PedagogicalNote from '@/components/lesson/PedagogicalNote.vue';
+import CodeSubmission from '@/components/exercise/CodeSubmission.vue';
+import DragAndDrop from '@/components/exercise/DragAndDrop.vue';
+import ConceptMapper from '@/components/exercise/ConceptMapper.vue';
+import BugFixChallenge from '@/components/exercise/BugFixChallenge.vue';
+import DataEntryForm from '@/components/exercise/DataEntryForm.vue';
+import ScenarioBuilder from '@/components/exercise/ScenarioBuilder.vue';
+import PeerReviewTask from '@/components/exercise/PeerReviewTask.vue';
+import TestGenerator from '@/components/exercise/TestGenerator.vue';
+import RubricDisplay from '@/components/exercise/RubricDisplay.vue';
+import SelfAssessment from '@/components/exercise/SelfAssessment.vue';
 import type { Component } from 'vue';
 
 export type LessonBlock = Record<string, unknown> & { type: string };
@@ -73,6 +93,26 @@ const customComponentRegistry: Record<string, Component> = {
   SpriteSheetViewer,
   CRCCards,
   ApiEndpoints,
+  DefinitionCard,
+  ComparativeTable,
+  SystemDiagram,
+  CodeChallenge,
+  MemoryVisualizer,
+  CaseStudy,
+  StatCard,
+  KnowledgeCheck,
+  InteractiveDemo,
+  PedagogicalNote,
+  CodeSubmission,
+  DragAndDrop,
+  ConceptMapper,
+  BugFixChallenge,
+  DataEntryForm,
+  ScenarioBuilder,
+  PeerReviewTask,
+  TestGenerator,
+  RubricDisplay,
+  SelfAssessment,
 };
 
 const blockHandlers: Record<string, (block: LessonBlock) => BlockResolution> = {
@@ -136,6 +176,26 @@ const blockHandlers: Record<string, (block: LessonBlock) => BlockResolution> = {
   spriteSheet: dataBlock(SpriteSheetViewer),
   crcCards: dataBlock(CRCCards),
   apiEndpoints: dataBlock(ApiEndpoints),
+  definitionCard: dataBlock(DefinitionCard),
+  comparativeTable: dataBlock(ComparativeTable),
+  systemDiagram: dataBlock(SystemDiagram),
+  codeChallenge: dataBlock(CodeChallenge),
+  memoryVisualizer: dataBlock(MemoryVisualizer),
+  caseStudy: dataBlock(CaseStudy),
+  statCard: dataBlock(StatCard),
+  knowledgeCheck: dataBlock(KnowledgeCheck),
+  interactiveDemo: dataBlock(InteractiveDemo),
+  pedagogicalNote: dataBlock(PedagogicalNote),
+  codeSubmission: dataBlock(CodeSubmission),
+  dragAndDrop: dataBlock(DragAndDrop),
+  conceptMapper: dataBlock(ConceptMapper),
+  bugFixChallenge: dataBlock(BugFixChallenge),
+  dataEntryForm: dataBlock(DataEntryForm),
+  scenarioBuilder: dataBlock(ScenarioBuilder),
+  peerReviewTask: dataBlock(PeerReviewTask),
+  testGenerator: dataBlock(TestGenerator),
+  rubricDisplay: dataBlock(RubricDisplay),
+  selfAssessment: dataBlock(SelfAssessment),
   truthTable(block) {
     return {
       component: TruthTable,
@@ -272,7 +332,7 @@ const blockHandlers: Record<string, (block: LessonBlock) => BlockResolution> = {
   },
 };
 
-const legacyBlockTypes = ['dragAndDrop', 'fileTree', 'quiz'] as const;
+const legacyBlockTypes = ['fileTree', 'quiz'] as const;
 
 export function resolveBlock(block: LessonBlock): BlockResolution {
   const handler = blockHandlers[block.type];

--- a/src/content/schema/lesson.ts
+++ b/src/content/schema/lesson.ts
@@ -31,6 +31,280 @@ export interface LessonBlock {
   [key: string]: unknown;
 }
 
+export interface DefinitionCardBlock extends LessonBlock {
+  type: 'definitionCard';
+  term: string;
+  definition: string;
+  source?: string;
+  sourceUrl?: string;
+}
+
+export interface ComparativeTableRow {
+  label: string;
+  values: string[];
+}
+
+export interface ComparativeTableBlock extends LessonBlock {
+  type: 'comparativeTable';
+  headers: string[];
+  rows: ComparativeTableRow[];
+  title?: string;
+  description?: string;
+  caption?: string;
+  leadingColumnLabel?: string;
+}
+
+export interface SystemDiagramNode {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+export interface SystemDiagramConnection {
+  from: string;
+  to: string;
+  label?: string;
+}
+
+export interface SystemDiagramBlock extends LessonBlock {
+  type: 'systemDiagram';
+  nodes: SystemDiagramNode[];
+  connections?: SystemDiagramConnection[];
+  title?: string;
+  summary?: string;
+  legend?: string[];
+}
+
+export interface CodeChallengeOption {
+  id: string;
+  text: string;
+}
+
+export interface CodeChallengeBlock extends LessonBlock {
+  type: 'codeChallenge';
+  prompt: string;
+  code?: string;
+  language?: string;
+  question?: string;
+  options?: CodeChallengeOption[];
+  answerExplanation?: string;
+}
+
+export interface MemoryVisualizerEntry {
+  label: string;
+  value: string;
+}
+
+export interface MemoryVisualizerBlock extends LessonBlock {
+  type: 'memoryVisualizer';
+  stack?: MemoryVisualizerEntry[];
+  heap?: MemoryVisualizerEntry[];
+  title?: string;
+  summary?: string;
+  notes?: string;
+}
+
+export interface CaseStudyDataPoint {
+  label: string;
+  value: string;
+}
+
+export interface CaseStudyBlock extends LessonBlock {
+  type: 'caseStudy';
+  scenario: string;
+  title?: string;
+  background?: string;
+  dataPoints?: CaseStudyDataPoint[];
+  questions?: string[];
+  tasks?: string[];
+}
+
+export type StatTrend = 'up' | 'down' | 'neutral';
+
+export interface StatCardBlock extends LessonBlock {
+  type: 'statCard';
+  label: string;
+  value: string;
+  context?: string;
+  source?: string;
+  trend?: StatTrend;
+}
+
+export interface KnowledgeCheckOption {
+  id: string;
+  text: string;
+}
+
+export interface KnowledgeCheckBlock extends LessonBlock {
+  type: 'knowledgeCheck';
+  prompt: string;
+  options: KnowledgeCheckOption[];
+  title?: string;
+  explanation?: string;
+  allowMultiple?: boolean;
+}
+
+export interface InteractiveDemoBlock extends LessonBlock {
+  type: 'interactiveDemo';
+  url: string;
+  title?: string;
+  description?: string;
+  height?: number;
+}
+
+export type PedagogicalNoteAudience = 'teacher' | 'student' | 'team';
+
+export interface PedagogicalNoteBlock extends LessonBlock {
+  type: 'pedagogicalNote';
+  content: string;
+  title?: string;
+  audience?: PedagogicalNoteAudience;
+}
+
+export interface CodeSubmissionTestCase {
+  name: string;
+  input?: string;
+  expectedOutput?: string;
+}
+
+export interface CodeSubmissionBlock extends LessonBlock {
+  type: 'codeSubmission';
+  prompt: string;
+  title?: string;
+  language?: string;
+  boilerplate?: string;
+  tests?: CodeSubmissionTestCase[];
+  tips?: string[];
+}
+
+export interface DragAndDropStep {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+export interface DragAndDropBlock extends LessonBlock {
+  type: 'dragAndDrop';
+  steps: DragAndDropStep[];
+  title?: string;
+  instructions?: string;
+}
+
+export interface ConceptMapperNode {
+  id: string;
+  label: string;
+  category?: string;
+  details?: string;
+}
+
+export interface ConceptMapperRelationship {
+  from: string;
+  to: string;
+  label?: string;
+}
+
+export interface ConceptMapperBlock extends LessonBlock {
+  type: 'conceptMapper';
+  nodes: ConceptMapperNode[];
+  description?: string;
+  title?: string;
+  relationships?: ConceptMapperRelationship[];
+}
+
+export interface BugFixChallengeBlock extends LessonBlock {
+  type: 'bugFixChallenge';
+  code: string;
+  title?: string;
+  description?: string;
+  language?: string;
+  hints?: number[];
+  guidance?: string[];
+}
+
+export type DataEntryFieldType = 'text' | 'number' | 'email' | 'date' | 'select';
+
+export interface DataEntryField {
+  id: string;
+  label: string;
+  type?: DataEntryFieldType;
+  required?: boolean;
+  options?: string[];
+  placeholder?: string;
+}
+
+export interface DataEntryFormBlock extends LessonBlock {
+  type: 'dataEntryForm';
+  fields: DataEntryField[];
+  title?: string;
+  description?: string;
+  submitLabel?: string;
+}
+
+export interface ScenarioBuilderBlock extends LessonBlock {
+  type: 'scenarioBuilder';
+  inputs: string[];
+  processes: string[];
+  outputs: string[];
+  title?: string;
+  description?: string;
+  guidingQuestions?: string[];
+}
+
+export interface PeerReviewCriterion {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+export interface PeerReviewTaskBlock extends LessonBlock {
+  type: 'peerReviewTask';
+  criteria: PeerReviewCriterion[];
+  title?: string;
+  description?: string;
+  steps?: string[];
+  dueDate?: string;
+}
+
+export type TestGeneratorDifficulty = 'easy' | 'medium' | 'hard';
+
+export interface TestGeneratorBlock extends LessonBlock {
+  type: 'testGenerator';
+  tags: string[];
+  title?: string;
+  description?: string;
+  difficulties?: TestGeneratorDifficulty[];
+}
+
+export interface RubricLevelDescriptor {
+  level: string;
+  description: string;
+}
+
+export interface RubricCriterion {
+  criterion: string;
+  levels: RubricLevelDescriptor[];
+}
+
+export interface RubricDisplayBlock extends LessonBlock {
+  type: 'rubricDisplay';
+  criteria: RubricCriterion[];
+  title?: string;
+  description?: string;
+}
+
+export interface SelfAssessmentPrompt {
+  id: string;
+  label: string;
+  placeholder?: string;
+}
+
+export interface SelfAssessmentBlock extends LessonBlock {
+  type: 'selfAssessment';
+  prompts: SelfAssessmentPrompt[];
+  title?: string;
+  description?: string;
+}
+
 export interface NormalizedLesson {
   formatVersion?: LessonFormatVersion | string;
   id: string;


### PR DESCRIPTION
## Summary
- add MD3 lesson content blocks for definitions, comparisons, diagrams, quick challenges and teacher-only notes alongside interactive exercise blocks
- extend the lesson manifest schema, shared TypeScript typings, and authoring guide to document the new block contracts
- cover the new components with Vitest suites to guard rendering behaviour

## Testing
- npx vitest run
- npm run validate:content -- --no-report

------
https://chatgpt.com/codex/tasks/task_e_68dfaf83361c832c8d141caa1dbc9d6f