### PR TITLE
Add reusable helpers for faculty E2E navigation tests

### DIFF
--- a/src/pages/faculty/__tests__/faculty-test-utils.ts
+++ b/src/pages/faculty/__tests__/faculty-test-utils.ts
@@ -1,0 +1,94 @@
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils';
+import { createMemoryHistory, createRouter, type Router } from 'vue-router';
+import { nextTick, type ComponentPublicInstance } from 'vue';
+import { expect } from 'vitest';
+
+type AnyWrapper = VueWrapper<ComponentPublicInstance>;
+
+type MountResult = {
+  router: Router;
+  wrapper: AnyWrapper;
+};
+
+const matchMediaMock = (query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: () => {},
+  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => false,
+});
+
+function setupBrowserMocks() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.matchMedia = matchMediaMock as unknown as typeof window.matchMedia;
+  window.scrollTo = () => {};
+  window.localStorage.clear();
+  window.localStorage.setItem('teacherMode', 'true');
+}
+
+export async function mountFacultyApp(initialPath = '/faculty'): Promise<MountResult> {
+  setupBrowserMocks();
+
+  const { routes } = await import('@/router');
+  const App = (await import('@/App.vue')).default;
+  const router = createRouter({ history: createMemoryHistory(), routes });
+
+  await router.push(initialPath);
+  const wrapper = mount(App, {
+    global: {
+      plugins: [router],
+    },
+  });
+
+  await router.isReady();
+
+  return { router, wrapper };
+}
+
+export async function flushAll() {
+  await flushPromises();
+  await nextTick();
+}
+
+export async function navigateTo(router: Router, path: string) {
+  await router.push(path);
+  await flushAll();
+}
+
+function getNav(wrapper: AnyWrapper) {
+  const nav = wrapper.find('[aria-label="Rotas principais"]');
+  expect(nav.exists()).toBe(true);
+  return nav;
+}
+
+function findNavLink(wrapper: AnyWrapper, label: string) {
+  const nav = getNav(wrapper);
+  const links = nav.findAll('a.md3-top-app-bar__action');
+  const target = links.find((link) => link.text().includes(label));
+  expect(target, `Link de navegação não encontrado: ${label}`).toBeTruthy();
+  return target!;
+}
+
+export function expectNavLinkActive(wrapper: AnyWrapper, label: string) {
+  const link = findNavLink(wrapper, label);
+  expect(link.attributes('aria-current')).toBe('page');
+  expect(link.classes()).toContain('md3-top-app-bar__action--active');
+}
+
+export function expectNavLinkVisible(wrapper: AnyWrapper, label: string) {
+  const link = findNavLink(wrapper, label);
+  expect(link.attributes('aria-current')).toBeUndefined();
+}
+
+export function expectDashboardBreadcrumb(wrapper: AnyWrapper) {
+  const link = wrapper
+    .findAll('a')
+    .find((anchor) => anchor.text().includes('Voltar para o painel'));
+  expect(link, 'Esperado link "Voltar para o painel" para navegação').toBeTruthy();
+}

--- a/src/pages/faculty/__tests__/faculty-workflow.e2e.test.ts
+++ b/src/pages/faculty/__tests__/faculty-workflow.e2e.test.ts
@@ -1,68 +1,62 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { flushPromises, mount } from '@vue/test-utils';
-import { createMemoryHistory, createRouter } from 'vue-router';
+import { beforeEach, describe, expect, it } from 'vitest';
 import type { Router } from 'vue-router';
-import { nextTick } from 'vue';
+import type { VueWrapper } from '@vue/test-utils';
+import type { ComponentPublicInstance } from 'vue';
 
-import { routes } from '@/router';
+import FacultyDashboard from '../FacultyDashboard.vue';
 
-const matchMediaStub = vi.fn().mockImplementation((query: string) => ({
-  matches: false,
-  media: query,
-  onchange: null,
-  addListener: vi.fn(),
-  removeListener: vi.fn(),
-  addEventListener: vi.fn(),
-  removeEventListener: vi.fn(),
-  dispatchEvent: vi.fn(),
-}));
-
-if (typeof window !== 'undefined') {
-  window.matchMedia = matchMediaStub;
-}
+import {
+  mountFacultyApp,
+  flushAll,
+  navigateTo,
+  expectNavLinkActive,
+  expectNavLinkVisible,
+  expectDashboardBreadcrumb,
+} from './faculty-test-utils';
 
 describe('Faculty workflow routes', () => {
-  beforeEach(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.clear();
-      window.localStorage.setItem('teacherMode', 'true');
-      window.scrollTo = vi.fn();
-    }
+  let router: Router;
+  let wrapper: VueWrapper<ComponentPublicInstance>;
+
+  beforeEach(async () => {
+    const harness = await mountFacultyApp('/faculty');
+    router = harness.router;
+    wrapper = harness.wrapper;
   });
 
-  async function navigate(router: Router, path: string) {
-    await router.push(path);
-    await flushPromises();
-    await nextTick();
-  }
-
   it('navega da ingestão até a publicação no modo professor', async () => {
-    const router = createRouter({
-      history: createMemoryHistory(),
-      routes,
-    });
+    const nav = wrapper.find('[aria-label="Rotas principais"]');
+    expect(nav.exists()).toBe(true);
+    expect(nav.attributes('aria-label')).toBe('Rotas principais');
 
-    const App = (await import('@/App.vue')).default;
+    const dashboard = wrapper.getComponent(FacultyDashboard);
+    (dashboard.vm as any).dashboardLoading = true;
+    await flushAll();
+    expect(wrapper.text()).toContain('Carregando disciplinas…');
 
-    const wrapper = mount(App, {
-      global: {
-        plugins: [router],
-      },
-    });
+    (dashboard.vm as any).dashboardLoading = false;
+    await flushAll();
 
-    await router.isReady();
-    await flushPromises();
+    expectNavLinkActive(wrapper, 'Painel docente');
+    expect(wrapper.text()).toContain('Hub administrativo do professor');
 
-    await navigate(router, '/faculty/ingestion');
+    await navigateTo(router, '/faculty/ingestion');
+    expectNavLinkActive(wrapper, 'Ingestão de JSON');
+    expectNavLinkVisible(wrapper, 'Painel docente');
+    expectDashboardBreadcrumb(wrapper);
     expect(wrapper.text()).toContain('Ingestão e validação de conteúdo JSON');
 
-    await navigate(router, '/faculty/editor');
+    await navigateTo(router, '/faculty/editor');
+    expectNavLinkActive(wrapper, 'Editor visual');
+    expectNavLinkVisible(wrapper, 'Painel docente');
     expect(wrapper.text()).toContain('Editor visual de aulas e exercícios');
 
-    await navigate(router, '/faculty/validation');
+    await navigateTo(router, '/faculty/validation');
+    expectNavLinkActive(wrapper, 'Validações & relatórios');
     expect(wrapper.text()).toContain('Validações automatizadas e relatórios');
 
-    await navigate(router, '/faculty/publication');
+    await navigateTo(router, '/faculty/publication');
+    expectNavLinkActive(wrapper, 'Publicação & Git');
     expect(wrapper.text()).toContain('Preparar publicação e pacote de Git');
   });
 });


### PR DESCRIPTION
## Summary
- add test utilities to mount the full app router and share navigation assertions for faculty routes
- expand the faculty workflow E2E to cover breadcrumbs, aria-current states, and loading UI while navigating across the main tools

## Testing
- `npx vitest run src/pages/faculty/__tests__/faculty-workflow.e2e.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e0f1237654832c920b0f0a1c70b815