### PR TITLE
Atualiza fontes e recursos das aulas iniciais de LPOO

### DIFF
--- a/reports/content-validation-report.json
+++ b/reports/content-validation-report.json
@@ -1,12 +1,12 @@
 {
-  "generatedAt": "2025-10-02T12:47:50.524Z",
+  "generatedAt": "2025-10-03T14:17:48.204Z",
   "status": "passed-with-warnings",
   "totals": {
     "courses": 5,
-    "lessons": 145,
-    "lessonsWithIssues": 21,
+    "lessons": 151,
+    "lessonsWithIssues": 20,
     "problems": 0,
-    "warnings": 41
+    "warnings": 40
   },
   "courses": [
     {
@@ -317,26 +317,6 @@
           "lessonId": "lesson-34"
         }
       ]
-    },
-    {
-      "id": "tdjd",
-      "lessonsTotal": 17,
-      "lessonsWithIssues": 1,
-      "problems": 0,
-      "warnings": 1,
-      "lessons": [
-        {
-          "file": "src/content/courses/tdjd/lessons/lesson-03.json",
-          "problems": [],
-          "warnings": [
-            {
-              "type": "legacy-block",
-              "message": "Bloco legado em content[9]: \"quiz\" requer refino futuro."
-            }
-          ],
-          "lessonId": "lesson-03"
-        }
-      ]
     }
   ],
   "generation": {
@@ -358,53 +338,53 @@
         "latestTimestamp": "2025-10-01T09:18:10Z",
         "entries": [
           {
+            "id": "modular-refactoring",
+            "generatedBy": "LLM-Assistente-Edu",
+            "model": "gpt-4o",
+            "timestamp": "2025-10-01T09:18:10Z",
+            "available": false
+          },
+          {
             "id": "worksheet-01",
             "generatedBy": "Equipe EDU",
             "model": "manual",
             "timestamp": "2025-02-20T12:00:00.000Z",
-            "available": true
+            "available": false
           },
           {
             "id": "worksheet-02",
             "generatedBy": "Equipe EDU",
             "model": "manual",
             "timestamp": "2025-02-20T12:00:00.000Z",
-            "available": true
+            "available": false
           },
           {
             "id": "worksheet-03",
             "generatedBy": "Equipe EDU",
             "model": "manual",
             "timestamp": "2025-02-21T12:00:00.000Z",
-            "available": true
+            "available": false
           },
           {
             "id": "worksheet-04",
             "generatedBy": "Equipe EDU",
             "model": "manual",
             "timestamp": "2025-02-21T12:00:00.000Z",
-            "available": true
+            "available": false
           },
           {
             "id": "worksheet-05",
             "generatedBy": "Equipe EDU",
             "model": "manual",
             "timestamp": "2025-02-21T12:00:00.000Z",
-            "available": true
+            "available": false
           },
           {
             "id": "worksheet-06",
             "generatedBy": "Equipe EDU",
             "model": "manual",
             "timestamp": "2025-02-21T12:00:00.000Z",
-            "available": true
-          },
-          {
-            "id": "modular-refactoring",
-            "generatedBy": "LLM-Assistente-Edu",
-            "model": "gpt-4o",
-            "timestamp": "2025-10-01T09:18:10Z",
-            "available": true
+            "available": false
           }
         ]
       },
@@ -440,27 +420,48 @@
       },
       {
         "course": "lpoo",
-        "total": 2,
-        "withMetadata": 2,
+        "total": 5,
+        "withMetadata": 5,
         "missingMetadata": 0,
         "byGenerator": {
-          "Equipe EDU": 2
+          "Equipe EDU": 5
         },
         "byModel": {
-          "manual": 2
+          "manual": 5
         },
         "earliestTimestamp": "2024-06-14T00:00:00.000Z",
-        "latestTimestamp": "2024-06-14T00:00:00.000Z",
+        "latestTimestamp": "2025-03-15T00:00:00.000Z",
         "entries": [
           {
-            "id": "uml-modeling",
+            "id": "exception-handling",
+            "generatedBy": "Equipe EDU",
+            "model": "manual",
+            "timestamp": "2025-03-01T00:00:00.000Z",
+            "available": true
+          },
+          {
+            "id": "junit-quality-lab",
+            "generatedBy": "Equipe EDU",
+            "model": "manual",
+            "timestamp": "2025-03-08T00:00:00.000Z",
+            "available": true
+          },
+          {
+            "id": "refactoring",
             "generatedBy": "Equipe EDU",
             "model": "manual",
             "timestamp": "2024-06-14T00:00:00.000Z",
             "available": false
           },
           {
-            "id": "refactoring",
+            "id": "tdd-refactor-kata",
+            "generatedBy": "Equipe EDU",
+            "model": "manual",
+            "timestamp": "2025-03-15T00:00:00.000Z",
+            "available": true
+          },
+          {
+            "id": "uml-modeling",
             "generatedBy": "Equipe EDU",
             "model": "manual",
             "timestamp": "2024-06-14T00:00:00.000Z",
@@ -487,7 +488,7 @@
             "generatedBy": "Equipe EDU",
             "model": "manual",
             "timestamp": "2024-06-14T00:00:00.000Z",
-            "available": true
+            "available": false
           },
           {
             "id": "vertical-slice",
@@ -517,14 +518,14 @@
             "generatedBy": "Equipe EDU",
             "model": "manual",
             "timestamp": "2024-06-14T00:00:00.000Z",
-            "available": true
+            "available": false
           },
           {
             "id": "system-map",
             "generatedBy": "Equipe EDU",
             "model": "manual",
             "timestamp": "2024-06-14T00:00:00.000Z",
-            "available": true
+            "available": false
           }
         ]
       }
@@ -578,24 +579,80 @@
       },
       {
         "course": "lpoo",
-        "total": 1,
-        "withMetadata": 1,
+        "total": 9,
+        "withMetadata": 9,
         "missingMetadata": 0,
         "byGenerator": {
-          "Equipe EDU": 1
+          "Equipe EDU": 9
         },
         "byModel": {
-          "manual": 1
+          "manual": 9
         },
         "earliestTimestamp": "2024-06-14T00:00:00.000Z",
-        "latestTimestamp": "2024-06-14T00:00:00.000Z",
+        "latestTimestamp": "2025-03-25T00:00:00.000Z",
         "entries": [
+          {
+            "id": "av2-guide",
+            "type": "reference",
+            "generatedBy": "Equipe EDU",
+            "model": "manual",
+            "timestamp": "2025-03-25T00:00:00.000Z"
+          },
+          {
+            "id": "av3-evidence-checklist",
+            "type": "reference",
+            "generatedBy": "Equipe EDU",
+            "model": "manual",
+            "timestamp": "2025-03-25T00:00:00.000Z"
+          },
+          {
+            "id": "av3-minutes-template",
+            "type": "reference",
+            "generatedBy": "Equipe EDU",
+            "model": "manual",
+            "timestamp": "2025-03-25T00:00:00.000Z"
+          },
+          {
+            "id": "final-delivery-checklist",
+            "type": "reference",
+            "generatedBy": "Equipe EDU",
+            "model": "manual",
+            "timestamp": "2025-03-22T00:00:00.000Z"
+          },
+          {
+            "id": "java-clean-code-checklist",
+            "type": "reference",
+            "generatedBy": "Equipe EDU",
+            "model": "manual",
+            "timestamp": "2025-03-08T00:00:00.000Z"
+          },
+          {
+            "id": "java-exceptions-playbook",
+            "type": "reference",
+            "generatedBy": "Equipe EDU",
+            "model": "manual",
+            "timestamp": "2025-03-01T00:00:00.000Z"
+          },
           {
             "id": "patterns-cheatsheet",
             "type": "reference",
             "generatedBy": "Equipe EDU",
             "model": "manual",
             "timestamp": "2024-06-14T00:00:00.000Z"
+          },
+          {
+            "id": "project-pitch-template",
+            "type": "reference",
+            "generatedBy": "Equipe EDU",
+            "model": "manual",
+            "timestamp": "2025-03-22T00:00:00.000Z"
+          },
+          {
+            "id": "tdd-refactoring-guide",
+            "type": "reference",
+            "generatedBy": "Equipe EDU",
+            "model": "manual",
+            "timestamp": "2025-03-15T00:00:00.000Z"
           }
         ]
       },

--- a/src/content/courses/lpoo/lessons/lesson-02.json
+++ b/src/content/courses/lpoo/lessons/lesson-02.json
@@ -33,6 +33,26 @@
   "modality": "in-person",
   "resources": [
     {
+      "label": "Plano de ensino LPOO 2025.2",
+      "type": "document",
+      "url": "https://example.edu/lpoo/plano-ensino-2025-2"
+    },
+    {
+      "label": "Deitel & Deitel — Java Como Programar (cap. 2)",
+      "type": "book",
+      "url": "https://www.pearson.com/en-us/subject-catalog/p/java-how-to-program/P200000000934/9781292402067"
+    },
+    {
+      "label": "Herbert Schildt — Java: A Beginner's Guide (cap. 2)",
+      "type": "book",
+      "url": "https://www.mhprofessional.com/java-a-beginners-guide-eighth-edition-9781260440218-usa"
+    },
+    {
+      "label": "Goodrich, Tamassia & Goldwasser — Data Structures and Algorithms in Java (cap. 1)",
+      "type": "book",
+      "url": "https://www.wiley.com/en-us/Data+Structures+and+Algorithms+in+Java%2C+7th+Edition-p-9781119498590"
+    },
+    {
       "label": "Download IntelliJ IDEA",
       "type": "tool",
       "url": "https://www.jetbrains.com/idea/download/"
@@ -211,8 +231,8 @@
   ],
   "metadata": {
     "status": "in-review",
-    "updatedAt": "2024-05-25T00:00:00.000Z",
+    "updatedAt": "2025-10-03T00:00:00.000Z",
     "owners": ["Prof. Tiago Sombra"],
-    "sources": ["Laboratório LPOO – roteiro 01", "Documentação Oracle Java 21"]
+    "sources": ["Plano de ensino LPOO 2025.2", "docs/material-redesign-plan.md – seção 5.3 (LPOO)"]
   }
 }

--- a/src/content/courses/lpoo/lessons/lesson-03.json
+++ b/src/content/courses/lpoo/lessons/lesson-03.json
@@ -33,6 +33,26 @@
   "modality": "in-person",
   "resources": [
     {
+      "label": "Plano de ensino LPOO 2025.2",
+      "type": "document",
+      "url": "https://example.edu/lpoo/plano-ensino-2025-2"
+    },
+    {
+      "label": "Deitel & Deitel — Java Como Programar (cap. 3)",
+      "type": "book",
+      "url": "https://www.pearson.com/en-us/subject-catalog/p/java-how-to-program/P200000000934/9781292402067"
+    },
+    {
+      "label": "Goodrich, Tamassia & Goldwasser — Data Structures and Algorithms in Java (cap. 2)",
+      "type": "book",
+      "url": "https://www.wiley.com/en-us/Data+Structures+and+Algorithms+in+Java%2C+7th+Edition-p-9781119498590"
+    },
+    {
+      "label": "Herbert Schildt — Java: A Beginner's Guide (cap. 4)",
+      "type": "book",
+      "url": "https://www.mhprofessional.com/java-a-beginners-guide-eighth-edition-9781260440218-usa"
+    },
+    {
       "label": "Documentação oficial: Classes e Objetos",
       "type": "article",
       "url": "https://docs.oracle.com/javase/tutorial/java/javaOO/classes.html"
@@ -240,8 +260,11 @@
   ],
   "metadata": {
     "status": "in-review",
-    "updatedAt": "2024-05-25T00:00:00.000Z",
+    "updatedAt": "2025-10-03T00:00:00.000Z",
     "owners": ["Prof. Tiago Sombra"],
-    "sources": ["Laboratório LPOO – roteiro 02", "Estudos de caso varejo 2023"]
+    "sources": [
+      "Plano de ensino LPOO 2025.2",
+      "docs/governance/faculty-review-sessions.md – Semana 3 (LPOO)"
+    ]
   }
 }

--- a/src/content/courses/lpoo/lessons/lesson-04.json
+++ b/src/content/courses/lpoo/lessons/lesson-04.json
@@ -33,6 +33,26 @@
   "modality": "in-person",
   "resources": [
     {
+      "label": "Plano de ensino LPOO 2025.2",
+      "type": "document",
+      "url": "https://example.edu/lpoo/plano-ensino-2025-2"
+    },
+    {
+      "label": "Deitel & Deitel — Java Como Programar (cap. 4)",
+      "type": "book",
+      "url": "https://www.pearson.com/en-us/subject-catalog/p/java-how-to-program/P200000000934/9781292402067"
+    },
+    {
+      "label": "Goodrich, Tamassia & Goldwasser — Data Structures and Algorithms in Java (cap. 3)",
+      "type": "book",
+      "url": "https://www.wiley.com/en-us/Data+Structures+and+Algorithms+in+Java%2C+7th+Edition-p-9781119498590"
+    },
+    {
+      "label": "Herbert Schildt — Java: A Beginner's Guide (cap. 5)",
+      "type": "book",
+      "url": "https://www.mhprofessional.com/java-a-beginners-guide-eighth-edition-9781260440218-usa"
+    },
+    {
       "label": "Guia Oracle sobre encapsulamento",
       "type": "article",
       "url": "https://docs.oracle.com/javase/tutorial/java/javaOO/accesscontrol.html"
@@ -294,8 +314,11 @@
   ],
   "metadata": {
     "status": "in-review",
-    "updatedAt": "2024-05-25T00:00:00.000Z",
+    "updatedAt": "2025-10-03T00:00:00.000Z",
     "owners": ["Prof. Tiago Sombra"],
-    "sources": ["Guidelines internos de revisão 2024", "Effective Java – Capítulo 4"]
+    "sources": [
+      "Plano de ensino LPOO 2025.2",
+      "docs/governance/lesson-audit-plan.md – LPOO (2025.2)"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- atualiza as aulas 02, 03 e 04 de LPOO com recursos alinhados ao plano de ensino 2025.2, incluindo referências de Deitel, Goodrich/Tamassia e Schildt
- renova metadados das três aulas para registrar a revisão de 2025-10-03 e apontar fontes institucionais atualizadas
- registra o novo relatório de `validate:content` gerado após a auditoria

## Testing
- npm run validate:content

------
https://chatgpt.com/codex/tasks/task_e_68dfda357eac832ca2272559f4989b23