### PR TITLE
Add dual assessment block validation to lesson schema

### DIFF
--- a/schemas/lesson.schema.json
+++ b/schemas/lesson.schema.json
@@ -231,8 +231,35 @@
         { "$ref": "#/$defs/peerReviewTaskBlock" },
         { "$ref": "#/$defs/testGeneratorBlock" },
         { "$ref": "#/$defs/rubricDisplayBlock" },
-        { "$ref": "#/$defs/selfAssessmentBlock" }
+        { "$ref": "#/$defs/selfAssessmentBlock" },
+        { "$ref": "#/$defs/dualAssessmentBlock" }
       ]
+    },
+    "dualAssessmentBlock": {
+      "if": {
+        "properties": { "type": { "const": "dualAssessment" } }
+      },
+      "then": {
+        "required": ["theory", "practice"],
+        "properties": {
+          "title": { "type": "string" },
+          "summary": { "type": "string" },
+          "theory": {
+            "type": "object",
+            "allOf": [{ "$ref": "#/$defs/knowledgeCheckBlock/then" }],
+            "properties": {
+              "type": { "const": "knowledgeCheck" }
+            }
+          },
+          "practice": {
+            "type": "object",
+            "allOf": [{ "$ref": "#/$defs/codeSubmissionBlock/then" }],
+            "properties": {
+              "type": { "const": "codeSubmission" }
+            }
+          }
+        }
+      }
     },
     "definitionCardBlock": {
       "if": {


### PR DESCRIPTION
## Summary
- add a JSON schema definition for dualAssessment blocks to enforce expected structure for theory and practice sections
- register the new block definition with the shared content block schema

## Testing
- npm run validate:content

------
https://chatgpt.com/codex/tasks/task_e_68e10d12e494832cb6fb677f069cf433