### PR TITLE
feat: add prompt tip lesson block

### DIFF
--- a/schemas/lesson.schema.json
+++ b/schemas/lesson.schema.json
@@ -221,6 +221,7 @@
         { "$ref": "#/$defs/knowledgeCheckBlock" },
         { "$ref": "#/$defs/interactiveDemoBlock" },
         { "$ref": "#/$defs/pedagogicalNoteBlock" },
+        { "$ref": "#/$defs/promptTipBlock" },
         { "$ref": "#/$defs/codeSubmissionBlock" },
         { "$ref": "#/$defs/dragAndDropBlock" },
         { "$ref": "#/$defs/conceptMapperBlock" },
@@ -481,6 +482,29 @@
           "title": { "type": "string" },
           "content": { "type": "string", "minLength": 1 },
           "audience": { "type": "string", "enum": ["teacher", "student", "team"] }
+        }
+      }
+    },
+    "promptTipBlock": {
+      "if": {
+        "properties": { "type": { "const": "promptTip" } }
+      },
+      "then": {
+        "required": ["prompt"],
+        "properties": {
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "prompt": { "type": "string", "minLength": 1 },
+          "tips": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "tags": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "uniqueItems": true
+          },
+          "audience": { "type": "string" }
         }
       }
     },

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -68,6 +68,7 @@ const SUPPORTED_BLOCK_TYPES = [
   'spriteSheet',
   'crcCards',
   'apiEndpoints',
+  'promptTip',
 ];
 
 const LEGACY_BLOCK_TYPES = ['dragAndDrop', 'fileTree', 'quiz'];
@@ -99,6 +100,7 @@ const SUPPORTED_CUSTOM_COMPONENTS = [
   'SpriteSheetViewer',
   'CRCCards',
   'ApiEndpoints',
+  'PromptTip',
 ];
 
 const ALLOWED_CALLOUT_VARIANTS = new Set([
@@ -414,6 +416,69 @@ const blockValidators = {
       block,
       context
     );
+  },
+  promptTip(block, context) {
+    requireStringField('prompt', 'Bloco "promptTip" requer o campo "prompt" com texto.')(
+      block,
+      context
+    );
+
+    if (block.title !== undefined && typeof block.title !== 'string') {
+      pushBlockProblem(
+        context,
+        'Campo "title" do bloco "promptTip" deve ser string quando presente.'
+      );
+    }
+
+    if (block.description !== undefined && typeof block.description !== 'string') {
+      pushBlockProblem(
+        context,
+        'Campo "description" do bloco "promptTip" deve ser string quando presente.'
+      );
+    }
+
+    if (block.audience !== undefined && typeof block.audience !== 'string') {
+      pushBlockProblem(
+        context,
+        'Campo "audience" do bloco "promptTip" deve ser string quando presente.'
+      );
+    }
+
+    if (block.tags !== undefined) {
+      if (!Array.isArray(block.tags)) {
+        pushBlockProblem(
+          context,
+          'Campo "tags" do bloco "promptTip" deve ser um array de strings.'
+        );
+      } else {
+        block.tags.forEach((tag, index) => {
+          if (!isNonEmptyString(tag)) {
+            pushBlockProblem(
+              context,
+              `tags[${index}]: valores do bloco "promptTip" devem ser strings não vazias.`
+            );
+          }
+        });
+      }
+    }
+
+    if (block.tips !== undefined) {
+      if (!Array.isArray(block.tips)) {
+        pushBlockProblem(
+          context,
+          'Campo "tips" do bloco "promptTip" deve ser um array de strings.'
+        );
+      } else {
+        block.tips.forEach((tip, index) => {
+          if (!isNonEmptyString(tip)) {
+            pushBlockProblem(
+              context,
+              `tips[${index}]: valores do bloco "promptTip" devem ser strings não vazias.`
+            );
+          }
+        });
+      }
+    }
   },
 };
 

--- a/src/components/lesson/PromptTip.stories.ts
+++ b/src/components/lesson/PromptTip.stories.ts
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import PromptTip from './PromptTip.vue';
+
+const meta: Meta<typeof PromptTip> = {
+  title: 'Lesson/Blocks/PromptTip',
+  component: PromptTip,
+  parameters: {
+    backgrounds: {
+      disable: false,
+      default: 'ChatGPT Night',
+      values: [
+        { name: 'ChatGPT Night', value: '#202123' },
+        { name: 'ChatGPT Jade', value: '#10a37f' },
+        { name: 'Studio Surface', value: '#f7f8fb' },
+      ],
+    },
+  },
+  args: {
+    data: {
+      title: 'Briefing para sandbox TOTVS',
+      description: 'Prompt base para acelerar o laboratório de experimentação controlada.',
+      audience: 'equipes de implantação',
+      prompt:
+        'Você é um especialista TOTVS em serviços. Estruture um roteiro de experimentos no sandbox que valide integrações críticas, riscos regulatórios e impactos financeiros.',
+      tags: ['laboratório', 'sandbox TOTVS', 'experimentos guiados'],
+      tips: [
+        'Peça uma versão com foco exclusivo em finanças e conciliações.',
+        'Solicite perguntas de checagem para entrevistas com áreas parceiras.',
+      ],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PromptTip>;
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { PromptTip },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div class="lesson-block-story md-stack md-stack-6" style="max-width: 56rem; margin: 0 auto; padding: 2rem;">
+        <PromptTip v-bind="args" />
+      </div>
+    `,
+  }),
+};
+
+export const Minimal: Story = {
+  args: {
+    data: {
+      prompt: 'Monte uma agenda de daily stand-up com foco em desafios do sprint atual.',
+    },
+  },
+  render: (args) => ({
+    components: { PromptTip },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div class="lesson-block-story md-stack md-stack-6" style="max-width: 48rem; margin: 0 auto; padding: 2rem;">
+        <PromptTip v-bind="args" />
+      </div>
+    `,
+  }),
+};
+
+export const WithPlayfulTips: Story = {
+  args: {
+    data: {
+      title: 'Variações criativas',
+      description: 'Teste abordagens diferentes para envolver squads.',
+      prompt:
+        'Atue como facilitador ágil e escreva um anúncio inspirador convidando o time a usar o sandbox de integrações TOTVS.',
+      tags: ['comunicação', 'engajamento'],
+      tips: [
+        'Reescreva como se fosse um thread de rede social com tom informal.',
+        'Gere uma versão curta para ser usada como descrição no Slack.',
+        'Peça uma alternativa destacando métricas de sucesso do laboratório.',
+      ],
+    },
+  },
+  render: (args) => ({
+    components: { PromptTip },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div class="lesson-block-story md-stack md-stack-6" style="max-width: 56rem; margin: 0 auto; padding: 2rem;">
+        <PromptTip v-bind="args" />
+      </div>
+    `,
+  }),
+};

--- a/src/components/lesson/PromptTip.vue
+++ b/src/components/lesson/PromptTip.vue
@@ -1,0 +1,252 @@
+<template>
+  <article class="prompt-tip card md-stack md-stack-4">
+    <header v-if="hasHeader" class="prompt-tip__header md-stack md-stack-2">
+      <div class="prompt-tip__header-copy md-stack md-stack-1">
+        <p
+          v-if="data.audience"
+          class="prompt-tip__audience text-label-medium uppercase tracking-[0.18em]"
+        >
+          Para {{ audienceLabel }}
+        </p>
+        <h3 v-if="data.title" class="prompt-tip__title text-title-medium font-semibold">
+          {{ data.title }}
+        </h3>
+        <p v-if="data.description" class="prompt-tip__description text-body-medium">
+          {{ data.description }}
+        </p>
+      </div>
+      <ul v-if="hasTags" class="prompt-tip__tags md-stack md-stack-1" role="list">
+        <li v-for="tag in data.tags" :key="tag" class="prompt-tip__tag-item">
+          <span class="prompt-tip__tag">{{ tag }}</span>
+        </li>
+      </ul>
+    </header>
+
+    <section class="prompt-tip__content md-stack md-stack-3">
+      <div class="prompt-tip__prompt">
+        <pre class="prompt-tip__prompt-text" aria-label="Sugestão de prompt">{{ data.prompt }}</pre>
+        <Md3Button
+          class="prompt-tip__copy-button"
+          variant="text"
+          icon
+          type="button"
+          :aria-label="copied ? 'Copiado!' : 'Copiar prompt'"
+          @click="copyPrompt"
+        >
+          <template #leading>
+            <span class="md-icon md-icon--md" aria-hidden="true">
+              <Check v-if="copied" />
+              <Copy v-else />
+            </span>
+          </template>
+          <span class="prompt-tip__copy-label">{{ copied ? 'Copiado!' : 'Copiar' }}</span>
+        </Md3Button>
+        <span v-if="copied" class="prompt-tip__feedback" role="status" aria-live="polite">
+          Prompt copiado com sucesso.
+        </span>
+      </div>
+
+      <section
+        v-if="hasTips"
+        class="prompt-tip__tips md-stack md-stack-2"
+        aria-label="Variações sugeridas"
+      >
+        <h4 class="prompt-tip__tips-title text-title-small font-semibold">Variações rápidas</h4>
+        <ul class="prompt-tip__tips-list md-stack md-stack-1" role="list">
+          <li
+            v-for="(tip, index) in data.tips"
+            :key="`${index}-${tip}`"
+            class="prompt-tip__tips-item"
+          >
+            {{ tip }}
+          </li>
+        </ul>
+      </section>
+    </section>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { Copy, Check } from 'lucide-vue-next';
+import Md3Button from '@/components/Md3Button.vue';
+
+export interface PromptTipBlockData {
+  prompt: string;
+  title?: string;
+  description?: string;
+  tips?: string[];
+  tags?: string[];
+  audience?: string;
+}
+
+const props = defineProps<{ data: PromptTipBlockData }>();
+
+const copied = ref(false);
+
+const hasTags = computed(() => Boolean(props.data.tags?.length));
+const hasTips = computed(() => Boolean(props.data.tips?.length));
+const hasHeader = computed(() =>
+  Boolean(
+    props.data.title || props.data.description || props.data.tags?.length || props.data.audience
+  )
+);
+
+const audienceLabel = computed(() => {
+  if (!props.data.audience) {
+    return '';
+  }
+
+  const label = props.data.audience.trim();
+  if (!label) {
+    return '';
+  }
+
+  return label.charAt(0).toUpperCase() + label.slice(1);
+});
+
+const copyPrompt = () => {
+  navigator.clipboard.writeText(props.data.prompt).then(() => {
+    copied.value = true;
+    window.setTimeout(() => {
+      copied.value = false;
+    }, 2000);
+  });
+};
+</script>
+
+<style scoped>
+:host {
+  display: block;
+}
+
+.prompt-tip {
+  position: relative;
+  padding: 1.75rem;
+  border-radius: 20px;
+  border: 1px solid rgba(16, 163, 127, 0.35);
+  background: linear-gradient(135deg, #f7f8fb 0%, #eef1f7 45%, #e4e9f5 100%);
+  color: var(--md-sys-color-on-surface, #0f172a);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.1);
+}
+
+:global(html[data-theme='dark']) :host .prompt-tip {
+  background: linear-gradient(135deg, #343541 0%, #444654 45%, #202123 100%);
+  color: #f7f7f8;
+  border-color: rgba(16, 163, 127, 0.45);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+}
+
+.prompt-tip__header {
+  align-items: flex-start;
+}
+
+.prompt-tip__audience {
+  letter-spacing: 0.18em;
+  color: rgba(16, 163, 127, 0.85);
+}
+
+.prompt-tip__description {
+  color: color-mix(in srgb, currentColor 88%, transparent 12%);
+}
+
+.prompt-tip__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.prompt-tip__tag-item {
+  list-style: none;
+}
+
+.prompt-tip__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #0f172a;
+  background: rgba(16, 163, 127, 0.16);
+  border: 1px solid rgba(16, 163, 127, 0.35);
+}
+
+:global(html[data-theme='dark']) :host .prompt-tip__tag {
+  color: #f7f7f8;
+  background: rgba(16, 163, 127, 0.22);
+  border-color: rgba(16, 163, 127, 0.55);
+}
+
+.prompt-tip__prompt {
+  position: relative;
+  padding: 1.5rem;
+  border-radius: 16px;
+  border: 1px solid rgba(16, 163, 127, 0.25);
+  background: rgba(255, 255, 255, 0.86);
+  color: inherit;
+}
+
+:global(html[data-theme='dark']) :host .prompt-tip__prompt {
+  background: rgba(32, 33, 35, 0.85);
+  border-color: rgba(16, 163, 127, 0.45);
+}
+
+.prompt-tip__prompt-text {
+  margin: 0;
+  font-family: var(
+    --md-sys-typescale-body-large-font,
+    'Fira Code',
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    'Liberation Mono',
+    'Courier New',
+    monospace
+  );
+  font-size: 0.95rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.prompt-tip__copy-button {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  --md3-button-icon-size: 1.1rem;
+}
+
+.prompt-tip__copy-label {
+  font-weight: 600;
+}
+
+.prompt-tip__feedback {
+  position: absolute;
+  bottom: 0.9rem;
+  right: 1rem;
+  font-size: 0.75rem;
+  color: rgba(16, 163, 127, 0.85);
+}
+
+:global(html[data-theme='dark']) :host .prompt-tip__feedback {
+  color: rgba(125, 255, 224, 0.85);
+}
+
+.prompt-tip__tips-title {
+  color: color-mix(in srgb, currentColor 92%, transparent 8%);
+}
+
+.prompt-tip__tips-list {
+  margin: 0;
+  padding-left: 1rem;
+}
+
+.prompt-tip__tips-item {
+  color: color-mix(in srgb, currentColor 88%, transparent 12%);
+}
+</style>

--- a/src/components/lesson/__tests__/NewLessonBlocks.test.ts
+++ b/src/components/lesson/__tests__/NewLessonBlocks.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import DefinitionCard from '../DefinitionCard.vue';
 import ComparativeTable from '../ComparativeTable.vue';
@@ -10,6 +10,7 @@ import StatCard from '../StatCard.vue';
 import KnowledgeCheck from '../KnowledgeCheck.vue';
 import InteractiveDemo from '../InteractiveDemo.vue';
 import PedagogicalNote from '../PedagogicalNote.vue';
+import PromptTip from '../PromptTip.vue';
 
 beforeEach(() => {
   window.localStorage.clear();
@@ -166,5 +167,39 @@ describe('New lesson content blocks', () => {
 
     expect(wrapper.text()).toContain('Orientação interna');
     expect(wrapper.text()).toContain('Lembrete de alinhamento');
+  });
+
+  it('renders PromptTip and copia o texto do prompt', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const wrapper = mount(PromptTip, {
+      props: {
+        data: {
+          title: 'Briefing para sandbox',
+          description: 'Use como ponto de partida para interações com o modelo.',
+          audience: 'facilitadores',
+          prompt: 'Atue como consultor TOTVS e gere plano de experimentos.',
+          tags: ['laboratório', 'sandbox TOTVS'],
+          tips: [
+            'Peça variações com foco financeiro',
+            'Solicite um checklist de riscos regulatórios',
+          ],
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('Briefing para sandbox');
+    expect(wrapper.text()).toContain('Atue como consultor TOTVS');
+    expect(wrapper.text()).toContain('sandbox TOTVS');
+
+    await wrapper.find('button').trigger('click');
+
+    expect(writeText).toHaveBeenCalledWith(
+      'Atue como consultor TOTVS e gere plano de experimentos.'
+    );
   });
 });

--- a/src/components/lesson/blockRegistry.ts
+++ b/src/components/lesson/blockRegistry.ts
@@ -47,6 +47,7 @@ import StatCard from '@/components/lesson/StatCard.vue';
 import KnowledgeCheck from '@/components/lesson/KnowledgeCheck.vue';
 import InteractiveDemo from '@/components/lesson/InteractiveDemo.vue';
 import PedagogicalNote from '@/components/lesson/PedagogicalNote.vue';
+import PromptTip from '@/components/lesson/PromptTip.vue';
 import CodeSubmission from '@/components/exercise/CodeSubmission.vue';
 import DragAndDrop from '@/components/exercise/DragAndDrop.vue';
 import ConceptMapper from '@/components/exercise/ConceptMapper.vue';
@@ -107,6 +108,7 @@ const customComponentRegistry: Record<string, Component> = {
   KnowledgeCheck,
   InteractiveDemo,
   PedagogicalNote,
+  PromptTip,
   CodeSubmission,
   DragAndDrop,
   ConceptMapper,
@@ -190,6 +192,7 @@ const blockHandlers: Record<string, (block: LessonBlock) => BlockResolution> = {
   knowledgeCheck: dataBlock(KnowledgeCheck),
   interactiveDemo: dataBlock(InteractiveDemo),
   pedagogicalNote: dataBlock(PedagogicalNote),
+  promptTip: dataBlock(PromptTip),
   codeSubmission: dataBlock(CodeSubmission),
   dragAndDrop: dataBlock(DragAndDrop),
   conceptMapper: dataBlock(ConceptMapper),

--- a/src/content/courses/tgs/lessons/lesson-25.json
+++ b/src/content/courses/tgs/lessons/lesson-25.json
@@ -180,6 +180,19 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para conduzir o laboratório no sandbox",
+      "description": "Use com o assistente para desenhar experimentos alinhados aos indicadores e riscos regulatórios do case.",
+      "audience": "facilitadores",
+      "prompt": "Você é consultor TOTVS responsável pelo laboratório em sandbox. Monte um roteiro de experimentos em três ondas: (1) validar integrações CRM ↔ Serviços, (2) testar automações de faturamento com cenários tributários críticos, (3) medir impacto financeiro e riscos de compliance. Para cada onda, descreva objetivo, dados necessários, alertas de risco e entregáveis para o squad.",
+      "tags": ["sandbox TOTVS", "laboratório guiado", "experimentos"],
+      "tips": [
+        "Peça uma versão focada apenas na visão financeira com ênfase em reconciliação e projeções de caixa.",
+        "Solicite follow-ups em formato de checklist para cada squad ao final de cada onda.",
+        "Gere um resumo executivo de uma página para apresentar ao sponsor do programa."
+      ]
+    },
+    {
       "type": "videos",
       "title": "Vídeos indicados",
       "videos": [

--- a/src/content/schema/lesson.ts
+++ b/src/content/schema/lesson.ts
@@ -161,6 +161,16 @@ export interface PedagogicalNoteBlock extends LessonBlock {
   audience?: PedagogicalNoteAudience;
 }
 
+export interface PromptTipBlock extends LessonBlock {
+  type: 'promptTip';
+  prompt: string;
+  title?: string;
+  description?: string;
+  tips?: string[];
+  tags?: string[];
+  audience?: string;
+}
+
 export interface CodeSubmissionTestCase {
   name: string;
   input?: string;


### PR DESCRIPTION
## Summary
- add the PromptTip lesson block with chat-inspired styling, copy feedback, tags, and variation tips
- wire the block into the registry, schemas, validation, tests, and storybook
- seed the TGS sandbox case study with a promptTip block for end-to-end coverage

## Testing
- npm run test
- npm run validate:content -- --no-report src/content/courses/tgs/lessons/lesson-25.json

------
https://chatgpt.com/codex/tasks/task_e_68e0e84557bc832c956d686f7fbc5955