### PR TITLE
Add prompt guidance to Algoritmos lessons

### DIFF
--- a/src/components/lesson/PromptTip.vue
+++ b/src/components/lesson/PromptTip.vue
@@ -1,6 +1,6 @@
 <template>
-  <article class="prompt-tip card md-stack md-stack-4">
-    <header class="prompt-tip__header md-stack md-stack-2">
+  <article class="prompt-tip md-stack md-stack-5">
+    <header class="prompt-tip__header md-stack md-stack-3">
       <div class="prompt-tip__badge" aria-hidden="true">
         <span class="prompt-tip__badge-icon md-icon md-icon--md">
           <Sparkles />
@@ -33,7 +33,7 @@
       </ul>
     </header>
 
-    <section class="prompt-tip__content md-stack md-stack-3">
+    <section class="prompt-tip__content md-stack md-stack-4">
       <div class="prompt-tip__prompt">
         <p :id="instructionsId" class="prompt-tip__prompt-instructions text-body-small">
           Compartilhe este prompt com uma IA generativa (como ChatGPT, Gemini ou Copilot) e siga as
@@ -60,7 +60,6 @@
               <Copy v-else />
             </span>
           </template>
-          <span class="prompt-tip__copy-label">{{ copied ? 'Copiado!' : 'Copiar' }}</span>
         </Md3Button>
         <span v-if="copied" class="prompt-tip__feedback" role="status" aria-live="polite">
           Prompt copiado com sucesso.
@@ -161,20 +160,26 @@ const copyPrompt = async () => {
 }
 
 .prompt-tip {
-  position: relative;
-  padding: 1.75rem;
-  border-radius: 20px;
-  border: 1px solid rgba(16, 163, 127, 0.35);
-  background: linear-gradient(135deg, #f7f8fb 0%, #eef1f7 45%, #e4e9f5 100%);
+  --prompt-tip-radius: 24px;
+  --prompt-tip-border: color-mix(
+    in srgb,
+    var(--md-sys-color-outline-variant, var(--md-sys-color-outline, #cbd5f5)) 65%,
+    transparent
+  );
+  --prompt-tip-surface: color-mix(
+    in srgb,
+    var(--md-sys-color-surface-container-high, var(--md-sys-color-surface, #ffffff)) 82%,
+    var(--md-sys-color-surface, #ffffff) 18%
+  );
+  --prompt-tip-shadow: color-mix(in srgb, var(--md-sys-color-on-surface, #0f172a) 12%, transparent);
+  display: grid;
+  gap: var(--md-sys-spacing-6, 1.5rem);
+  padding: clamp(1.5rem, 1.8vw + 1rem, 2rem);
+  border-radius: var(--prompt-tip-radius);
+  border: 1px solid var(--prompt-tip-border);
+  background: var(--prompt-tip-surface);
   color: var(--md-sys-color-on-surface, #0f172a);
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.1);
-}
-
-:global(html[data-theme='dark']) :host .prompt-tip {
-  background: linear-gradient(135deg, #343541 0%, #444654 45%, #202123 100%);
-  color: #f7f7f8;
-  border-color: rgba(16, 163, 127, 0.45);
-  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 16px 36px var(--prompt-tip-shadow);
 }
 
 .prompt-tip__header {
@@ -184,20 +189,18 @@ const copyPrompt = async () => {
 .prompt-tip__badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.4rem 0.85rem;
+  gap: var(--md-sys-spacing-2, 0.5rem);
+  padding: 0.45rem 0.9rem;
   border-radius: 999px;
-  background: rgba(16, 163, 127, 0.12);
-  color: rgba(16, 163, 127, 0.95);
+  background: color-mix(in srgb, var(--md-sys-color-primary, #2563eb) 16%, transparent);
+  color: color-mix(
+    in srgb,
+    var(--md-sys-color-primary, #2563eb) 82%,
+    var(--md-sys-color-on-surface, #0f172a) 18%
+  );
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  margin-bottom: 0.75rem;
-}
-
-:global(html[data-theme='dark']) :host .prompt-tip__badge {
-  background: rgba(16, 163, 127, 0.22);
-  color: rgba(125, 255, 224, 0.95);
 }
 
 .prompt-tip__badge-icon {
@@ -205,8 +208,17 @@ const copyPrompt = async () => {
 }
 
 .prompt-tip__badge-icon :deep(svg) {
-  width: 1.1rem;
-  height: 1.1rem;
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.prompt-tip__badge-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+}
+
+.prompt-tip__header-copy {
+  margin: 0;
 }
 
 .prompt-tip__intro {
@@ -216,17 +228,26 @@ const copyPrompt = async () => {
 
 .prompt-tip__audience {
   letter-spacing: 0.18em;
-  color: rgba(16, 163, 127, 0.85);
+  color: color-mix(
+    in srgb,
+    var(--md-sys-color-primary, #2563eb) 70%,
+    var(--md-sys-color-on-surface, #0f172a) 30%
+  );
+}
+
+.prompt-tip__title {
+  margin: 0;
 }
 
 .prompt-tip__description {
+  margin: 0;
   color: color-mix(in srgb, currentColor 88%, transparent 12%);
 }
 
 .prompt-tip__tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: var(--md-sys-spacing-2, 0.5rem);
   margin: 0;
   padding: 0;
 }
@@ -241,31 +262,40 @@ const copyPrompt = async () => {
   gap: 0.4rem;
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  font-size: 0.8125rem;
+  font-size: 0.8rem;
   font-weight: 600;
-  color: #0f172a;
-  background: rgba(16, 163, 127, 0.16);
-  border: 1px solid rgba(16, 163, 127, 0.35);
+  color: color-mix(
+    in srgb,
+    var(--md-sys-color-on-secondary-container, var(--md-sys-color-on-surface)) 90%,
+    var(--md-sys-color-on-surface, #0f172a) 10%
+  );
+  background: color-mix(in srgb, var(--md-sys-color-secondary-container, #e0e8ff) 70%, transparent);
+  border: 1px solid color-mix(in srgb, var(--md-sys-color-secondary, #4c51bf) 35%, transparent);
 }
 
-:global(html[data-theme='dark']) :host .prompt-tip__tag {
-  color: #f7f7f8;
-  background: rgba(16, 163, 127, 0.22);
-  border-color: rgba(16, 163, 127, 0.55);
+.prompt-tip__content {
+  position: relative;
 }
 
 .prompt-tip__prompt {
   position: relative;
-  padding: 1.5rem;
-  border-radius: 16px;
-  border: 1px solid rgba(16, 163, 127, 0.25);
-  background: rgba(255, 255, 255, 0.86);
+  padding: clamp(1.1rem, 1vw + 0.9rem, 1.5rem);
+  border-radius: 18px;
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--md-sys-color-outline-variant, var(--md-sys-color-outline, #cbd5f5)) 60%,
+      transparent
+    );
+  background: color-mix(
+    in srgb,
+    var(--md-sys-color-surface-container-highest, #f4f6fb) 88%,
+    var(--md-sys-color-surface, #ffffff) 12%
+  );
+  box-shadow: 0 12px 26px
+    color-mix(in srgb, var(--md-sys-color-on-surface, #0f172a) 10%, transparent);
   color: inherit;
-}
-
-:global(html[data-theme='dark']) :host .prompt-tip__prompt {
-  background: rgba(32, 33, 35, 0.85);
-  border-color: rgba(16, 163, 127, 0.45);
+  overflow: hidden;
 }
 
 .prompt-tip__prompt-instructions {
@@ -290,42 +320,58 @@ const copyPrompt = async () => {
   font-size: 0.95rem;
   line-height: 1.55;
   white-space: pre-wrap;
+  word-break: break-word;
   overflow-x: auto;
+  padding-right: 2.75rem;
 }
 
 .prompt-tip__copy-button {
   position: absolute;
   top: 0.75rem;
   right: 0.75rem;
-  --md3-button-icon-size: 1.1rem;
-}
-
-.prompt-tip__copy-label {
-  font-weight: 600;
+  --md3-button-icon-size: 1.15rem;
 }
 
 .prompt-tip__feedback {
   position: absolute;
-  bottom: 0.9rem;
-  right: 1rem;
+  inset-block-end: 0.85rem;
+  inset-inline-end: 1rem;
   font-size: 0.75rem;
-  color: rgba(16, 163, 127, 0.85);
-}
-
-:global(html[data-theme='dark']) :host .prompt-tip__feedback {
-  color: rgba(125, 255, 224, 0.85);
+  font-weight: 600;
+  color: color-mix(
+    in srgb,
+    var(--md-sys-color-primary, #2563eb) 78%,
+    var(--md-sys-color-on-surface, #0f172a) 22%
+  );
 }
 
 .prompt-tip__tips-title {
+  margin: 0;
   color: color-mix(in srgb, currentColor 92%, transparent 8%);
 }
 
 .prompt-tip__tips-list {
   margin: 0;
   padding-left: 1rem;
+  display: grid;
+  gap: var(--md-sys-spacing-1, 0.25rem);
 }
 
 .prompt-tip__tips-item {
   color: color-mix(in srgb, currentColor 88%, transparent 12%);
+}
+
+@media (max-width: 768px) {
+  .prompt-tip {
+    padding: clamp(1.25rem, 4vw, 1.75rem);
+  }
+
+  .prompt-tip__prompt {
+    padding: clamp(1rem, 3vw, 1.35rem);
+  }
+
+  .prompt-tip__prompt-text {
+    padding-right: 2.25rem;
+  }
 }
 </style>

--- a/src/content/courses/algi/lessons/lesson-01.json
+++ b/src/content/courses/algi/lessons/lesson-01.json
@@ -140,6 +140,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Introdução à Lógica e Algoritmos",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 1: Introdução à Lógica e Algoritmos. Contexto da aula: Apresenta a disciplina, posiciona a lógica como base para resolver problemas computacionais e introduz o ciclo de criação de algoritmos. Objetivo central: Conhecer o funcionamento do curso, alinhar expectativas e compreender por que a lógica é a linguagem dos computadores. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "logica", "planejamento"],
+      "tips": [
+        "Peça variações de atividades que reforcem contextualizar o papel da lógica na resolução de problemas computacionais.",
+        "Solicite exemplos adicionais relacionados a logica, algoritmos.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem mapear o funcionamento da disciplina, critérios de avaliação e recursos de apoio."
+      ]
+    },
+    {
       "type": "callout",
       "variant": "info",
       "title": "Check-in inicial",

--- a/src/content/courses/algi/lessons/lesson-02.json
+++ b/src/content/courses/algi/lessons/lesson-02.json
@@ -134,6 +134,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Raciocínio Lógico e Operadores",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 2: Raciocínio Lógico e Operadores. Contexto da aula: Aprofunda o pensamento computacional por meio da decomposição de problemas e da aplicação de operadores lógicos para embasar decisões. Objetivo central: Traduzir situações cotidianas em estruturas lógicas utilizando operadores AND, OR e NOT. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "logica", "operadores", "tabela-verdade"],
+      "tips": [
+        "Peça variações de atividades que reforcem praticar a decomposição de problemas em passos ordenados.",
+        "Solicite exemplos adicionais relacionados a logica, operadores.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem reconhecer operadores lógicos e aplicá-los a regras de decisão."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Decompondo problemas",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-03.json
+++ b/src/content/courses/algi/lessons/lesson-03.json
@@ -123,6 +123,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Estruturando Algoritmos",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 3: Estruturando Algoritmos. Contexto da aula: Explora estratégias para organizar passos de um algoritmo, destacar decisões e preparar a transição para pseudocódigo. Objetivo central: Transformar ideias em sequências claras e ordenadas que possam ser implementadas em linguagem de programação. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "pseudocodigo", "sequencia"],
+      "tips": [
+        "Peça variações de atividades que reforcem aplicar técnicas de decomposição para mapear processos complexos.",
+        "Solicite exemplos adicionais relacionados a algoritmos, sequencia.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem comparar diferentes representações (texto estruturado, fluxogramas, pseudocódigo)."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "A ordem importa",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-04.json
+++ b/src/content/courses/algi/lessons/lesson-04.json
@@ -107,6 +107,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Do Pseudocódigo ao Primeiro Programa em C",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 4: Do Pseudocódigo ao Primeiro Programa em C. Contexto da aula: Mostra como traduzir algoritmos escritos em Portugol para um programa funcional em C, destacando sintaxe e boas práticas. Objetivo central: Conectar o planejamento em linguagem natural/pseudocódigo com a implementação inicial em C. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "implementacao", "linguagem-c", "pseudocodigo"],
+      "tips": [
+        "Peça variações de atividades que reforcem relembrar a estrutura padrão de um algoritmo em portugol.",
+        "Solicite exemplos adicionais relacionados a pseudocodigo, linguagem-c.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem mapear cada parte do pseudocódigo para a sintaxe equivalente em c."
+      ]
+    },
+    {
       "type": "callout",
       "variant": "good-practice",
       "title": "Prepare o ambiente antes de codar",

--- a/src/content/courses/algi/lessons/lesson-05.json
+++ b/src/content/courses/algi/lessons/lesson-05.json
@@ -199,6 +199,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Fluxogramas e Visualização da Lógica",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 5: Fluxogramas e Visualização da Lógica. Contexto da aula: Apresenta a simbologia essencial dos fluxogramas e orienta a tradução de algoritmos textuais para representações visuais. Objetivo central: Representar algoritmos usando fluxogramas claros que facilitem a comunicação entre equipe e stakeholders. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "fluxograma", "processos", "visualizacao"],
+      "tips": [
+        "Peça variações de atividades que reforcem mapear algoritmos simples em fluxogramas legíveis.",
+        "Solicite exemplos adicionais relacionados a fluxograma, visualizacao.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem relacionar símbolos padronizados a operações de entrada, processamento e decisão."
+      ]
+    },
+    {
       "type": "cardGrid",
       "title": "Simbologia essencial",
       "cards": [

--- a/src/content/courses/algi/lessons/lesson-06.json
+++ b/src/content/courses/algi/lessons/lesson-06.json
@@ -107,6 +107,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Variáveis, Constantes e Tipos de Dados",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 6: Variáveis, Constantes e Tipos de Dados. Contexto da aula: Apresenta como armazenar dados em C, declarando variáveis, utilizando constantes e escolhendo tipos adequados. Objetivo central: Dominar a sintaxe de declaração e atribuição em C para preparar programas que manipulem dados com segurança. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "constantes", "tipos", "variaveis"],
+      "tips": [
+        "Peça variações de atividades que reforcem diferenciar variáveis de constantes e aplicar boas práticas de nomeação.",
+        "Solicite exemplos adicionais relacionados a variaveis, tipos.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem selecionar tipos primitivos apropriados para cada informação."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Variáveis: caixas nomeadas",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-07.json
+++ b/src/content/courses/algi/lessons/lesson-07.json
@@ -130,6 +130,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Operadores e Expressões em C",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 7: Operadores e Expressões em C. Contexto da aula: Apresenta as famílias de operadores da linguagem C, mostra como combinar expressões com precedência correta e conecta os resultados às decisões lógicas do algoritmo. Objetivo central: Construir expressões aritméticas e lógicas corretas em C, respeitando precedência e usando operadores apropriados para cada situação. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "expressoes", "linguagem-c", "operadores"],
+      "tips": [
+        "Peça variações de atividades que reforcem identificar a função das principais categorias de operadores em c.",
+        "Solicite exemplos adicionais relacionados a operadores, expressoes.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem aplicar precedência e agrupamento para evitar ambiguidades em expressões."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Por que operadores importam",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-08.json
+++ b/src/content/courses/algi/lessons/lesson-08.json
@@ -126,6 +126,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Leituras múltiplas, cálculos encadeados e printf",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 8: Leituras múltiplas, cálculos encadeados e printf. Contexto da aula: Consolida o fluxo Entrada → Processamento → Saída combinando leituras com scanf, variáveis intermediárias para cálculos e formatação profissional com printf. Objetivo central: Construir programas sequenciais completos que recebem múltiplos dados, processam com clareza e exibem resultados formatados. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "printf", "scanf", "sequencial"],
+      "tips": [
+        "Peça variações de atividades que reforcem construir programas sequenciais em c que realizem múltiplas leituras e saídas formatadas.",
+        "Solicite exemplos adicionais relacionados a sequencial, scanf.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem aplicar operações aritméticas encadeadas preservando a ordem correta de execução."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Leitura múltipla com scanf",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-09.json
+++ b/src/content/courses/algi/lessons/lesson-09.json
@@ -136,6 +136,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Problemas sequenciais aplicados em C",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 9: Problemas sequenciais aplicados em C. Contexto da aula: Aplica o fluxo Entrada → Processamento → Saída em estudos de caso reais, combinando leitura estruturada, cálculos encadeados e comunicação de resultados. Objetivo central: Resolver problemas cotidianos com programas sequenciais em C documentando cada etapa do processo. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "pratica", "problemas", "sequencial"],
+      "tips": [
+        "Peça variações de atividades que reforcem planejar a solução identificando entradas, processamento e saídas de cada caso.",
+        "Solicite exemplos adicionais relacionados a sequencial, problemas.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem implementar programas sequenciais com validações simples e formatação clara."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Estudo de caso: salário líquido",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-10.json
+++ b/src/content/courses/algi/lessons/lesson-10.json
@@ -132,6 +132,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Condicionais com if e else",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 10: Condicionais com if e else. Contexto da aula: Transforma algoritmos sequenciais em decisões controladas por condições booleanas, introduzindo desvios simples e comunicação clara de cada caminho. Objetivo central: Empregar estruturas if e if-else para alterar o fluxo do programa conforme regras de negócio bem definidas. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "condicionais", "controle-de-fluxo", "if-else"],
+      "tips": [
+        "Peça variações de atividades que reforcem reconhecer situações em que o fluxo sequencial precisa ser desviado por meio de uma condição.",
+        "Solicite exemplos adicionais relacionados a condicionais, if-else.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem escrever e testar expressões booleanas que alimentam estruturas if e if-else."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Quando precisamos desviar do fluxo sequencial",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-11.json
+++ b/src/content/courses/algi/lessons/lesson-11.json
@@ -130,6 +130,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Seleção múltipla com switch-case",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 11: Seleção múltipla com switch-case. Contexto da aula: Simplifica decisões com muitas alternativas ao agrupar lógicas repetitivas em rótulos claros de switch-case, mantendo o fluxo organizado. Objetivo central: Selecionar um entre vários blocos de código com base em uma única expressão usando switch-case de forma segura. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "condicionais", "controle-de-fluxo", "switch-case"],
+      "tips": [
+        "Peça variações de atividades que reforcem identificar quando cadeias longas de if-else podem ser substituídas por switch-case.",
+        "Solicite exemplos adicionais relacionados a condicionais, switch-case.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem configurar cases, break e default para controlar exatamente quais blocos executam."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Mini-teste Moodle (15 min)",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-12.json
+++ b/src/content/courses/algi/lessons/lesson-12.json
@@ -140,6 +140,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Cadeias de decisão com else if",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 12: Cadeias de decisão com else if. Contexto da aula: Organiza múltiplas regras exclusivas priorizando faixas e combinações lógicas, garantindo que cada entrada encontre exatamente um caminho. Objetivo central: Modelar cadeias de else if que cobrem todos os cenários possíveis com clareza e sem lacunas. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "condicionais", "else-if", "regras"],
+      "tips": [
+        "Peça variações de atividades que reforcem planejar a ordem das condições para evitar sobreposição entre faixas.",
+        "Solicite exemplos adicionais relacionados a condicionais, else-if.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem combinar operadores lógicos para refinar regras com múltiplos critérios."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Por que encadear decisões",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-13.json
+++ b/src/content/courses/algi/lessons/lesson-13.json
@@ -121,6 +121,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Condições compostas e encadeadas",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 13: Condições compostas e encadeadas. Contexto da aula: Combina operadores lógicos e cadeias else if para tratar cenários complexos sem deixar lacunas ou sobreposições. Objetivo central: Aplicar &&, || e ! em cadeias de decisão planejadas que cobrem todas as regras do problema. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "condicionais", "controle-de-fluxo", "operadores-logicos"],
+      "tips": [
+        "Peça variações de atividades que reforcem compor expressões lógicas combinando operadores relacionais e lógicos.",
+        "Solicite exemplos adicionais relacionados a condicionais, operadores-logicos.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem planejar cadeias else if para atender múltiplos cenários de decisão."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Por que combinar condições?",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-14.json
+++ b/src/content/courses/algi/lessons/lesson-14.json
@@ -138,6 +138,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Avaliação NP1",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 14: Avaliação NP1. Contexto da aula: Aplica a primeira avaliação formal para medir domínio de lógica, fluxogramas e condicionais simples. Objetivo central: Avaliar de forma individual a aplicação correta da lógica sequencial e das decisões condicionais estudadas nas aulas anteriores. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "avaliacao", "diagnostico", "np1"],
+      "tips": [
+        "Peça variações de atividades que reforcem verificar a compreensão dos conceitos fundamentais de algoritmos e programação em c.",
+        "Solicite exemplos adicionais relacionados a avaliacao, np1.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem identificar lacunas de aprendizagem em lógica booleana e estruturas condicionais."
+      ]
+    },
+    {
       "type": "timeline",
       "title": "Cronograma 10-90-10",
       "steps": [

--- a/src/content/courses/algi/lessons/lesson-15.json
+++ b/src/content/courses/algi/lessons/lesson-15.json
@@ -165,6 +165,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Correção da NP1 e aprofundamento",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 15: Correção da NP1 e aprofundamento. Contexto da aula: Analisa os resultados da NP1, corrige erros recorrentes e reforça decisões compostas com exercícios direcionados. Objetivo central: Transformar o feedback da NP1 em plano de melhoria, revisando condicionais compostas e boas práticas de implementação. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "avaliacao", "condicionais", "revisao"],
+      "tips": [
+        "Peça variações de atividades que reforcem apresentar panorama geral das notas e dos critérios avaliados na np1.",
+        "Solicite exemplos adicionais relacionados a condicionais, revisao.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem corrigir coletivamente os erros mais frequentes identificados nas questões."
+      ]
+    },
+    {
       "type": "md3Table",
       "title": "Panorama da NP1",
       "headers": ["Questão", "Média", "Principais erros"],

--- a/src/content/courses/algi/lessons/lesson-16.json
+++ b/src/content/courses/algi/lessons/lesson-16.json
@@ -144,6 +144,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Atividade Prática Assíncrona – Condicionais",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 16: Atividade Prática Assíncrona – Condicionais. Contexto da aula: Aplica condicionais compostas em um miniaplicativo de triagem, documentando decisões, testes e evidências de entrega. Objetivo central: Conduzir uma atividade autônoma que consolide condicionais aninhadas, operadores lógicos e planejamento de testes. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "assincrona", "atividade", "condicionais"],
+      "tips": [
+        "Peça variações de atividades que reforcem revisar requisitos funcionais de um fluxo de triagem clínica.",
+        "Solicite exemplos adicionais relacionados a condicionais, atividade.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem desenhar fluxogramas que reflitam decisões exclusivas e caminhos alternativos."
+      ]
+    },
+    {
       "type": "pipelineCanvas",
       "title": "Fluxo da atividade assíncrona",
       "summary": "Três etapas obrigatórias para concluir a triagem médica digital.",

--- a/src/content/courses/algi/lessons/lesson-17.json
+++ b/src/content/courses/algi/lessons/lesson-17.json
@@ -107,15 +107,16 @@
     },
     {
       "type": "promptTip",
-      "title": "Prompt para ativar invariantes e sentinelas",
-      "description": "Use com o assistente para guiar revisões rápidas ou dinâmicas de laboratório sobre loops while.",
-      "audience": "docentes e monitores",
-      "prompt": "Você é tutor de Algoritmos I preparando estudantes para implementar laços while com sentinela. Elabore um roteiro em três etapas: (1) revisar a lógica do while e definir invariantes, (2) propor um exercício de média de notas com sentinela e validação de entrada, (3) montar um checklist de testes cobrindo entradas válidas, inválidas e casos limite. Para cada etapa, indique objetivo, atividades sugeridas e perguntas disparadoras.",
-      "tags": ["algoritmos", "while", "sentinela"],
+      "title": "Prompt para planejar Estrutura de Repetição while",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 17: Estrutura de Repetição while. Contexto da aula: Introduz laços while para repetir blocos enquanto condições permanecem verdadeiras, aplicando sentinelas e validações. Objetivo central: Compreender, modelar e implementar laços while controlados por condição e por sentinela. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "loops", "repeticao", "while"],
       "tips": [
-        "Peça uma versão adaptada para estudantes que ainda confundem condição de parada com atualização de variáveis.",
-        "Solicite exemplos extras de validação de entrada envolvendo valores negativos e limites superiores.",
-        "Gere um resumo final em formato de quadro branco com tópicos-chave para projetar na sala."
+        "Peça variações de atividades que reforcem identificar situações em que while é mais adequado que for ou decisões simples.",
+        "Solicite exemplos adicionais relacionados a loops, while.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem traduzir fluxogramas com laço enquanto em pseudocódigo/c."
       ]
     },
     {
@@ -157,28 +158,60 @@
       "headers": ["Situação", "for", "while", "do-while"],
       "rows": [
         [
-          { "value": "Contagem conhecida" },
-          { "value": "✅" },
-          { "value": "⚠️" },
-          { "value": "⚠️" }
+          {
+            "value": "Contagem conhecida"
+          },
+          {
+            "value": "✅"
+          },
+          {
+            "value": "⚠️"
+          },
+          {
+            "value": "⚠️"
+          }
         ],
         [
-          { "value": "Condição avaliada antes" },
-          { "value": "✅" },
-          { "value": "✅" },
-          { "value": "❌" }
+          {
+            "value": "Condição avaliada antes"
+          },
+          {
+            "value": "✅"
+          },
+          {
+            "value": "✅"
+          },
+          {
+            "value": "❌"
+          }
         ],
         [
-          { "value": "Executar ao menos 1 vez" },
-          { "value": "❌" },
-          { "value": "❌" },
-          { "value": "✅" }
+          {
+            "value": "Executar ao menos 1 vez"
+          },
+          {
+            "value": "❌"
+          },
+          {
+            "value": "❌"
+          },
+          {
+            "value": "✅"
+          }
         ],
         [
-          { "value": "Leitura com sentinela" },
-          { "value": "⚠️" },
-          { "value": "✅" },
-          { "value": "✅" }
+          {
+            "value": "Leitura com sentinela"
+          },
+          {
+            "value": "⚠️"
+          },
+          {
+            "value": "✅"
+          },
+          {
+            "value": "✅"
+          }
         ]
       ],
       "summary": "(⚠️ = possível, mas não é o mais natural)"

--- a/src/content/courses/algi/lessons/lesson-18.json
+++ b/src/content/courses/algi/lessons/lesson-18.json
@@ -142,6 +142,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Estrutura de Repetição for",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 18: Estrutura de Repetição for. Contexto da aula: Explora o laço for para repetir instruções com contadores definidos, destacando inicialização, condição e atualização. Objetivo central: Planejar e implementar laços for para percorrer intervalos, vetores e produzir tabulações controladas. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "for", "loops", "repeticao"],
+      "tips": [
+        "Peça variações de atividades que reforcem mapear os três componentes do for (inicialização, condição, atualização).",
+        "Solicite exemplos adicionais relacionados a loops, for.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem comparar equivalências entre for e while em exemplos reais."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Componentes do for",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-19.json
+++ b/src/content/courses/algi/lessons/lesson-19.json
@@ -100,6 +100,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Comparação entre for e while",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Comparação entre for e while. Contexto da aula: Discute critérios práticos para escolher entre for e while e como refatorar algoritmos sem alterar resultados. Objetivo central: Decidir com segurança entre for e while e justificar a refatoração escolhida para cada problema. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "boas-praticas", "comparacao", "loops"],
+      "tips": [
+        "Peça variações de atividades que reforcem distinguir cenários ideais para laços controlados por contador e por condição.",
+        "Solicite exemplos adicionais relacionados a loops, comparacao.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem refatorar algoritmos simples convertendo entre for e while sem alterar resultados."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Perguntas para decidir entre for e while",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-20.json
+++ b/src/content/courses/algi/lessons/lesson-20.json
@@ -106,6 +106,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Estrutura de repetição do-while",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Estrutura de repetição do-while. Contexto da aula: Apresenta o do-while em C para menus e validações que exigem uma execução inicial garantida. Objetivo central: Implementar menus que exigem execução inicial obrigatória usando do-while e validar todas as opções com feedback imediato. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "do-while", "loops", "menus"],
+      "tips": [
+        "Peça variações de atividades que reforcem identificar problemas que exigem execução mínima antes da validação.",
+        "Solicite exemplos adicionais relacionados a loops, do-while.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem implementar menus interativos utilizando a estrutura do-while."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Por que usar do-while?",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-21.json
+++ b/src/content/courses/algi/lessons/lesson-21.json
@@ -98,6 +98,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Problemas com laços aninhados simples",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Problemas com laços aninhados simples. Contexto da aula: Integra laços aninhados para resolver problemas bidimensionais, produzindo tabelas e padrões em C. Objetivo central: Modelar e implementar laços aninhados que gerem estruturas 2D consistentes, avaliando custos e depurando erros comuns. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "aninhamento", "loops", "padroes"],
+      "tips": [
+        "Peça variações de atividades que reforcem planejar estruturas de dados bidimensionais que dependem de laços aninhados.",
+        "Solicite exemplos adicionais relacionados a loops, aninhamento.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem implementar algoritmos com laços aninhados simples para tabulações e padrões visuais."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Fundamentos dos laços aninhados",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-22.json
+++ b/src/content/courses/algi/lessons/lesson-22.json
@@ -108,6 +108,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Integrando Laços e Condicionais",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Integrando Laços e Condicionais. Contexto da aula: Integra estruturas de repetição com decisões complexas para tratar fluxos completos de processamento. Objetivo central: Construir rotinas robustas que combinem laços e condicionais com validação e relatórios de execução. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "condicionais", "integracao", "loops"],
+      "tips": [
+        "Peça variações de atividades que reforcem mapear pontos de decisão dentro e fora de laços.",
+        "Solicite exemplos adicionais relacionados a loops, condicionais.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem implementar validações de entrada antes de iniciar ciclos."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Pipeline da integração",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-23.json
+++ b/src/content/courses/algi/lessons/lesson-23.json
@@ -121,6 +121,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Atividade Assíncrona de Triagem Clínica",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Atividade Assíncrona de Triagem Clínica. Contexto da aula: Propõe atividade assíncrona integradora que combina laços, condicionais e registro de testes na simulação de triagem. Objetivo central: Planejar e executar a triagem automatizada cumprindo requisitos funcionais, documentação e entrega assíncrona. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "assincrona", "projeto", "triagem"],
+      "tips": [
+        "Peça variações de atividades que reforcem interpretar o briefing de triagem e planejar o fluxo de decisão.",
+        "Solicite exemplos adicionais relacionados a assincrona, projeto.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem implementar algoritmo que percorre formulários e classifica pacientes."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Cronograma de 3 dias",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-24.json
+++ b/src/content/courses/algi/lessons/lesson-24.json
@@ -126,6 +126,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Síntese e Retrospectiva dos Laços",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Síntese e Retrospectiva dos Laços. Contexto da aula: Consolida aprendizados das aulas 19-23 com showcase da triagem, retroalimentação e plano de melhoria contínua. Objetivo central: Refletir sobre o ciclo de laços, compartilhar entregas da triagem e definir próximos passos de estudo. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "feedback", "planejamento", "retrospectiva"],
+      "tips": [
+        "Peça variações de atividades que reforcem apresentar resultados da atividade assíncrona de triagem.",
+        "Solicite exemplos adicionais relacionados a retrospectiva, feedback.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem identificar boas práticas e pontos de melhoria nas soluções."
+      ]
+    },
+    {
       "type": "lessonPlan",
       "title": "Plano de voo (1h40)",
       "cards": [

--- a/src/content/courses/algi/lessons/lesson-25.json
+++ b/src/content/courses/algi/lessons/lesson-25.json
@@ -141,6 +141,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Introdução a Funções e Modularização",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 25: Introdução a Funções e Modularização. Contexto da aula: Motiva a decomposição de programas em funções, introduzindo protótipos, escopo e primeiros padrões de modularização. Objetivo central: Compreender por que dividir o código em funções torna programas mais legíveis, testáveis e sustentáveis. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "c-basico", "funcoes", "modularizacao"],
+      "tips": [
+        "Peça variações de atividades que reforcem identificar sinais de que um algoritmo deve ser quebrado em funções.",
+        "Solicite exemplos adicionais relacionados a funcoes, modularizacao.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem escrever protótipos simples com parâmetros e retorno."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Por que modularizar?",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-26.json
+++ b/src/content/courses/algi/lessons/lesson-26.json
@@ -140,6 +140,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Funções com Parâmetros e Retorno",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 26: Funções com Parâmetros e Retorno. Contexto da aula: Explora assinatura completa de funções em C, analisando passagem de parâmetros por valor e por referência com foco em testes. Objetivo central: Aplicar parâmetros e valores de retorno para construir funções reutilizáveis que tratam entradas variadas com segurança. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "funcoes", "parametros", "ponteiros"],
+      "tips": [
+        "Peça variações de atividades que reforcem comparar passagem por valor e por referência em c.",
+        "Solicite exemplos adicionais relacionados a funcoes, parametros.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem projetar funções que retornam códigos de erro ou resultados numéricos."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Quando usar ponteiros?",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-27.json
+++ b/src/content/courses/algi/lessons/lesson-27.json
@@ -140,6 +140,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Programas Modulares com Múltiplas Funções",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 27: Programas Modulares com Múltiplas Funções. Contexto da aula: Integra funções em arquitetura modular com arquivos separados, headers e fluxo de compilação incremental. Objetivo central: Projetar um mini-sistema em C dividindo responsabilidades entre múltiplas funções e arquivos com headers dedicados. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "headers", "makefile", "modularizacao"],
+      "tips": [
+        "Peça variações de atividades que reforcem planejar módulos e dependências utilizando canvas de design.",
+        "Solicite exemplos adicionais relacionados a modularizacao, headers.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem criar e incluir arquivos header com protótipos organizados."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Estratégias de separação",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-28.json
+++ b/src/content/courses/algi/lessons/lesson-28.json
@@ -129,6 +129,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Boas Práticas e Manutenção de Funções",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Boas Práticas e Manutenção de Funções. Contexto da aula: Consolida padrões de escrita, testes e documentação para funções em C, com foco em revisão de código e qualidade contínua. Objetivo central: Aplicar boas práticas de legibilidade, cobertura de testes e monitoramento de métricas em projetos modulares. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "boas-praticas", "qualidade", "testes"],
+      "tips": [
+        "Peça variações de atividades que reforcem avaliar código usando checklist de boas práticas.",
+        "Solicite exemplos adicionais relacionados a boas-praticas, qualidade.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem instrumentar funções com logs e medições simples."
+      ]
+    },
+    {
       "type": "lessonPlan",
       "title": "Plano de voo (1h50)",
       "cards": [

--- a/src/content/courses/algi/lessons/lesson-29.json
+++ b/src/content/courses/algi/lessons/lesson-29.json
@@ -40,6 +40,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Avaliação NP2",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 29: Avaliação NP2. Contexto da aula: Avaliação escrita que sintetiza estruturas condicionais, laços de repetição e modularização com funções em problemas contextualizados. Objetivo central: Avaliar a capacidade de aplicar if/else encadeados, operadores lógicos e estruturas de repetição (while, for, do-while), bem como a modularização com funções (parâmetros, retorno e boas práticas de escopo/protótipos) em problemas práticos de pequena escala. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "avaliacao", "estruturas-de-controle"],
+      "tips": [
+        "Peça variações de atividades que reforcem aplicar condicionais encadeadas em algoritmos de tomada de decisão.",
+        "Solicite exemplos adicionais relacionados a avaliacao, algoritmos.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem combinar laços de repetição com contadores e acumuladores."
+      ]
+    },
+    {
       "type": "cardGrid",
       "title": "Domínios avaliados",
       "cards": [

--- a/src/content/courses/algi/lessons/lesson-30.json
+++ b/src/content/courses/algi/lessons/lesson-30.json
@@ -137,6 +137,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Introdução a Vetores",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Introdução a Vetores. Contexto da aula: Apresenta o conceito de vetores (arrays) em C, destacando sua utilidade na organização de dados homogêneos e no cálculo de estatísticas básicas. Objetivo central: Reconhecer vetores como estruturas de dados fundamentais, compreender sua sintaxe em C e aplicar percursos lineares para obter estatísticas simples. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "arrays", "estatistica-basica", "vetores"],
+      "tips": [
+        "Peça variações de atividades que reforcem declarar e inicializar vetores em c respeitando tipos e tamanhos.",
+        "Solicite exemplos adicionais relacionados a vetores, arrays.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem percorrer vetores com loops for para calcular média, mínimo e máximo."
+      ]
+    },
+    {
       "type": "lessonPlan",
       "title": "Plano de voo (1h50)",
       "cards": [

--- a/src/content/courses/algi/lessons/lesson-31.json
+++ b/src/content/courses/algi/lessons/lesson-31.json
@@ -146,6 +146,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Operações e Transformações com Vetores",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Operações e Transformações com Vetores. Contexto da aula: Explora padrões de somatório, normalização e geração de tabelas a partir de vetores, consolidando o domínio de loops e acumuladores. Objetivo central: Aplicar percursos sobre vetores para executar operações agregadas e construir tabelas de frequência ou rankings simples. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "arrays", "operacoes", "vetores"],
+      "tips": [
+        "Peça variações de atividades que reforcem implementar funções para somar, normalizar e copiar vetores.",
+        "Solicite exemplos adicionais relacionados a vetores, arrays.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem construir tabelas de frequência a partir de dados numéricos."
+      ]
+    },
+    {
       "type": "lessonPlan",
       "title": "Plano de voo (1h55)",
       "cards": [

--- a/src/content/courses/algi/lessons/lesson-32.json
+++ b/src/content/courses/algi/lessons/lesson-32.json
@@ -166,6 +166,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Buscas em Vetores",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Buscas em Vetores. Contexto da aula: Introduz algoritmos de busca linear e variantes com sentinela, conectando-os a cenários de catálogo e relatórios. Objetivo central: Selecionar e implementar estratégias de busca apropriadas para localizar elementos em vetores não ordenados. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "arrays", "busca", "vetores"],
+      "tips": [
+        "Peça variações de atividades que reforcem implementar busca linear tradicional e com sentinela.",
+        "Solicite exemplos adicionais relacionados a vetores, busca.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem analisar custo temporal das buscas e seu impacto em coleções grandes."
+      ]
+    },
+    {
       "type": "lessonPlan",
       "title": "Plano de voo (1h50)",
       "cards": [

--- a/src/content/courses/algi/lessons/lesson-33.json
+++ b/src/content/courses/algi/lessons/lesson-33.json
@@ -133,6 +133,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Matrizes 2D e Geração de Tabelas",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Matrizes 2D e Geração de Tabelas. Contexto da aula: Apresenta matrizes bidimensionais em C para organizar dados tabulares e gerar relatórios estruturados. Objetivo central: Compreender a representação de matrizes 2D, percorrer linhas e colunas com loops aninhados e montar tabelas formatadas. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "arrays", "loops-aninhados", "matrizes"],
+      "tips": [
+        "Peça variações de atividades que reforcem declarar matrizes estáticas e inicializá-las com dados reais.",
+        "Solicite exemplos adicionais relacionados a matrizes, arrays.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem percorrer linhas e colunas utilizando loops aninhados."
+      ]
+    },
+    {
       "type": "lessonPlan",
       "title": "Plano de voo (1h55)",
       "cards": [

--- a/src/content/courses/algi/lessons/lesson-34.json
+++ b/src/content/courses/algi/lessons/lesson-34.json
@@ -163,6 +163,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Manipulações com Matrizes",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Manipulações com Matrizes. Contexto da aula: Aprofunda o trabalho com matrizes 2D realizando transposição, somas e multiplicação para resolver problemas de relatórios e transformações. Objetivo central: Aplicar operações clássicas de matrizes para gerar indicadores combinados e preparar o terreno para algoritmos de processamento de imagens e dados. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "arrays", "matrizes", "multiplicacao"],
+      "tips": [
+        "Peça variações de atividades que reforcem implementar funções para transpor e somar matrizes.",
+        "Solicite exemplos adicionais relacionados a matrizes, arrays.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem executar multiplicação matricial com três loops."
+      ]
+    },
+    {
       "type": "lessonPlan",
       "title": "Plano de voo (2h00)",
       "cards": [

--- a/src/content/courses/algi/lessons/lesson-35.json
+++ b/src/content/courses/algi/lessons/lesson-35.json
@@ -134,6 +134,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Introdução a Structs (Registros)",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Introdução a Structs (Registros). Contexto da aula: Apresenta structs em C como registros compostos e conduz um CRUD básico em memória para consolidar o modelo de dados. Objetivo central: Compreender a declaração, instância e manipulação inicial de structs em C, preparando-se para coleções de registros. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "crud", "revisao", "structs"],
+      "tips": [
+        "Peça variações de atividades que reforcem declarar structs com campos adequados ao domínio proposto.",
+        "Solicite exemplos adicionais relacionados a structs, crud.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem inicializar e acessar membros por ponto e ponteiros."
+      ]
+    },
+    {
       "type": "lessonPlan",
       "title": "Plano de voo (1h55)",
       "cards": [

--- a/src/content/courses/algi/lessons/lesson-36.json
+++ b/src/content/courses/algi/lessons/lesson-36.json
@@ -166,6 +166,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Vetores de Structs",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Vetores de Structs. Contexto da aula: Constrói coleções de registros com structs em vetor e prepara o terreno para operações CRUD completas. Objetivo central: Estruturar vetores de structs para representar catálogos de dados e aplicar operações coletivas de ordenação e agregação. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "crud", "revisao", "structs"],
+      "tips": [
+        "Peça variações de atividades que reforcem armazenar múltiplos registros em vetores de structs com limites configuráveis.",
+        "Solicite exemplos adicionais relacionados a structs, crud.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem aplicar ordenação simples para organizar a coleção."
+      ]
+    },
+    {
       "type": "lessonPlan",
       "title": "Plano de voo (2h00)",
       "cards": [

--- a/src/content/courses/algi/lessons/lesson-37.json
+++ b/src/content/courses/algi/lessons/lesson-37.json
@@ -151,6 +151,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Busca e Atualização em Vetores de Structs",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Busca e Atualização em Vetores de Structs. Contexto da aula: Refina o CRUD em memória adicionando buscas flexíveis, atualização de campos e estratégias de auditoria. Objetivo central: Desenvolver habilidades para localizar, atualizar e remover registros em vetores de structs, garantindo integridade dos dados. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "crud", "revisao", "structs"],
+      "tips": [
+        "Peça variações de atividades que reforcem implementar buscas lineares e por chave composta.",
+        "Solicite exemplos adicionais relacionados a structs, crud.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem atualizar campos selecionados mantendo histórico mínimo."
+      ]
+    },
+    {
       "type": "lessonPlan",
       "title": "Plano de voo (2h05)",
       "cards": [

--- a/src/content/courses/algi/lessons/lesson-38.json
+++ b/src/content/courses/algi/lessons/lesson-38.json
@@ -150,6 +150,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Revisão Gamificada do Semestre",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Revisão Gamificada do Semestre. Contexto da aula: Consolida conteúdos com dinâmica Jeopardy, ranking colaborativo e síntese dos aprendizados em squads. Objetivo central: Promover revisão abrangente dos conceitos-chave da disciplina por meio de atividades gamificadas e colaborativas. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "crud", "revisao", "structs"],
+      "tips": [
+        "Peça variações de atividades que reforcem relembrar tópicos centrais (fluxo sequencial, controle, funções, structs).",
+        "Solicite exemplos adicionais relacionados a structs, crud.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem aplicar conhecimento em desafios práticos e quizzes competitivos."
+      ]
+    },
+    {
       "type": "contentBlock",
       "title": "Kit Jeopardy por squad",
       "content": [

--- a/src/content/courses/algi/lessons/lesson-39.json
+++ b/src/content/courses/algi/lessons/lesson-39.json
@@ -63,6 +63,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Avaliação NP3",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 39: Avaliação NP3. Contexto da aula: Avaliação integradora que cobre todo o percurso da disciplina, exigindo aplicação articulada de lógica, estruturas de dados básicas e modularização. Objetivo central: Avaliar de forma global o domínio dos conteúdos trabalhados ao longo do semestre, testando a capacidade do aluno de analisar problemas e implementar soluções completas em C, com estruturas de dados básicas. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "avaliacao", "integrador"],
+      "tips": [
+        "Peça variações de atividades que reforcem avaliar domínio de algoritmos sequenciais, condicionais e iterativos.",
+        "Solicite exemplos adicionais relacionados a avaliacao, algoritmos.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem verificar a manipulação correta de vetores, matrizes e registros."
+      ]
+    },
+    {
       "type": "lessonPlan",
       "title": "Roteiro operacional da NP3",
       "cards": [

--- a/src/content/courses/algi/lessons/lesson-40.json
+++ b/src/content/courses/algi/lessons/lesson-40.json
@@ -125,6 +125,20 @@
       ]
     },
     {
+      "type": "promptTip",
+      "title": "Prompt para planejar Encerramento e Devolutiva",
+      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
+      "audience": "docentes de Algoritmos I",
+      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 40: Encerramento e Devolutiva. Contexto da aula: Celebra entregas finais, devolve resultados das NPs e orienta trilhas futuras (Git e estruturas de dados) com recursos para estudo contínuo. Objetivo central: Encerrar o semestre consolidando aprendizados, oferecendo devolutivas personalizadas e mapeando próximos passos de desenvolvimento. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "tags": ["algoritmos", "encerramento", "feedback", "planejamento"],
+      "tips": [
+        "Peça variações de atividades que reforcem apresentar síntese dos resultados das avaliações (nps) e destacar evidências de evolução.",
+        "Solicite exemplos adicionais relacionados a encerramento, feedback.",
+        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
+        "Peça sugestões de avaliação formativa que evidenciem promover showcase dos projetos finais com feedback estruturado e celebração da turma."
+      ]
+    },
+    {
       "type": "lessonPlan",
       "title": "Roteiro detalhado da devolutiva",
       "cards": [


### PR DESCRIPTION
## Summary
- add PromptTip guidance blocks to every Algoritmos lesson so assistant prompts align with each aula's foco e objetivos
- populate each prompt with lesson-specific objetivos, tags e dicas para facilitar preparação, condução e acompanhamento

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e11a343f8c832c908f711b7a7ad4d9