### PR TITLE
Add dual assessment lesson block

### DIFF
--- a/src/components/lesson/DualAssessment.vue
+++ b/src/components/lesson/DualAssessment.vue
@@ -1,0 +1,105 @@
+<template>
+  <article class="dual-assessment card md-stack md-stack-5">
+    <header class="dual-assessment__header md-stack md-stack-2">
+      <p class="text-label-medium uppercase tracking-[0.2em] text-on-surface-variant">
+        Avaliação integrada
+      </p>
+      <h3 v-if="data.title" class="text-title-large font-semibold text-on-surface">
+        {{ data.title }}
+      </h3>
+      <p v-if="data.summary" class="text-body-medium text-on-surface">
+        {{ data.summary }}
+      </p>
+    </header>
+
+    <section class="dual-assessment__section md-stack md-stack-3" aria-labelledby="theory-heading">
+      <header id="theory-heading" class="dual-assessment__section-header">
+        <h4 class="text-title-small font-semibold text-on-surface">Teoria</h4>
+        <p class="text-body-small text-on-surface-variant">
+          Revise conceitos rápidos antes de partir para a prática.
+        </p>
+      </header>
+      <KnowledgeCheck :data="theoryData" />
+    </section>
+
+    <section
+      class="dual-assessment__section md-stack md-stack-3"
+      aria-labelledby="practice-heading"
+    >
+      <header id="practice-heading" class="dual-assessment__section-header">
+        <h4 class="text-title-small font-semibold text-on-surface">Prática</h4>
+        <p class="text-body-small text-on-surface-variant">
+          Coloque o aprendizado em ação com o exercício orientado.
+        </p>
+      </header>
+      <CodeSubmission :data="practiceData" />
+    </section>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import KnowledgeCheck, {
+  type KnowledgeCheckBlockData,
+} from '@/components/lesson/KnowledgeCheck.vue';
+import CodeSubmission, {
+  type CodeSubmissionBlockData,
+} from '@/components/exercise/CodeSubmission.vue';
+
+interface DualAssessmentBlockData {
+  title?: string;
+  summary?: string;
+  theory: KnowledgeCheckBlockData & { type?: string };
+  practice: CodeSubmissionBlockData & { type?: string };
+}
+
+const props = defineProps<{ data: DualAssessmentBlockData }>();
+
+const theoryData = computed<KnowledgeCheckBlockData>(() => {
+  const { type: _type, ...rest } = props.data.theory;
+  return rest;
+});
+
+const practiceData = computed<CodeSubmissionBlockData>(() => {
+  const { type: _type, ...rest } = props.data.practice;
+  return rest;
+});
+</script>
+
+<style scoped>
+.dual-assessment {
+  border-radius: 1.5rem;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  padding: 1.5rem;
+  background: var(--md-sys-color-surface-container);
+}
+
+.dual-assessment__header {
+  text-align: left;
+}
+
+.dual-assessment__section {
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+  padding-top: 1.25rem;
+  margin-top: 0.75rem;
+}
+
+.dual-assessment__section:first-of-type {
+  border-top: none;
+  padding-top: 0;
+  margin-top: 0;
+}
+
+.dual-assessment__section-header {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.dual-assessment :deep(.knowledge-check),
+.dual-assessment :deep(.code-submission) {
+  border-radius: 1.25rem;
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface);
+  box-shadow: none;
+}
+</style>

--- a/src/components/lesson/blockRegistry.ts
+++ b/src/components/lesson/blockRegistry.ts
@@ -45,6 +45,7 @@ import MemoryVisualizer from '@/components/lesson/MemoryVisualizer.vue';
 import CaseStudy from '@/components/lesson/CaseStudy.vue';
 import StatCard from '@/components/lesson/StatCard.vue';
 import KnowledgeCheck from '@/components/lesson/KnowledgeCheck.vue';
+import DualAssessment from '@/components/lesson/DualAssessment.vue';
 import InteractiveDemo from '@/components/lesson/InteractiveDemo.vue';
 import PedagogicalNote from '@/components/lesson/PedagogicalNote.vue';
 import PromptTip from '@/components/lesson/PromptTip.vue';
@@ -106,6 +107,7 @@ const customComponentRegistry: Record<string, Component> = {
   CaseStudy,
   StatCard,
   KnowledgeCheck,
+  DualAssessment,
   InteractiveDemo,
   PedagogicalNote,
   PromptTip,
@@ -190,6 +192,7 @@ const blockHandlers: Record<string, (block: LessonBlock) => BlockResolution> = {
   caseStudy: dataBlock(CaseStudy),
   statCard: dataBlock(StatCard),
   knowledgeCheck: dataBlock(KnowledgeCheck),
+  dualAssessment: dataBlock(DualAssessment),
   interactiveDemo: dataBlock(InteractiveDemo),
   pedagogicalNote: dataBlock(PedagogicalNote),
   promptTip: dataBlock(PromptTip),


### PR DESCRIPTION
## Summary
- add a DualAssessment lesson component that combines knowledge and practice sections with shared framing
- register the dual assessment block in the lesson block registry for runtime resolution

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68e10dde5a90832c921f90685e366922