### PR TITLE
Add async task checklist to LPOO lesson 05

### DIFF
--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -80,6 +80,8 @@ const SUPPORTED_CUSTOM_COMPONENTS = [
   'Md3CodeSample',
   'MemoryDiagram',
   'OrderedList',
+  'Md3Checklist',
+  'Md3Callout',
   'CardGrid',
   'ClassDesigner',
   'PipelineCanvas',

--- a/src/components/lesson/blockRegistry.ts
+++ b/src/components/lesson/blockRegistry.ts
@@ -78,6 +78,8 @@ const customComponentRegistry: Record<string, Component> = {
   Md3CodeSample,
   MemoryDiagram,
   OrderedList,
+  Md3Checklist: ChecklistBlock,
+  Md3Callout: Callout,
   CardGrid,
   Roadmap,
   ClassDesigner,

--- a/src/content/courses/lpoo/lessons/lesson-05.json
+++ b/src/content/courses/lpoo/lessons/lesson-05.json
@@ -118,6 +118,43 @@
       ]
     },
     {
+      "type": "component",
+      "component": "Md3Checklist",
+      "props": {
+        "title": "Tarefa assíncrona: consolidar o plano pós-AV1",
+        "supportingText": "Converta os insights da aula em compromissos mensuráveis e compartilhe com a dupla de acompanhamento.",
+        "items": [
+          {
+            "label": "Metas prioritárias",
+            "supportingText": "Mapeie ao menos duas habilidades da AV1 que precisam de reforço, vinculando-as a indicadores concretos (ex.: testes que falharam, dúvidas recorrentes)."
+          },
+          {
+            "label": "Entregáveis",
+            "supportingText": "Atualize o repositório da disciplina com uma versão refinada da hierarquia `Funcionario` e registre no README o racional das mudanças."
+          },
+          {
+            "label": "Prazo",
+            "supportingText": "Submeta as evidências até sexta-feira, 23h59, garantindo tempo para feedback antes da aula 06."
+          },
+          {
+            "label": "Critérios de qualidade",
+            "supportingText": "Mantenha cobertura de testes para os cenários críticos da AV1, documente métricas de complexidade se houver ajustes significativos e descreva implicações no plano de ação individual."
+          }
+        ],
+        "links": [
+          {
+            "label": "Repositório oficial da turma",
+            "url": "https://example.edu/repos/lpoo/heranca-funcionarios"
+          },
+          {
+            "label": "Formulário de feedback rápido",
+            "url": "https://example.edu/forms/lpoo/feedback-heranca"
+          }
+        ],
+        "integrationNote": "Os artefatos entregues alimentam o plano de ação individual listado nos outcomes, orientando mentorias e intervenções personalizadas nas próximas sprints."
+      }
+    },
+    {
       "type": "callout",
       "variant": "info",
       "title": "Pergunta norteadora",


### PR DESCRIPTION
## Summary
- add an Md3Checklist block to lesson 05 so the async task includes goals, deliverables, deadline, quality criteria and support links
- register Md3Checklist and Md3Callout as supported custom components in the lesson renderer and validator

## Testing
- npm run validate:content

------
https://chatgpt.com/codex/tasks/task_e_68e01cc5c5f4832c9370a9fdd8b2fab1