### PR TITLE
Reequilibra plano de LPOO e agenda entregas de suporte

### DIFF
--- a/docs/WORK_STATUS.md
+++ b/docs/WORK_STATUS.md
@@ -173,6 +173,12 @@ Esses materiais dão visibilidade sobre o estado atual do projeto e aceleram a c
 - Histórias interativas documentam o `Md3AppShell`, a barra inferior, breadcrumbs e campo de busca com roteador em memória, cobrindo a navegação adaptativa e eventos de busca/navegação antes da integração nas telas reais. 【F:src/components/layout/Md3AppShell.stories.ts†L1-L200】【F:src/components/layout/Md3BottomAppBar.stories.ts†L1-L83】【F:src/components/layout/Md3Breadcrumbs.stories.ts†L1-L74】【F:src/components/layout/Md3SearchField.stories.ts†L1-L61】
 - A documentação de layout e do Storybook foi atualizada para refletir o novo escopo, próximos passos de viewports e testes visuais. 【F:docs/design-system/layout.md†L42-L55】【F:docs/design-system/storybook.md†L15-L32】
 
+36. **Plano de ação de LPOO reequilibrado e comunicado ao QA/Implantação**
+
+- `docs/content/personal-site-course-plan.md` removeu a pendência de migração das aulas 09-12 e detalha o reequilíbrio do cronograma 09-16, produção de vídeos e liberação de exercícios com janela alinhada à APS. 【F:docs/content/personal-site-course-plan.md†L115-L141】
+- `docs/material-redesign-plan.md` passou a consolidar os novos marcos (semanas 11-13), responsáveis e dependências de QA para cronograma, vídeos e exercícios do curso de LPOO. 【F:docs/material-redesign-plan.md†L118-L132】
+- A atualização foi registrada neste relatório para informar QA e implantação; compartilharemos o resumo no canal de acompanhamento para antecipar validações de testes e publicação.
+
 ## O que ainda pode ser feito
 
 A partir das recomendações listadas na revisão de arquitetura, seguem frentes prioritárias:

--- a/docs/content/personal-site-course-plan.md
+++ b/docs/content/personal-site-course-plan.md
@@ -51,8 +51,9 @@ Este documento traduz os dados do relatório `reports/course-content-summary.jso
 **Ações imediatas**
 
 1. Projetar o componente `ClassDesigner` derivado do `Md3BlockDiagram` para representar relações UML, preparando presets para Storybook.
-2. Migrar as próximas aulas (09-12) mantendo estudos de caso, fluxos de regras de negócio e exercícios práticos alinhados ao novo padrão MD3.
-3. Atualizar os exercícios com rubricas de orientação a objetos (encapsulamento, herança, polimorfismo) e implementar feedback automático via testes ou checklists.
+2. Reequilibrar o cronograma das aulas 09-16, antecipando a revisão de herança/polimorfismo para a semana anterior à NP2 e registrando os novos marcos de entrega em `lessons.json`.
+3. Produzir os vídeos de apoio dos módulos 09-12 (análise de casos, refatoração guiada e padrões de projeto introdutórios) e anexá-los aos blocos `videos` já publicados.
+4. Liberar os exercícios revisados com rubricas de encapsulamento, herança e polimorfismo, conectando-os ao `validate:content` e abrindo janela de submissão assistida uma semana antes da APS.
 
 ### Tecnologia e Desenvolvimento para Jogos Digitais (TDJD)
 

--- a/docs/material-redesign-plan.md
+++ b/docs/material-redesign-plan.md
@@ -65,8 +65,14 @@
 
 - As aulas 01-08 foram migradas para o schema `md3.lesson.v1`, reorganizando objetivos, planos de voo e novos blocos MD3 (fluxogramas, tabelas de visibilidade e diagramas de blocos). 【F:src/content/courses/lpoo/lessons/lesson-01.json†L1-L214】【F:src/content/courses/lpoo/lessons/lesson-02.json†L1-L203】【F:src/content/courses/lpoo/lessons/lesson-03.json†L1-L214】【F:src/content/courses/lpoo/lessons/lesson-04.json†L1-L227】【F:src/content/courses/lpoo/lessons/lesson-05.json†L1-L210】【F:src/content/courses/lpoo/lessons/lesson-06.json†L1-L208】【F:src/content/courses/lpoo/lessons/lesson-07.json†L1-L242】【F:src/content/courses/lpoo/lessons/lesson-08.json†L1-L211】
 - O índice `lessons.json` agora aponta para os arquivos JSON, traz resumo, tags, duração e `formatVersion`, permitindo que os relatórios de governança identifiquem o status real das aulas. 【F:src/content/courses/lpoo/lessons.json†L1-L64】
-- Próximos passos: preparar um componente "ClassDesigner" a partir do `Md3BlockDiagram` para ilustrar relações UML, migrar exercícios (`modelagem-uml.json`, `refatoracao.json`) para o novo schema e registrar rubricas alinhadas às competências de orientação a objetos.
+- Plano de ação atualizado: reequilibrar a carga horária das aulas 09-16 para encaixar checkpoints de projeto e devolutivas antes da NP2, publicar vídeos complementares para estudos assíncronos e liberar exercícios revisados com rubricas alinhadas às competências de orientação a objetos.
 - ✅ `ClassDesigner` especificado e implementado com documentação MD3, habilitando diagramas de classes reusáveis nas próximas aulas. 【F:docs/didactics/class-designer.md†L1-L63】【F:src/components/lesson/ClassDesigner.vue†L1-L344】【F:src/components/lesson/**tests**/ClassDesigner.test.ts†L1-L81】
+
+| Entrega                                            | Responsável   | Prazo (S2024) | Dependências/Observações                                                                                                                   |
+| -------------------------------------------------- | ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Cronograma revisado das aulas 09-16                | Conteúdo      | Semana 11     | Deve antecipar revisão de herança/polimorfismo para a semana anterior à NP2 e alinhar publicação de `lessons.json`.                        |
+| Kit de vídeos (casos de uso, refatoração, padrões) | Audiovisual   | Semana 12     | Storyboards derivados dos blocos `caseStudy` já publicados; QA audiovisual antes da liberação.                                             |
+| Exercícios reabertos com rubricas e testes         | Conteúdo + QA | Semana 13     | `validate:content` atualizado, janelas de submissão abertas 7 dias antes da APS, suites de testes automatizados validadas pelo time de QA. |
 
 ### 5.4 Tecnologia e Desenvolvimento para Jogos Digitais (TDJD)
 


### PR DESCRIPTION
## Summary
- atualiza o plano do site pessoal removendo a pendência de migração das aulas 09-12 e descrevendo novas frentes (cronograma, vídeos e exercícios)
- revê o material redesign plan para incluir o novo plano de ação com responsáveis, prazos e dependências com QA/APS
- registra o resumo em docs/WORK_STATUS.md para informar QA e implantação

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e00cb1e4f0832ca1a62f7eaaa92567