### PR TITLE
Add DualAssessmentBlock interface for lessons

### DIFF
--- a/src/content/schema/lesson.ts
+++ b/src/content/schema/lesson.ts
@@ -187,6 +187,18 @@ export interface CodeSubmissionBlock extends LessonBlock {
   tips?: string[];
 }
 
+export interface DualAssessmentBlock extends LessonBlock {
+  type: 'dualAssessment';
+  title?: string;
+  summary?: string;
+  theory: Omit<KnowledgeCheckBlock, keyof LessonBlock> & {
+    type?: 'knowledgeCheck';
+  };
+  practice: Omit<CodeSubmissionBlock, keyof LessonBlock> & {
+    type?: 'codeSubmission';
+  };
+}
+
 export interface DragAndDropStep {
   id: string;
   label: string;


### PR DESCRIPTION
## Summary
- add a DualAssessmentBlock interface for dual assessments with shared metadata
- reuse the existing knowledge check and code submission shapes for theory and practice content

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e10886c38c832cb2c25690727943ba