### PR TITLE
test: cover runtime utilities

### DIFF
--- a/docs/UTILS.md
+++ b/docs/UTILS.md
@@ -1,0 +1,12 @@
+# Runtime utilities coverage
+
+This document tracks the status of the utility helpers under `src/utils/` so it
+is clear which ones are wired into the application and how they are validated.
+
+| Utility              | Runtime usage                                                                                                                                 | Validation                                                                                                                       |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `contentManifest.ts` | Not imported by the Vue runtime yet. Mirrors the Node implementation in `scripts/utils/manifest.mjs` for future client-side manifest loading. | Dedicated unit tests in `src/utils/__tests__/contentManifest.test.ts` cover array/object exports and invalid payloads.           |
+| `sanitizeHtml.ts`    | Used extensively across lesson/exercise components to clean HTML snippets rendered at runtime.                                                | Direct unit tests in `src/utils/__tests__/sanitizeHtml.test.ts` exercise DOMPurify integration, SSR fallback and error handling. |
+
+Re-run `npm run test:coverage` whenever a helper is added or modified to
+ensure all code paths keep their coverage guarantees.

--- a/src/utils/__tests__/contentManifest.test.ts
+++ b/src/utils/__tests__/contentManifest.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractManifestEntries,
+  extractManifestEnvelope,
+  type ManifestEnvelope,
+} from '../contentManifest';
+
+describe('extractManifestEnvelope', () => {
+  it('returns entries when the module default export is an array', () => {
+    const moduleExport = {
+      default: [{ id: 'lesson-1' }, { id: 'lesson-2' }],
+    };
+
+    const result = extractManifestEnvelope<{ id: string }>(moduleExport);
+
+    expect(result).toEqual<ManifestEnvelope<{ id: string }>>({
+      entries: [{ id: 'lesson-1' }, { id: 'lesson-2' }],
+    });
+  });
+
+  it('normalises manifest metadata when the default export is an object', () => {
+    const moduleExport = {
+      default: {
+        entries: [{ id: 'exercise-1' }],
+        version: 'v2',
+        generatedAt: '2024-05-01T12:00:00Z',
+        metadata: {
+          checksum: 'abc123',
+        },
+      },
+    };
+
+    const result = extractManifestEnvelope<{ id: string }>(moduleExport);
+
+    expect(result.entries).toEqual([{ id: 'exercise-1' }]);
+    expect(result.version).toBe('v2');
+    expect(result.generatedAt).toBe('2024-05-01T12:00:00Z');
+    expect(result.metadata).toEqual({ checksum: 'abc123' });
+  });
+
+  it('falls back to safe defaults when payload properties are malformed', () => {
+    const moduleExport = {
+      default: {
+        entries: 'not-an-array',
+        version: 42,
+        generatedAt: null,
+        metadata: 'invalid',
+      },
+    };
+
+    const result = extractManifestEnvelope<{ id: string }>(moduleExport);
+
+    expect(result.entries).toEqual([]);
+    expect(result.version).toBeUndefined();
+    expect(result.generatedAt).toBeUndefined();
+    expect(result.metadata).toBeUndefined();
+  });
+
+  it('returns an empty envelope when the payload is unsupported', () => {
+    expect(extractManifestEnvelope<number>('not-a-manifest')).toEqual<ManifestEnvelope<number>>({
+      entries: [],
+    });
+  });
+});
+
+describe('extractManifestEntries', () => {
+  it('returns only the entries from the manifest envelope', () => {
+    const entries = extractManifestEntries<{ id: string }>([
+      { id: 'supplement-1' },
+      { id: 'supplement-2' },
+    ]);
+
+    expect(entries).toEqual([{ id: 'supplement-1' }, { id: 'supplement-2' }]);
+  });
+
+  it('returns an empty array when the manifest cannot be parsed', () => {
+    expect(extractManifestEntries<{ id: string }>({ invalid: true })).toEqual([]);
+  });
+});

--- a/src/utils/__tests__/sanitizeHtml.test.ts
+++ b/src/utils/__tests__/sanitizeHtml.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const createDomPurifyMock = vi.fn();
+
+vi.mock('dompurify', () => ({
+  default: createDomPurifyMock,
+}));
+
+describe('sanitizeHtml', () => {
+  const originalWindow = globalThis.window;
+
+  afterEach(() => {
+    createDomPurifyMock.mockReset();
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    if (originalWindow) {
+      globalThis.window = originalWindow;
+    } else {
+      delete (globalThis as unknown as { window?: unknown }).window;
+    }
+  });
+
+  it('returns an empty string when the input is not a string', async () => {
+    const { sanitizeHtml } = await import('../sanitizeHtml');
+
+    expect(sanitizeHtml(undefined)).toBe('');
+    expect(createDomPurifyMock).not.toHaveBeenCalled();
+  });
+
+  it('delegates sanitisation to DOMPurify when available', async () => {
+    const sanitizeSpy = vi.fn((value: string) => value.replace('<script>evil()</script>', ''));
+    createDomPurifyMock.mockReturnValue({ sanitize: sanitizeSpy });
+
+    const { DEFAULT_CONFIG, sanitizeHtml } = await import('../sanitizeHtml');
+    const input = '<p>Valid</p><script>evil()</script>';
+
+    const expectedConfig = { ...DEFAULT_CONFIG, KEEP_CONTENT: true };
+
+    const result = sanitizeHtml(input, { KEEP_CONTENT: true });
+
+    expect(result).toBe('<p>Valid</p>');
+    expect(createDomPurifyMock).toHaveBeenCalledWith(window);
+    expect(sanitizeSpy).toHaveBeenCalledWith(input, expectedConfig);
+  });
+
+  it('falls back to regex stripping when DOMPurify cannot be initialised', async () => {
+    delete (globalThis as unknown as { window?: unknown }).window;
+
+    const { sanitizeHtml } = await import('../sanitizeHtml');
+    const input = '<div>Keep me</div><script>remove()</script>';
+
+    expect(sanitizeHtml(input)).toBe('<div>Keep me</div>');
+    expect(createDomPurifyMock).not.toHaveBeenCalled();
+  });
+
+  it('logs a warning and uses the fallback when DOMPurify throws', async () => {
+    const error = new Error('purifier exploded');
+    const sanitizeSpy = vi.fn(() => {
+      throw error;
+    });
+
+    createDomPurifyMock.mockReturnValue({ sanitize: sanitizeSpy });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { sanitizeHtml } = await import('../sanitizeHtml');
+    const input = '<span>Clean</span><script>evil()</script>';
+
+    expect(sanitizeHtml(input)).toBe('<span>Clean</span>');
+    expect(sanitizeSpy).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[sanitizeHtml] Falling back to regex-based sanitisation due to error:',
+      error
+    );
+
+    warnSpy.mockRestore();
+  });
+});

--- a/src/utils/contentManifest.ts
+++ b/src/utils/contentManifest.ts
@@ -1,3 +1,11 @@
+/**
+ * Lightweight counterpart to the Node scripts living under `scripts/utils/manifest.mjs`.
+ *
+ * The runtime does not import this helper yet – Vue pages rely on the
+ * server-side manifest normaliser – but upcoming work will let the client load
+ * indexes directly. Keeping the functions documented (and covered by unit
+ * tests) avoids regressions when we eventually plug them in.
+ */
 export interface ManifestEnvelope<T> {
   entries: T[];
   version?: string;


### PR DESCRIPTION
## Summary
- add dedicated Vitest specs for `extractManifestEnvelope`/`extractManifestEntries`
- exercise DOMPurify, SSR fallback and error handling paths in `sanitizeHtml`
- document runtime utility status for future manifest work and note the helper in code

## Testing
- npx vitest run src/utils/__tests__/contentManifest.test.ts src/utils/__tests__/sanitizeHtml.test.ts
- npx vitest run --coverage src/utils/__tests__/contentManifest.test.ts src/utils/__tests__/sanitizeHtml.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e0e85d9460832ca59d366746a62f0c