### PR TITLE
Adjust scroll-to-top FAB colors

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -1696,11 +1696,11 @@ html {
     min-width: 3.5rem;
     min-height: 3.5rem;
     padding: 0;
-    --md3-button-container: var(--md-sys-color-primary-container);
-    --md3-button-color: var(--md-sys-color-on-primary-container);
-    --md3-button-outline-color: var(--md-sys-color-primary-container);
-    --md3-button-shadow: var(--md-sys-elevation-level2);
-    --md3-button-state-layer: var(--md-sys-state-layer-on-primary-container);
+    --md3-button-container: var(--md-sys-color-primary);
+    --md3-button-color: var(--md-sys-color-on-primary);
+    --md3-button-outline-color: var(--md-sys-color-primary);
+    --md3-button-shadow: var(--md-sys-elevation-level3);
+    --md3-button-state-layer: var(--md-sys-state-layer-on-primary);
     border-radius: var(--md-sys-border-radius-4xl);
     box-shadow: var(--md3-button-shadow);
     transition:


### PR DESCRIPTION
## Summary
- update the scroll-to-top floating action button to use primary color tokens for better contrast across themes

## Testing
- not run (npm unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfb91804d8832c899b9b1155a112cb