### PR TITLE
Add DualAssessment block handler

### DIFF
--- a/src/components/lesson/blockRegistry.ts
+++ b/src/components/lesson/blockRegistry.ts
@@ -192,7 +192,12 @@ const blockHandlers: Record<string, (block: LessonBlock) => BlockResolution> = {
   caseStudy: dataBlock(CaseStudy),
   statCard: dataBlock(StatCard),
   knowledgeCheck: dataBlock(KnowledgeCheck),
-  dualAssessment: dataBlock(DualAssessment),
+  dualAssessment(block) {
+    return {
+      component: DualAssessment,
+      props: { data: block },
+    };
+  },
   interactiveDemo: dataBlock(InteractiveDemo),
   pedagogicalNote: dataBlock(PedagogicalNote),
   promptTip: dataBlock(PromptTip),


### PR DESCRIPTION
## Summary
- ensure the DualAssessment block handler explicitly returns the component with the block payload as props

## Testing
- npm run lint *(fails: missing dependency @eslint/js in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e10ee504c4832c831dd660ee258ed6