### PR TITLE
Refine home filters behavior for small course lists

### DIFF
--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -6,8 +6,7 @@
           <span class="chip w-fit">Disciplinas</span>
           <h1 class="text-display-small font-semibold text-on-surface">Escolha sua disciplina</h1>
           <p class="supporting-text text-body-large">
-            Materiais, exercícios e referências de todas as turmas do professor Tiago Sombra em um
-            único lugar. Use a busca para encontrar rapidamente a disciplina desejada.
+            {{ heroDescription }}
           </p>
         </div>
         <div class="grid gap-3 sm:grid-cols-2 md:w-64 md:grid-cols-1">
@@ -32,7 +31,7 @@
         </div>
       </div>
 
-      <div class="mt-6">
+      <div v-if="shouldShowFilters" class="mt-6">
         <Md3Button
           type="button"
           :variant="filtersOpen ? 'tonal' : 'text'"
@@ -107,7 +106,7 @@
       <div v-else class="card p-8 text-center">
         <h3 class="text-title-medium font-semibold">Nenhuma disciplina encontrada</h3>
         <p class="mt-2 supporting-text">
-          Ajuste os filtros ou limpe a busca para visualizar todas as opções disponíveis.
+          {{ noResultsHelp }}
         </p>
         <Md3Button class="mt-4" variant="text" type="button" @click="clearFilters">
           Limpar filtros
@@ -129,12 +128,6 @@ const q = ref('');
 const inst = ref('');
 const filtersOpen = ref(false);
 
-const institutions = computed(() => {
-  const unique = new Set<string>();
-  courses.forEach((c) => unique.add(c.institution));
-  return Array.from(unique);
-});
-
 const filtered = computed(() => {
   const term = q.value.trim().toLowerCase();
   return courses.filter((course) => {
@@ -146,13 +139,49 @@ const filtered = computed(() => {
   });
 });
 
+const shouldShowFilters = computed(() => courses.length > 10);
+const heroDescription = computed(() => {
+  const baseMessage =
+    'Materiais, exercícios e referências de todas as turmas do professor Tiago Sombra em um único lugar.';
+  if (shouldShowFilters.value) {
+    return `${baseMessage} Use a busca para encontrar rapidamente a disciplina desejada.`;
+  }
+  return `${baseMessage} Explore as opções disponíveis abaixo.`;
+});
+const noResultsHelp = computed(() => {
+  if (shouldShowFilters.value) {
+    return 'Ajuste os filtros ou limpe a busca para visualizar todas as opções disponíveis.';
+  }
+  return 'Verifique os termos digitados ou tente uma nova busca para visualizar as opções disponíveis.';
+});
+
+const institutions = computed(() => {
+  const unique = new Set<string>();
+  courses.forEach((c) => unique.add(c.institution));
+  return Array.from(unique);
+});
+
+watch(shouldShowFilters, (canShow) => {
+  if (!canShow) {
+    filtersOpen.value = false;
+    q.value = '';
+    inst.value = '';
+  }
+});
+
 watch([q, inst], ([query, institution]) => {
+  if (!shouldShowFilters.value) {
+    return;
+  }
   if (query || institution) {
     filtersOpen.value = true;
   }
 });
 
 function toggleFilters() {
+  if (!shouldShowFilters.value) {
+    return;
+  }
   filtersOpen.value = !filtersOpen.value;
 }
 


### PR DESCRIPTION
## Summary
- ensure the home filter controls are completely hidden and reset when there are 10 or fewer courses
- adjust hero and empty state copy to avoid referencing filters when they are not available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfc9c671e8832c8c753d47a041319d