### PR TITLE
Atualiza referências de LPOO para plano 2025.2

### DIFF
--- a/src/content/courses/lpoo/lessons/lesson-01.json
+++ b/src/content/courses/lpoo/lessons/lesson-01.json
@@ -33,9 +33,10 @@
   "modality": "in-person",
   "resources": [
     {
-      "label": "Plano de ensino LPOO 2024.1",
+      "label": "Plano de ensino LPOO 2025.2",
       "type": "document",
-      "url": "https://example.edu/lpoo/plano-ensino"
+      "description": "Plano de ensino oficial atualizado da disciplina para o semestre 2025.2.",
+      "url": "https://example.edu/lpoo/plano-ensino-2025-2"
     },
     {
       "label": "Configuração do ambiente Java",
@@ -269,8 +270,8 @@
   ],
   "metadata": {
     "status": "in-review",
-    "updatedAt": "2024-05-25T00:00:00.000Z",
+    "updatedAt": "2025-02-01T00:00:00.000Z",
     "owners": ["Prof. Tiago Sombra"],
-    "sources": ["Plano de ensino LPOO 2024.1", "Anotações de aula 2023.2"]
+    "sources": ["Plano de ensino LPOO 2025.2", "Anotações de aula 2023.2"]
   }
 }

--- a/src/content/courses/lpoo/lessons/lesson-05.json
+++ b/src/content/courses/lpoo/lessons/lesson-05.json
@@ -231,8 +231,8 @@
   ],
   "metadata": {
     "status": "in-review",
-    "updatedAt": "2024-05-25T00:00:00.000Z",
+    "updatedAt": "2025-02-01T00:00:00.000Z",
     "owners": ["Prof. Tiago Sombra"],
-    "sources": ["Relatório AV1 2024.1", "Plano de aula LPOO – módulo 2"]
+    "sources": ["Relatório AV1 2025.2", "Plano de aula LPOO – módulo 2"]
   }
 }

--- a/src/content/courses/lpoo/lessons/lesson-06.json
+++ b/src/content/courses/lpoo/lessons/lesson-06.json
@@ -157,8 +157,8 @@
   ],
   "metadata": {
     "status": "in-review",
-    "updatedAt": "2024-05-25T00:00:00.000Z",
+    "updatedAt": "2025-02-01T00:00:00.000Z",
     "owners": ["Prof. Tiago Sombra"],
-    "sources": ["Plano de ensino LPOO 2024.1", "Oficina de polimorfismo 2023"]
+    "sources": ["Plano de ensino LPOO 2025.2", "Oficina de polimorfismo 2023"]
   }
 }

--- a/src/content/courses/lpoo/lessons/lesson-07.json
+++ b/src/content/courses/lpoo/lessons/lesson-07.json
@@ -274,8 +274,8 @@
   ],
   "metadata": {
     "status": "in-review",
-    "updatedAt": "2024-05-25T00:00:00.000Z",
+    "updatedAt": "2025-02-01T00:00:00.000Z",
     "owners": ["Prof. Tiago Sombra"],
-    "sources": ["Plano de ensino LPOO 2024.1", "Workshop SOLID 2023"]
+    "sources": ["Plano de ensino LPOO 2025.2", "Workshop SOLID 2023"]
   }
 }

--- a/src/content/courses/lpoo/lessons/lesson-08.json
+++ b/src/content/courses/lpoo/lessons/lesson-08.json
@@ -201,8 +201,8 @@
   ],
   "metadata": {
     "status": "in-review",
-    "updatedAt": "2024-05-25T00:00:00.000Z",
+    "updatedAt": "2025-02-01T00:00:00.000Z",
     "owners": ["Prof. Tiago Sombra"],
-    "sources": ["Plano de projeto LPOO 2024", "Workshops de POO 2023"]
+    "sources": ["Plano de projeto LPOO 2025.2", "Workshops de POO 2023"]
   }
 }


### PR DESCRIPTION
## Summary
- atualiza o recurso principal da aula 01 para citar explicitamente o plano de ensino de LPOO 2025.2, incluindo descrição e URL revisada
- ajusta fontes e datas de atualização das aulas 05 a 08 para refletirem os materiais de 2025.2
- garante a remoção das menções antigas a 2024.1 nas referências das aulas impactadas

## Testing
- rg "2024.1" src/content/courses/lpoo/lessons

------
https://chatgpt.com/codex/tasks/task_e_68dfcd086f94832cb2e74eb60249110d