### PR TITLE
feat: align course card colors with institution branding

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -5,6 +5,15 @@
 @tailwind utilities;
 
 :root {
+  /* Institution brand accents */
+  --institution-unichristus-accent: #0b57d0;
+  --institution-unichristus-accent-container: #d8e2ff;
+  --institution-unichristus-on-accent-container: #001b3b;
+
+  --institution-unifametro-accent: #0b6a4a;
+  --institution-unifametro-accent-container: #bfe8d1;
+  --institution-unifametro-on-accent-container: #002116;
+
   /* MD3 Spacing System */
   --md-sys-spacing-1: 0.25rem; /* 4px */
   --md-sys-spacing-2: 0.5rem; /* 8px */

--- a/src/components/CourseCard.vue
+++ b/src/components/CourseCard.vue
@@ -52,35 +52,38 @@ import Md3Button from './Md3Button.vue';
 
 const props = defineProps<{ meta: CourseMeta }>();
 
-const institutionLabel = computed(() => props.meta.institution);
-
-const accentStyle = computed<Record<string, string>>(() => {
-  switch (props.meta.institution) {
-    case 'Unichristus':
-      return {
-        '--course-card-accent': 'var(--md-sys-color-primary)',
-        '--course-card-accent-container': 'var(--md-sys-color-primary-container)',
-        '--course-card-accent-on-container': 'var(--md-sys-color-on-primary-container)',
-        '--course-card-badge-bg': 'var(--md-sys-color-primary-container)',
-        '--course-card-badge-color': 'var(--md-sys-color-on-primary-container)',
-      };
-    case 'Unifametro':
-      return {
-        '--course-card-accent': 'var(--md-sys-color-success)',
-        '--course-card-accent-container': 'var(--md-sys-color-success-container)',
-        '--course-card-accent-on-container': 'var(--md-sys-color-on-success-container)',
-        '--course-card-badge-bg': 'var(--md-sys-color-success-container)',
-        '--course-card-badge-color': 'var(--md-sys-color-on-success-container)',
-      };
-    default:
-      return {
-        '--course-card-accent': 'var(--md-sys-color-secondary)',
-        '--course-card-accent-container': 'var(--md-sys-color-secondary-container)',
-        '--course-card-accent-on-container': 'var(--md-sys-color-on-secondary-container)',
-        '--course-card-badge-bg':
-          'color-mix(in srgb, var(--course-card-accent-container) 86%, transparent)',
-        '--course-card-badge-color': 'var(--course-card-accent-on-container)',
-      };
-  }
+const institutionLabel = computed(() => {
+  const label = props.meta.institution?.trim();
+  return label && label.length > 0 ? label : 'Universidade';
 });
+
+const baseAccentStyle = {
+  '--course-card-accent': 'var(--md-sys-color-secondary)',
+  '--course-card-accent-container': 'var(--md-sys-color-secondary-container)',
+  '--course-card-accent-on-container': 'var(--md-sys-color-on-secondary-container)',
+  '--course-card-badge-bg':
+    'color-mix(in srgb, var(--course-card-accent-container) 86%, transparent)',
+  '--course-card-badge-color': 'var(--course-card-accent-on-container)',
+} satisfies Record<string, string>;
+
+const institutionAccentStyles: Record<string, Record<string, string>> = {
+  Unichristus: {
+    '--course-card-accent': 'var(--institution-unichristus-accent)',
+    '--course-card-accent-container': 'var(--institution-unichristus-accent-container)',
+    '--course-card-accent-on-container': 'var(--institution-unichristus-on-accent-container)',
+    '--course-card-badge-bg': 'var(--institution-unichristus-accent-container)',
+    '--course-card-badge-color': 'var(--institution-unichristus-on-accent-container)',
+  },
+  Unifametro: {
+    '--course-card-accent': 'var(--institution-unifametro-accent)',
+    '--course-card-accent-container': 'var(--institution-unifametro-accent-container)',
+    '--course-card-accent-on-container': 'var(--institution-unifametro-on-accent-container)',
+    '--course-card-badge-bg': 'var(--institution-unifametro-accent-container)',
+    '--course-card-badge-color': 'var(--institution-unifametro-on-accent-container)',
+  },
+};
+
+const accentStyle = computed<Record<string, string>>(
+  () => institutionAccentStyles[institutionLabel.value] ?? baseAccentStyle
+);
 </script>


### PR DESCRIPTION
## Summary
- add CSS custom properties for Unichristus and Unifametro branding
- update course card accent styles to reuse the new brand tokens
- ensure the institution badge falls back to a neutral label when metadata is missing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfc0f18818832cb90c0b15e7cb4aae