### PR TITLE
Arrange prompt tip tags in a responsive grid

### DIFF
--- a/src/components/lesson/PromptTip.vue
+++ b/src/components/lesson/PromptTip.vue
@@ -245,8 +245,10 @@ const copyPrompt = async () => {
 }
 
 .prompt-tip__tags {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, max-content));
+  justify-content: flex-start;
+  justify-items: start;
   gap: var(--md-sys-spacing-2, 0.5rem);
   margin: 0;
   padding: 0;

--- a/src/content/courses/algi/lessons/lesson-01.json
+++ b/src/content/courses/algi/lessons/lesson-01.json
@@ -142,15 +142,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Introdução à Lógica e Algoritmos",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 1: Introdução à Lógica e Algoritmos. Contexto da aula: Apresenta a disciplina, posiciona a lógica como base para resolver problemas computacionais e introduz o ciclo de criação de algoritmos. Objetivo central: Conhecer o funcionamento do curso, alinhar expectativas e compreender por que a lógica é a linguagem dos computadores. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 1: Introdução à Lógica e Algoritmos. Contexto da aula: Apresenta a disciplina, posiciona a lógica como base para resolver problemas computacionais e introduz o ciclo de criação de algoritmos. Objetivo central: Conhecer o funcionamento do curso, alinhar expectativas e compreender por que a lógica é a linguagem dos computadores. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "logica", "planejamento"],
       "tips": [
-        "Peça variações de atividades que reforcem contextualizar o papel da lógica na resolução de problemas computacionais.",
-        "Solicite exemplos adicionais relacionados a logica, algoritmos.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem mapear o funcionamento da disciplina, critérios de avaliação e recursos de apoio."
+        "Peça ao assistente variações de exercícios que reforcem contextualizar o papel da lógica na resolução de problemas computacionais.",
+        "Solicite exemplos adicionais relacionados a logica, algoritmos para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a mapear o funcionamento da disciplina, critérios de avaliação e recursos de apoio."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-02.json
+++ b/src/content/courses/algi/lessons/lesson-02.json
@@ -136,15 +136,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Raciocínio Lógico e Operadores",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 2: Raciocínio Lógico e Operadores. Contexto da aula: Aprofunda o pensamento computacional por meio da decomposição de problemas e da aplicação de operadores lógicos para embasar decisões. Objetivo central: Traduzir situações cotidianas em estruturas lógicas utilizando operadores AND, OR e NOT. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 2: Raciocínio Lógico e Operadores. Contexto da aula: Aprofunda o pensamento computacional por meio da decomposição de problemas e da aplicação de operadores lógicos para embasar decisões. Objetivo central: Traduzir situações cotidianas em estruturas lógicas utilizando operadores AND, OR e NOT. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "logica", "operadores", "tabela-verdade"],
       "tips": [
-        "Peça variações de atividades que reforcem praticar a decomposição de problemas em passos ordenados.",
-        "Solicite exemplos adicionais relacionados a logica, operadores.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem reconhecer operadores lógicos e aplicá-los a regras de decisão."
+        "Peça ao assistente variações de exercícios que reforcem praticar a decomposição de problemas em passos ordenados.",
+        "Solicite exemplos adicionais relacionados a logica, operadores para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a reconhecer operadores lógicos e aplicá-los a regras de decisão."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-03.json
+++ b/src/content/courses/algi/lessons/lesson-03.json
@@ -125,15 +125,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Estruturando Algoritmos",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 3: Estruturando Algoritmos. Contexto da aula: Explora estratégias para organizar passos de um algoritmo, destacar decisões e preparar a transição para pseudocódigo. Objetivo central: Transformar ideias em sequências claras e ordenadas que possam ser implementadas em linguagem de programação. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 3: Estruturando Algoritmos. Contexto da aula: Explora estratégias para organizar passos de um algoritmo, destacar decisões e preparar a transição para pseudocódigo. Objetivo central: Transformar ideias em sequências claras e ordenadas que possam ser implementadas em linguagem de programação. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "pseudocodigo", "sequencia"],
       "tips": [
-        "Peça variações de atividades que reforcem aplicar técnicas de decomposição para mapear processos complexos.",
-        "Solicite exemplos adicionais relacionados a algoritmos, sequencia.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem comparar diferentes representações (texto estruturado, fluxogramas, pseudocódigo)."
+        "Peça ao assistente variações de exercícios que reforcem aplicar técnicas de decomposição para mapear processos complexos.",
+        "Solicite exemplos adicionais relacionados a algoritmos, sequencia para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a comparar diferentes representações (texto estruturado, fluxogramas, pseudocódigo)."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-04.json
+++ b/src/content/courses/algi/lessons/lesson-04.json
@@ -109,15 +109,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Do Pseudocódigo ao Primeiro Programa em C",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 4: Do Pseudocódigo ao Primeiro Programa em C. Contexto da aula: Mostra como traduzir algoritmos escritos em Portugol para um programa funcional em C, destacando sintaxe e boas práticas. Objetivo central: Conectar o planejamento em linguagem natural/pseudocódigo com a implementação inicial em C. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 4: Do Pseudocódigo ao Primeiro Programa em C. Contexto da aula: Mostra como traduzir algoritmos escritos em Portugol para um programa funcional em C, destacando sintaxe e boas práticas. Objetivo central: Conectar o planejamento em linguagem natural/pseudocódigo com a implementação inicial em C. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "implementacao", "linguagem-c", "pseudocodigo"],
       "tips": [
-        "Peça variações de atividades que reforcem relembrar a estrutura padrão de um algoritmo em portugol.",
-        "Solicite exemplos adicionais relacionados a pseudocodigo, linguagem-c.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem mapear cada parte do pseudocódigo para a sintaxe equivalente em c."
+        "Peça ao assistente variações de exercícios que reforcem relembrar a estrutura padrão de um algoritmo em portugol.",
+        "Solicite exemplos adicionais relacionados a pseudocodigo, linguagem-c para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a mapear cada parte do pseudocódigo para a sintaxe equivalente em c."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-05.json
+++ b/src/content/courses/algi/lessons/lesson-05.json
@@ -201,15 +201,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Fluxogramas e Visualização da Lógica",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 5: Fluxogramas e Visualização da Lógica. Contexto da aula: Apresenta a simbologia essencial dos fluxogramas e orienta a tradução de algoritmos textuais para representações visuais. Objetivo central: Representar algoritmos usando fluxogramas claros que facilitem a comunicação entre equipe e stakeholders. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 5: Fluxogramas e Visualização da Lógica. Contexto da aula: Apresenta a simbologia essencial dos fluxogramas e orienta a tradução de algoritmos textuais para representações visuais. Objetivo central: Representar algoritmos usando fluxogramas claros que facilitem a comunicação entre equipe e stakeholders. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "fluxograma", "processos", "visualizacao"],
       "tips": [
-        "Peça variações de atividades que reforcem mapear algoritmos simples em fluxogramas legíveis.",
-        "Solicite exemplos adicionais relacionados a fluxograma, visualizacao.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem relacionar símbolos padronizados a operações de entrada, processamento e decisão."
+        "Peça ao assistente variações de exercícios que reforcem mapear algoritmos simples em fluxogramas legíveis.",
+        "Solicite exemplos adicionais relacionados a fluxograma, visualizacao para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a relacionar símbolos padronizados a operações de entrada, processamento e decisão."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-06.json
+++ b/src/content/courses/algi/lessons/lesson-06.json
@@ -109,15 +109,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Variáveis, Constantes e Tipos de Dados",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 6: Variáveis, Constantes e Tipos de Dados. Contexto da aula: Apresenta como armazenar dados em C, declarando variáveis, utilizando constantes e escolhendo tipos adequados. Objetivo central: Dominar a sintaxe de declaração e atribuição em C para preparar programas que manipulem dados com segurança. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 6: Variáveis, Constantes e Tipos de Dados. Contexto da aula: Apresenta como armazenar dados em C, declarando variáveis, utilizando constantes e escolhendo tipos adequados. Objetivo central: Dominar a sintaxe de declaração e atribuição em C para preparar programas que manipulem dados com segurança. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "constantes", "tipos", "variaveis"],
       "tips": [
-        "Peça variações de atividades que reforcem diferenciar variáveis de constantes e aplicar boas práticas de nomeação.",
-        "Solicite exemplos adicionais relacionados a variaveis, tipos.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem selecionar tipos primitivos apropriados para cada informação."
+        "Peça ao assistente variações de exercícios que reforcem diferenciar variáveis de constantes e aplicar boas práticas de nomeação.",
+        "Solicite exemplos adicionais relacionados a variaveis, tipos para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a selecionar tipos primitivos apropriados para cada informação."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-07.json
+++ b/src/content/courses/algi/lessons/lesson-07.json
@@ -132,15 +132,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Operadores e Expressões em C",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 7: Operadores e Expressões em C. Contexto da aula: Apresenta as famílias de operadores da linguagem C, mostra como combinar expressões com precedência correta e conecta os resultados às decisões lógicas do algoritmo. Objetivo central: Construir expressões aritméticas e lógicas corretas em C, respeitando precedência e usando operadores apropriados para cada situação. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 7: Operadores e Expressões em C. Contexto da aula: Apresenta as famílias de operadores da linguagem C, mostra como combinar expressões com precedência correta e conecta os resultados às decisões lógicas do algoritmo. Objetivo central: Construir expressões aritméticas e lógicas corretas em C, respeitando precedência e usando operadores apropriados para cada situação. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "expressoes", "linguagem-c", "operadores"],
       "tips": [
-        "Peça variações de atividades que reforcem identificar a função das principais categorias de operadores em c.",
-        "Solicite exemplos adicionais relacionados a operadores, expressoes.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem aplicar precedência e agrupamento para evitar ambiguidades em expressões."
+        "Peça ao assistente variações de exercícios que reforcem identificar a função das principais categorias de operadores em c.",
+        "Solicite exemplos adicionais relacionados a operadores, expressoes para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a aplicar precedência e agrupamento para evitar ambiguidades em expressões."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-08.json
+++ b/src/content/courses/algi/lessons/lesson-08.json
@@ -128,15 +128,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Leituras múltiplas, cálculos encadeados e printf",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 8: Leituras múltiplas, cálculos encadeados e printf. Contexto da aula: Consolida o fluxo Entrada → Processamento → Saída combinando leituras com scanf, variáveis intermediárias para cálculos e formatação profissional com printf. Objetivo central: Construir programas sequenciais completos que recebem múltiplos dados, processam com clareza e exibem resultados formatados. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 8: Leituras múltiplas, cálculos encadeados e printf. Contexto da aula: Consolida o fluxo Entrada → Processamento → Saída combinando leituras com scanf, variáveis intermediárias para cálculos e formatação profissional com printf. Objetivo central: Construir programas sequenciais completos que recebem múltiplos dados, processam com clareza e exibem resultados formatados. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "printf", "scanf", "sequencial"],
       "tips": [
-        "Peça variações de atividades que reforcem construir programas sequenciais em c que realizem múltiplas leituras e saídas formatadas.",
-        "Solicite exemplos adicionais relacionados a sequencial, scanf.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem aplicar operações aritméticas encadeadas preservando a ordem correta de execução."
+        "Peça ao assistente variações de exercícios que reforcem construir programas sequenciais em c que realizem múltiplas leituras e saídas formatadas.",
+        "Solicite exemplos adicionais relacionados a sequencial, scanf para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a aplicar operações aritméticas encadeadas preservando a ordem correta de execução."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-09.json
+++ b/src/content/courses/algi/lessons/lesson-09.json
@@ -138,15 +138,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Problemas sequenciais aplicados em C",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 9: Problemas sequenciais aplicados em C. Contexto da aula: Aplica o fluxo Entrada → Processamento → Saída em estudos de caso reais, combinando leitura estruturada, cálculos encadeados e comunicação de resultados. Objetivo central: Resolver problemas cotidianos com programas sequenciais em C documentando cada etapa do processo. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 9: Problemas sequenciais aplicados em C. Contexto da aula: Aplica o fluxo Entrada → Processamento → Saída em estudos de caso reais, combinando leitura estruturada, cálculos encadeados e comunicação de resultados. Objetivo central: Resolver problemas cotidianos com programas sequenciais em C documentando cada etapa do processo. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "pratica", "problemas", "sequencial"],
       "tips": [
-        "Peça variações de atividades que reforcem planejar a solução identificando entradas, processamento e saídas de cada caso.",
-        "Solicite exemplos adicionais relacionados a sequencial, problemas.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem implementar programas sequenciais com validações simples e formatação clara."
+        "Peça ao assistente variações de exercícios que reforcem planejar a solução identificando entradas, processamento e saídas de cada caso.",
+        "Solicite exemplos adicionais relacionados a sequencial, problemas para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a implementar programas sequenciais com validações simples e formatação clara."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-10.json
+++ b/src/content/courses/algi/lessons/lesson-10.json
@@ -134,15 +134,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Condicionais com if e else",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 10: Condicionais com if e else. Contexto da aula: Transforma algoritmos sequenciais em decisões controladas por condições booleanas, introduzindo desvios simples e comunicação clara de cada caminho. Objetivo central: Empregar estruturas if e if-else para alterar o fluxo do programa conforme regras de negócio bem definidas. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 10: Condicionais com if e else. Contexto da aula: Transforma algoritmos sequenciais em decisões controladas por condições booleanas, introduzindo desvios simples e comunicação clara de cada caminho. Objetivo central: Empregar estruturas if e if-else para alterar o fluxo do programa conforme regras de negócio bem definidas. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "condicionais", "controle-de-fluxo", "if-else"],
       "tips": [
-        "Peça variações de atividades que reforcem reconhecer situações em que o fluxo sequencial precisa ser desviado por meio de uma condição.",
-        "Solicite exemplos adicionais relacionados a condicionais, if-else.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem escrever e testar expressões booleanas que alimentam estruturas if e if-else."
+        "Peça ao assistente variações de exercícios que reforcem reconhecer situações em que o fluxo sequencial precisa ser desviado por meio de uma condição.",
+        "Solicite exemplos adicionais relacionados a condicionais, if-else para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a escrever e testar expressões booleanas que alimentam estruturas if e if-else."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-11.json
+++ b/src/content/courses/algi/lessons/lesson-11.json
@@ -132,15 +132,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Seleção múltipla com switch-case",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 11: Seleção múltipla com switch-case. Contexto da aula: Simplifica decisões com muitas alternativas ao agrupar lógicas repetitivas em rótulos claros de switch-case, mantendo o fluxo organizado. Objetivo central: Selecionar um entre vários blocos de código com base em uma única expressão usando switch-case de forma segura. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 11: Seleção múltipla com switch-case. Contexto da aula: Simplifica decisões com muitas alternativas ao agrupar lógicas repetitivas em rótulos claros de switch-case, mantendo o fluxo organizado. Objetivo central: Selecionar um entre vários blocos de código com base em uma única expressão usando switch-case de forma segura. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "condicionais", "controle-de-fluxo", "switch-case"],
       "tips": [
-        "Peça variações de atividades que reforcem identificar quando cadeias longas de if-else podem ser substituídas por switch-case.",
-        "Solicite exemplos adicionais relacionados a condicionais, switch-case.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem configurar cases, break e default para controlar exatamente quais blocos executam."
+        "Peça ao assistente variações de exercícios que reforcem identificar quando cadeias longas de if-else podem ser substituídas por switch-case.",
+        "Solicite exemplos adicionais relacionados a condicionais, switch-case para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a configurar cases, break e default para controlar exatamente quais blocos executam."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-12.json
+++ b/src/content/courses/algi/lessons/lesson-12.json
@@ -142,15 +142,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Cadeias de decisão com else if",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 12: Cadeias de decisão com else if. Contexto da aula: Organiza múltiplas regras exclusivas priorizando faixas e combinações lógicas, garantindo que cada entrada encontre exatamente um caminho. Objetivo central: Modelar cadeias de else if que cobrem todos os cenários possíveis com clareza e sem lacunas. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 12: Cadeias de decisão com else if. Contexto da aula: Organiza múltiplas regras exclusivas priorizando faixas e combinações lógicas, garantindo que cada entrada encontre exatamente um caminho. Objetivo central: Modelar cadeias de else if que cobrem todos os cenários possíveis com clareza e sem lacunas. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "condicionais", "else-if", "regras"],
       "tips": [
-        "Peça variações de atividades que reforcem planejar a ordem das condições para evitar sobreposição entre faixas.",
-        "Solicite exemplos adicionais relacionados a condicionais, else-if.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem combinar operadores lógicos para refinar regras com múltiplos critérios."
+        "Peça ao assistente variações de exercícios que reforcem planejar a ordem das condições para evitar sobreposição entre faixas.",
+        "Solicite exemplos adicionais relacionados a condicionais, else-if para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a combinar operadores lógicos para refinar regras com múltiplos critérios."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-13.json
+++ b/src/content/courses/algi/lessons/lesson-13.json
@@ -123,15 +123,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Condições compostas e encadeadas",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 13: Condições compostas e encadeadas. Contexto da aula: Combina operadores lógicos e cadeias else if para tratar cenários complexos sem deixar lacunas ou sobreposições. Objetivo central: Aplicar &&, || e ! em cadeias de decisão planejadas que cobrem todas as regras do problema. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 13: Condições compostas e encadeadas. Contexto da aula: Combina operadores lógicos e cadeias else if para tratar cenários complexos sem deixar lacunas ou sobreposições. Objetivo central: Aplicar &&, || e ! em cadeias de decisão planejadas que cobrem todas as regras do problema. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "condicionais", "controle-de-fluxo", "operadores-logicos"],
       "tips": [
-        "Peça variações de atividades que reforcem compor expressões lógicas combinando operadores relacionais e lógicos.",
-        "Solicite exemplos adicionais relacionados a condicionais, operadores-logicos.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem planejar cadeias else if para atender múltiplos cenários de decisão."
+        "Peça ao assistente variações de exercícios que reforcem compor expressões lógicas combinando operadores relacionais e lógicos.",
+        "Solicite exemplos adicionais relacionados a condicionais, operadores-logicos para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a planejar cadeias else if para atender múltiplos cenários de decisão."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-14.json
+++ b/src/content/courses/algi/lessons/lesson-14.json
@@ -140,15 +140,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Avaliação NP1",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 14: Avaliação NP1. Contexto da aula: Aplica a primeira avaliação formal para medir domínio de lógica, fluxogramas e condicionais simples. Objetivo central: Avaliar de forma individual a aplicação correta da lógica sequencial e das decisões condicionais estudadas nas aulas anteriores. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 14: Avaliação NP1. Contexto da aula: Aplica a primeira avaliação formal para medir domínio de lógica, fluxogramas e condicionais simples. Objetivo central: Avaliar de forma individual a aplicação correta da lógica sequencial e das decisões condicionais estudadas nas aulas anteriores. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "avaliacao", "diagnostico", "np1"],
       "tips": [
-        "Peça variações de atividades que reforcem verificar a compreensão dos conceitos fundamentais de algoritmos e programação em c.",
-        "Solicite exemplos adicionais relacionados a avaliacao, np1.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem identificar lacunas de aprendizagem em lógica booleana e estruturas condicionais."
+        "Peça ao assistente variações de exercícios que reforcem verificar a compreensão dos conceitos fundamentais de algoritmos e programação em c.",
+        "Solicite exemplos adicionais relacionados a avaliacao, np1 para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a identificar lacunas de aprendizagem em lógica booleana e estruturas condicionais."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-15.json
+++ b/src/content/courses/algi/lessons/lesson-15.json
@@ -167,15 +167,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Correção da NP1 e aprofundamento",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 15: Correção da NP1 e aprofundamento. Contexto da aula: Analisa os resultados da NP1, corrige erros recorrentes e reforça decisões compostas com exercícios direcionados. Objetivo central: Transformar o feedback da NP1 em plano de melhoria, revisando condicionais compostas e boas práticas de implementação. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 15: Correção da NP1 e aprofundamento. Contexto da aula: Analisa os resultados da NP1, corrige erros recorrentes e reforça decisões compostas com exercícios direcionados. Objetivo central: Transformar o feedback da NP1 em plano de melhoria, revisando condicionais compostas e boas práticas de implementação. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "avaliacao", "condicionais", "revisao"],
       "tips": [
-        "Peça variações de atividades que reforcem apresentar panorama geral das notas e dos critérios avaliados na np1.",
-        "Solicite exemplos adicionais relacionados a condicionais, revisao.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem corrigir coletivamente os erros mais frequentes identificados nas questões."
+        "Peça ao assistente variações de exercícios que reforcem apresentar panorama geral das notas e dos critérios avaliados na np1.",
+        "Solicite exemplos adicionais relacionados a condicionais, revisao para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a corrigir coletivamente os erros mais frequentes identificados nas questões."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-16.json
+++ b/src/content/courses/algi/lessons/lesson-16.json
@@ -146,15 +146,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Atividade Prática Assíncrona – Condicionais",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 16: Atividade Prática Assíncrona – Condicionais. Contexto da aula: Aplica condicionais compostas em um miniaplicativo de triagem, documentando decisões, testes e evidências de entrega. Objetivo central: Conduzir uma atividade autônoma que consolide condicionais aninhadas, operadores lógicos e planejamento de testes. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 16: Atividade Prática Assíncrona – Condicionais. Contexto da aula: Aplica condicionais compostas em um miniaplicativo de triagem, documentando decisões, testes e evidências de entrega. Objetivo central: Conduzir uma atividade autônoma que consolide condicionais aninhadas, operadores lógicos e planejamento de testes. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "assincrona", "atividade", "condicionais"],
       "tips": [
-        "Peça variações de atividades que reforcem revisar requisitos funcionais de um fluxo de triagem clínica.",
-        "Solicite exemplos adicionais relacionados a condicionais, atividade.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem desenhar fluxogramas que reflitam decisões exclusivas e caminhos alternativos."
+        "Peça ao assistente variações de exercícios que reforcem revisar requisitos funcionais de um fluxo de triagem clínica.",
+        "Solicite exemplos adicionais relacionados a condicionais, atividade para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a desenhar fluxogramas que reflitam decisões exclusivas e caminhos alternativos."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-17.json
+++ b/src/content/courses/algi/lessons/lesson-17.json
@@ -108,15 +108,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Estrutura de Repetição while",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 17: Estrutura de Repetição while. Contexto da aula: Introduz laços while para repetir blocos enquanto condições permanecem verdadeiras, aplicando sentinelas e validações. Objetivo central: Compreender, modelar e implementar laços while controlados por condição e por sentinela. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 17: Estrutura de Repetição while. Contexto da aula: Introduz laços while para repetir blocos enquanto condições permanecem verdadeiras, aplicando sentinelas e validações. Objetivo central: Compreender, modelar e implementar laços while controlados por condição e por sentinela. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "loops", "repeticao", "while"],
       "tips": [
-        "Peça variações de atividades que reforcem identificar situações em que while é mais adequado que for ou decisões simples.",
-        "Solicite exemplos adicionais relacionados a loops, while.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem traduzir fluxogramas com laço enquanto em pseudocódigo/c."
+        "Peça ao assistente variações de exercícios que reforcem identificar situações em que while é mais adequado que for ou decisões simples.",
+        "Solicite exemplos adicionais relacionados a loops, while para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a traduzir fluxogramas com laço enquanto em pseudocódigo/c."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-18.json
+++ b/src/content/courses/algi/lessons/lesson-18.json
@@ -144,15 +144,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Estrutura de Repetição for",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 18: Estrutura de Repetição for. Contexto da aula: Explora o laço for para repetir instruções com contadores definidos, destacando inicialização, condição e atualização. Objetivo central: Planejar e implementar laços for para percorrer intervalos, vetores e produzir tabulações controladas. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 18: Estrutura de Repetição for. Contexto da aula: Explora o laço for para repetir instruções com contadores definidos, destacando inicialização, condição e atualização. Objetivo central: Planejar e implementar laços for para percorrer intervalos, vetores e produzir tabulações controladas. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "for", "loops", "repeticao"],
       "tips": [
-        "Peça variações de atividades que reforcem mapear os três componentes do for (inicialização, condição, atualização).",
-        "Solicite exemplos adicionais relacionados a loops, for.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem comparar equivalências entre for e while em exemplos reais."
+        "Peça ao assistente variações de exercícios que reforcem mapear os três componentes do for (inicialização, condição, atualização).",
+        "Solicite exemplos adicionais relacionados a loops, for para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a comparar equivalências entre for e while em exemplos reais."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-19.json
+++ b/src/content/courses/algi/lessons/lesson-19.json
@@ -102,15 +102,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Comparação entre for e while",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Comparação entre for e while. Contexto da aula: Discute critérios práticos para escolher entre for e while e como refatorar algoritmos sem alterar resultados. Objetivo central: Decidir com segurança entre for e while e justificar a refatoração escolhida para cada problema. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Comparação entre for e while. Contexto da aula: Discute critérios práticos para escolher entre for e while e como refatorar algoritmos sem alterar resultados. Objetivo central: Decidir com segurança entre for e while e justificar a refatoração escolhida para cada problema. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "boas-praticas", "comparacao", "loops"],
       "tips": [
-        "Peça variações de atividades que reforcem distinguir cenários ideais para laços controlados por contador e por condição.",
-        "Solicite exemplos adicionais relacionados a loops, comparacao.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem refatorar algoritmos simples convertendo entre for e while sem alterar resultados."
+        "Peça ao assistente variações de exercícios que reforcem distinguir cenários ideais para laços controlados por contador e por condição.",
+        "Solicite exemplos adicionais relacionados a loops, comparacao para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a refatorar algoritmos simples convertendo entre for e while sem alterar resultados."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-20.json
+++ b/src/content/courses/algi/lessons/lesson-20.json
@@ -108,15 +108,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Estrutura de repetição do-while",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Estrutura de repetição do-while. Contexto da aula: Apresenta o do-while em C para menus e validações que exigem uma execução inicial garantida. Objetivo central: Implementar menus que exigem execução inicial obrigatória usando do-while e validar todas as opções com feedback imediato. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Estrutura de repetição do-while. Contexto da aula: Apresenta o do-while em C para menus e validações que exigem uma execução inicial garantida. Objetivo central: Implementar menus que exigem execução inicial obrigatória usando do-while e validar todas as opções com feedback imediato. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "do-while", "loops", "menus"],
       "tips": [
-        "Peça variações de atividades que reforcem identificar problemas que exigem execução mínima antes da validação.",
-        "Solicite exemplos adicionais relacionados a loops, do-while.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem implementar menus interativos utilizando a estrutura do-while."
+        "Peça ao assistente variações de exercícios que reforcem identificar problemas que exigem execução mínima antes da validação.",
+        "Solicite exemplos adicionais relacionados a loops, do-while para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a implementar menus interativos utilizando a estrutura do-while."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-21.json
+++ b/src/content/courses/algi/lessons/lesson-21.json
@@ -100,15 +100,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Problemas com laços aninhados simples",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Problemas com laços aninhados simples. Contexto da aula: Integra laços aninhados para resolver problemas bidimensionais, produzindo tabelas e padrões em C. Objetivo central: Modelar e implementar laços aninhados que gerem estruturas 2D consistentes, avaliando custos e depurando erros comuns. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Problemas com laços aninhados simples. Contexto da aula: Integra laços aninhados para resolver problemas bidimensionais, produzindo tabelas e padrões em C. Objetivo central: Modelar e implementar laços aninhados que gerem estruturas 2D consistentes, avaliando custos e depurando erros comuns. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "aninhamento", "loops", "padroes"],
       "tips": [
-        "Peça variações de atividades que reforcem planejar estruturas de dados bidimensionais que dependem de laços aninhados.",
-        "Solicite exemplos adicionais relacionados a loops, aninhamento.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem implementar algoritmos com laços aninhados simples para tabulações e padrões visuais."
+        "Peça ao assistente variações de exercícios que reforcem planejar estruturas de dados bidimensionais que dependem de laços aninhados.",
+        "Solicite exemplos adicionais relacionados a loops, aninhamento para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a implementar algoritmos com laços aninhados simples para tabulações e padrões visuais."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-22.json
+++ b/src/content/courses/algi/lessons/lesson-22.json
@@ -110,15 +110,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Integrando Laços e Condicionais",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Integrando Laços e Condicionais. Contexto da aula: Integra estruturas de repetição com decisões complexas para tratar fluxos completos de processamento. Objetivo central: Construir rotinas robustas que combinem laços e condicionais com validação e relatórios de execução. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Integrando Laços e Condicionais. Contexto da aula: Integra estruturas de repetição com decisões complexas para tratar fluxos completos de processamento. Objetivo central: Construir rotinas robustas que combinem laços e condicionais com validação e relatórios de execução. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "condicionais", "integracao", "loops"],
       "tips": [
-        "Peça variações de atividades que reforcem mapear pontos de decisão dentro e fora de laços.",
-        "Solicite exemplos adicionais relacionados a loops, condicionais.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem implementar validações de entrada antes de iniciar ciclos."
+        "Peça ao assistente variações de exercícios que reforcem mapear pontos de decisão dentro e fora de laços.",
+        "Solicite exemplos adicionais relacionados a loops, condicionais para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a implementar validações de entrada antes de iniciar ciclos."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-23.json
+++ b/src/content/courses/algi/lessons/lesson-23.json
@@ -123,15 +123,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Atividade Assíncrona de Triagem Clínica",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Atividade Assíncrona de Triagem Clínica. Contexto da aula: Propõe atividade assíncrona integradora que combina laços, condicionais e registro de testes na simulação de triagem. Objetivo central: Planejar e executar a triagem automatizada cumprindo requisitos funcionais, documentação e entrega assíncrona. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Atividade Assíncrona de Triagem Clínica. Contexto da aula: Propõe atividade assíncrona integradora que combina laços, condicionais e registro de testes na simulação de triagem. Objetivo central: Planejar e executar a triagem automatizada cumprindo requisitos funcionais, documentação e entrega assíncrona. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "assincrona", "projeto", "triagem"],
       "tips": [
-        "Peça variações de atividades que reforcem interpretar o briefing de triagem e planejar o fluxo de decisão.",
-        "Solicite exemplos adicionais relacionados a assincrona, projeto.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem implementar algoritmo que percorre formulários e classifica pacientes."
+        "Peça ao assistente variações de exercícios que reforcem interpretar o briefing de triagem e planejar o fluxo de decisão.",
+        "Solicite exemplos adicionais relacionados a assincrona, projeto para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a implementar algoritmo que percorre formulários e classifica pacientes."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-24.json
+++ b/src/content/courses/algi/lessons/lesson-24.json
@@ -128,15 +128,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Síntese e Retrospectiva dos Laços",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Síntese e Retrospectiva dos Laços. Contexto da aula: Consolida aprendizados das aulas 19-23 com showcase da triagem, retroalimentação e plano de melhoria contínua. Objetivo central: Refletir sobre o ciclo de laços, compartilhar entregas da triagem e definir próximos passos de estudo. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Síntese e Retrospectiva dos Laços. Contexto da aula: Consolida aprendizados das aulas 19-23 com showcase da triagem, retroalimentação e plano de melhoria contínua. Objetivo central: Refletir sobre o ciclo de laços, compartilhar entregas da triagem e definir próximos passos de estudo. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "feedback", "planejamento", "retrospectiva"],
       "tips": [
-        "Peça variações de atividades que reforcem apresentar resultados da atividade assíncrona de triagem.",
-        "Solicite exemplos adicionais relacionados a retrospectiva, feedback.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem identificar boas práticas e pontos de melhoria nas soluções."
+        "Peça ao assistente variações de exercícios que reforcem apresentar resultados da atividade assíncrona de triagem.",
+        "Solicite exemplos adicionais relacionados a retrospectiva, feedback para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a identificar boas práticas e pontos de melhoria nas soluções."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-25.json
+++ b/src/content/courses/algi/lessons/lesson-25.json
@@ -143,15 +143,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Introdução a Funções e Modularização",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 25: Introdução a Funções e Modularização. Contexto da aula: Motiva a decomposição de programas em funções, introduzindo protótipos, escopo e primeiros padrões de modularização. Objetivo central: Compreender por que dividir o código em funções torna programas mais legíveis, testáveis e sustentáveis. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 25: Introdução a Funções e Modularização. Contexto da aula: Motiva a decomposição de programas em funções, introduzindo protótipos, escopo e primeiros padrões de modularização. Objetivo central: Compreender por que dividir o código em funções torna programas mais legíveis, testáveis e sustentáveis. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "c-basico", "funcoes", "modularizacao"],
       "tips": [
-        "Peça variações de atividades que reforcem identificar sinais de que um algoritmo deve ser quebrado em funções.",
-        "Solicite exemplos adicionais relacionados a funcoes, modularizacao.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem escrever protótipos simples com parâmetros e retorno."
+        "Peça ao assistente variações de exercícios que reforcem identificar sinais de que um algoritmo deve ser quebrado em funções.",
+        "Solicite exemplos adicionais relacionados a funcoes, modularizacao para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a escrever protótipos simples com parâmetros e retorno."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-26.json
+++ b/src/content/courses/algi/lessons/lesson-26.json
@@ -142,15 +142,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Funções com Parâmetros e Retorno",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 26: Funções com Parâmetros e Retorno. Contexto da aula: Explora assinatura completa de funções em C, analisando passagem de parâmetros por valor e por referência com foco em testes. Objetivo central: Aplicar parâmetros e valores de retorno para construir funções reutilizáveis que tratam entradas variadas com segurança. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 26: Funções com Parâmetros e Retorno. Contexto da aula: Explora assinatura completa de funções em C, analisando passagem de parâmetros por valor e por referência com foco em testes. Objetivo central: Aplicar parâmetros e valores de retorno para construir funções reutilizáveis que tratam entradas variadas com segurança. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "funcoes", "parametros", "ponteiros"],
       "tips": [
-        "Peça variações de atividades que reforcem comparar passagem por valor e por referência em c.",
-        "Solicite exemplos adicionais relacionados a funcoes, parametros.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem projetar funções que retornam códigos de erro ou resultados numéricos."
+        "Peça ao assistente variações de exercícios que reforcem comparar passagem por valor e por referência em c.",
+        "Solicite exemplos adicionais relacionados a funcoes, parametros para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a projetar funções que retornam códigos de erro ou resultados numéricos."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-27.json
+++ b/src/content/courses/algi/lessons/lesson-27.json
@@ -142,15 +142,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Programas Modulares com Múltiplas Funções",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 27: Programas Modulares com Múltiplas Funções. Contexto da aula: Integra funções em arquitetura modular com arquivos separados, headers e fluxo de compilação incremental. Objetivo central: Projetar um mini-sistema em C dividindo responsabilidades entre múltiplas funções e arquivos com headers dedicados. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 27: Programas Modulares com Múltiplas Funções. Contexto da aula: Integra funções em arquitetura modular com arquivos separados, headers e fluxo de compilação incremental. Objetivo central: Projetar um mini-sistema em C dividindo responsabilidades entre múltiplas funções e arquivos com headers dedicados. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "headers", "makefile", "modularizacao"],
       "tips": [
-        "Peça variações de atividades que reforcem planejar módulos e dependências utilizando canvas de design.",
-        "Solicite exemplos adicionais relacionados a modularizacao, headers.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem criar e incluir arquivos header com protótipos organizados."
+        "Peça ao assistente variações de exercícios que reforcem planejar módulos e dependências utilizando canvas de design.",
+        "Solicite exemplos adicionais relacionados a modularizacao, headers para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a criar e incluir arquivos header com protótipos organizados."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-28.json
+++ b/src/content/courses/algi/lessons/lesson-28.json
@@ -131,15 +131,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Boas Práticas e Manutenção de Funções",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Boas Práticas e Manutenção de Funções. Contexto da aula: Consolida padrões de escrita, testes e documentação para funções em C, com foco em revisão de código e qualidade contínua. Objetivo central: Aplicar boas práticas de legibilidade, cobertura de testes e monitoramento de métricas em projetos modulares. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Boas Práticas e Manutenção de Funções. Contexto da aula: Consolida padrões de escrita, testes e documentação para funções em C, com foco em revisão de código e qualidade contínua. Objetivo central: Aplicar boas práticas de legibilidade, cobertura de testes e monitoramento de métricas em projetos modulares. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "boas-praticas", "qualidade", "testes"],
       "tips": [
-        "Peça variações de atividades que reforcem avaliar código usando checklist de boas práticas.",
-        "Solicite exemplos adicionais relacionados a boas-praticas, qualidade.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem instrumentar funções com logs e medições simples."
+        "Peça ao assistente variações de exercícios que reforcem avaliar código usando checklist de boas práticas.",
+        "Solicite exemplos adicionais relacionados a boas-praticas, qualidade para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a instrumentar funções com logs e medições simples."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-29.json
+++ b/src/content/courses/algi/lessons/lesson-29.json
@@ -42,15 +42,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Avaliação NP2",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 29: Avaliação NP2. Contexto da aula: Avaliação escrita que sintetiza estruturas condicionais, laços de repetição e modularização com funções em problemas contextualizados. Objetivo central: Avaliar a capacidade de aplicar if/else encadeados, operadores lógicos e estruturas de repetição (while, for, do-while), bem como a modularização com funções (parâmetros, retorno e boas práticas de escopo/protótipos) em problemas práticos de pequena escala. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 29: Avaliação NP2. Contexto da aula: Avaliação escrita que sintetiza estruturas condicionais, laços de repetição e modularização com funções em problemas contextualizados. Objetivo central: Avaliar a capacidade de aplicar if/else encadeados, operadores lógicos e estruturas de repetição (while, for, do-while), bem como a modularização com funções (parâmetros, retorno e boas práticas de escopo/protótipos) em problemas práticos de pequena escala. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "avaliacao", "estruturas-de-controle"],
       "tips": [
-        "Peça variações de atividades que reforcem aplicar condicionais encadeadas em algoritmos de tomada de decisão.",
-        "Solicite exemplos adicionais relacionados a avaliacao, algoritmos.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem combinar laços de repetição com contadores e acumuladores."
+        "Peça ao assistente variações de exercícios que reforcem aplicar condicionais encadeadas em algoritmos de tomada de decisão.",
+        "Solicite exemplos adicionais relacionados a avaliacao, algoritmos para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a combinar laços de repetição com contadores e acumuladores."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-30.json
+++ b/src/content/courses/algi/lessons/lesson-30.json
@@ -139,15 +139,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Introdução a Vetores",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Introdução a Vetores. Contexto da aula: Apresenta o conceito de vetores (arrays) em C, destacando sua utilidade na organização de dados homogêneos e no cálculo de estatísticas básicas. Objetivo central: Reconhecer vetores como estruturas de dados fundamentais, compreender sua sintaxe em C e aplicar percursos lineares para obter estatísticas simples. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Introdução a Vetores. Contexto da aula: Apresenta o conceito de vetores (arrays) em C, destacando sua utilidade na organização de dados homogêneos e no cálculo de estatísticas básicas. Objetivo central: Reconhecer vetores como estruturas de dados fundamentais, compreender sua sintaxe em C e aplicar percursos lineares para obter estatísticas simples. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "arrays", "estatistica-basica", "vetores"],
       "tips": [
-        "Peça variações de atividades que reforcem declarar e inicializar vetores em c respeitando tipos e tamanhos.",
-        "Solicite exemplos adicionais relacionados a vetores, arrays.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem percorrer vetores com loops for para calcular média, mínimo e máximo."
+        "Peça ao assistente variações de exercícios que reforcem declarar e inicializar vetores em c respeitando tipos e tamanhos.",
+        "Solicite exemplos adicionais relacionados a vetores, arrays para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a percorrer vetores com loops for para calcular média, mínimo e máximo."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-31.json
+++ b/src/content/courses/algi/lessons/lesson-31.json
@@ -148,15 +148,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Operações e Transformações com Vetores",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Operações e Transformações com Vetores. Contexto da aula: Explora padrões de somatório, normalização e geração de tabelas a partir de vetores, consolidando o domínio de loops e acumuladores. Objetivo central: Aplicar percursos sobre vetores para executar operações agregadas e construir tabelas de frequência ou rankings simples. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Operações e Transformações com Vetores. Contexto da aula: Explora padrões de somatório, normalização e geração de tabelas a partir de vetores, consolidando o domínio de loops e acumuladores. Objetivo central: Aplicar percursos sobre vetores para executar operações agregadas e construir tabelas de frequência ou rankings simples. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "arrays", "operacoes", "vetores"],
       "tips": [
-        "Peça variações de atividades que reforcem implementar funções para somar, normalizar e copiar vetores.",
-        "Solicite exemplos adicionais relacionados a vetores, arrays.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem construir tabelas de frequência a partir de dados numéricos."
+        "Peça ao assistente variações de exercícios que reforcem implementar funções para somar, normalizar e copiar vetores.",
+        "Solicite exemplos adicionais relacionados a vetores, arrays para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a construir tabelas de frequência a partir de dados numéricos."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-32.json
+++ b/src/content/courses/algi/lessons/lesson-32.json
@@ -168,15 +168,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Buscas em Vetores",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Buscas em Vetores. Contexto da aula: Introduz algoritmos de busca linear e variantes com sentinela, conectando-os a cenários de catálogo e relatórios. Objetivo central: Selecionar e implementar estratégias de busca apropriadas para localizar elementos em vetores não ordenados. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Buscas em Vetores. Contexto da aula: Introduz algoritmos de busca linear e variantes com sentinela, conectando-os a cenários de catálogo e relatórios. Objetivo central: Selecionar e implementar estratégias de busca apropriadas para localizar elementos em vetores não ordenados. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "arrays", "busca", "vetores"],
       "tips": [
-        "Peça variações de atividades que reforcem implementar busca linear tradicional e com sentinela.",
-        "Solicite exemplos adicionais relacionados a vetores, busca.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem analisar custo temporal das buscas e seu impacto em coleções grandes."
+        "Peça ao assistente variações de exercícios que reforcem implementar busca linear tradicional e com sentinela.",
+        "Solicite exemplos adicionais relacionados a vetores, busca para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a analisar custo temporal das buscas e seu impacto em coleções grandes."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-33.json
+++ b/src/content/courses/algi/lessons/lesson-33.json
@@ -135,15 +135,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Matrizes 2D e Geração de Tabelas",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Matrizes 2D e Geração de Tabelas. Contexto da aula: Apresenta matrizes bidimensionais em C para organizar dados tabulares e gerar relatórios estruturados. Objetivo central: Compreender a representação de matrizes 2D, percorrer linhas e colunas com loops aninhados e montar tabelas formatadas. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Matrizes 2D e Geração de Tabelas. Contexto da aula: Apresenta matrizes bidimensionais em C para organizar dados tabulares e gerar relatórios estruturados. Objetivo central: Compreender a representação de matrizes 2D, percorrer linhas e colunas com loops aninhados e montar tabelas formatadas. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "arrays", "loops-aninhados", "matrizes"],
       "tips": [
-        "Peça variações de atividades que reforcem declarar matrizes estáticas e inicializá-las com dados reais.",
-        "Solicite exemplos adicionais relacionados a matrizes, arrays.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem percorrer linhas e colunas utilizando loops aninhados."
+        "Peça ao assistente variações de exercícios que reforcem declarar matrizes estáticas e inicializá-las com dados reais.",
+        "Solicite exemplos adicionais relacionados a matrizes, arrays para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a percorrer linhas e colunas utilizando loops aninhados."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-34.json
+++ b/src/content/courses/algi/lessons/lesson-34.json
@@ -165,15 +165,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Manipulações com Matrizes",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Manipulações com Matrizes. Contexto da aula: Aprofunda o trabalho com matrizes 2D realizando transposição, somas e multiplicação para resolver problemas de relatórios e transformações. Objetivo central: Aplicar operações clássicas de matrizes para gerar indicadores combinados e preparar o terreno para algoritmos de processamento de imagens e dados. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Manipulações com Matrizes. Contexto da aula: Aprofunda o trabalho com matrizes 2D realizando transposição, somas e multiplicação para resolver problemas de relatórios e transformações. Objetivo central: Aplicar operações clássicas de matrizes para gerar indicadores combinados e preparar o terreno para algoritmos de processamento de imagens e dados. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "arrays", "matrizes", "multiplicacao"],
       "tips": [
-        "Peça variações de atividades que reforcem implementar funções para transpor e somar matrizes.",
-        "Solicite exemplos adicionais relacionados a matrizes, arrays.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem executar multiplicação matricial com três loops."
+        "Peça ao assistente variações de exercícios que reforcem implementar funções para transpor e somar matrizes.",
+        "Solicite exemplos adicionais relacionados a matrizes, arrays para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a executar multiplicação matricial com três loops."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-35.json
+++ b/src/content/courses/algi/lessons/lesson-35.json
@@ -136,15 +136,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Introdução a Structs (Registros)",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Introdução a Structs (Registros). Contexto da aula: Apresenta structs em C como registros compostos e conduz um CRUD básico em memória para consolidar o modelo de dados. Objetivo central: Compreender a declaração, instância e manipulação inicial de structs em C, preparando-se para coleções de registros. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Introdução a Structs (Registros). Contexto da aula: Apresenta structs em C como registros compostos e conduz um CRUD básico em memória para consolidar o modelo de dados. Objetivo central: Compreender a declaração, instância e manipulação inicial de structs em C, preparando-se para coleções de registros. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "crud", "revisao", "structs"],
       "tips": [
-        "Peça variações de atividades que reforcem declarar structs com campos adequados ao domínio proposto.",
-        "Solicite exemplos adicionais relacionados a structs, crud.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem inicializar e acessar membros por ponto e ponteiros."
+        "Peça ao assistente variações de exercícios que reforcem declarar structs com campos adequados ao domínio proposto.",
+        "Solicite exemplos adicionais relacionados a structs, crud para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a inicializar e acessar membros por ponto e ponteiros."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-36.json
+++ b/src/content/courses/algi/lessons/lesson-36.json
@@ -168,15 +168,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Vetores de Structs",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Vetores de Structs. Contexto da aula: Constrói coleções de registros com structs em vetor e prepara o terreno para operações CRUD completas. Objetivo central: Estruturar vetores de structs para representar catálogos de dados e aplicar operações coletivas de ordenação e agregação. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Vetores de Structs. Contexto da aula: Constrói coleções de registros com structs em vetor e prepara o terreno para operações CRUD completas. Objetivo central: Estruturar vetores de structs para representar catálogos de dados e aplicar operações coletivas de ordenação e agregação. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "crud", "revisao", "structs"],
       "tips": [
-        "Peça variações de atividades que reforcem armazenar múltiplos registros em vetores de structs com limites configuráveis.",
-        "Solicite exemplos adicionais relacionados a structs, crud.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem aplicar ordenação simples para organizar a coleção."
+        "Peça ao assistente variações de exercícios que reforcem armazenar múltiplos registros em vetores de structs com limites configuráveis.",
+        "Solicite exemplos adicionais relacionados a structs, crud para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a aplicar ordenação simples para organizar a coleção."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-37.json
+++ b/src/content/courses/algi/lessons/lesson-37.json
@@ -153,15 +153,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Busca e Atualização em Vetores de Structs",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Busca e Atualização em Vetores de Structs. Contexto da aula: Refina o CRUD em memória adicionando buscas flexíveis, atualização de campos e estratégias de auditoria. Objetivo central: Desenvolver habilidades para localizar, atualizar e remover registros em vetores de structs, garantindo integridade dos dados. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Busca e Atualização em Vetores de Structs. Contexto da aula: Refina o CRUD em memória adicionando buscas flexíveis, atualização de campos e estratégias de auditoria. Objetivo central: Desenvolver habilidades para localizar, atualizar e remover registros em vetores de structs, garantindo integridade dos dados. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "crud", "revisao", "structs"],
       "tips": [
-        "Peça variações de atividades que reforcem implementar buscas lineares e por chave composta.",
-        "Solicite exemplos adicionais relacionados a structs, crud.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem atualizar campos selecionados mantendo histórico mínimo."
+        "Peça ao assistente variações de exercícios que reforcem implementar buscas lineares e por chave composta.",
+        "Solicite exemplos adicionais relacionados a structs, crud para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a atualizar campos selecionados mantendo histórico mínimo."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-38.json
+++ b/src/content/courses/algi/lessons/lesson-38.json
@@ -152,15 +152,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Revisão Gamificada do Semestre",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Revisão Gamificada do Semestre. Contexto da aula: Consolida conteúdos com dinâmica Jeopardy, ranking colaborativo e síntese dos aprendizados em squads. Objetivo central: Promover revisão abrangente dos conceitos-chave da disciplina por meio de atividades gamificadas e colaborativas. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Revisão Gamificada do Semestre. Contexto da aula: Consolida conteúdos com dinâmica Jeopardy, ranking colaborativo e síntese dos aprendizados em squads. Objetivo central: Promover revisão abrangente dos conceitos-chave da disciplina por meio de atividades gamificadas e colaborativas. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "crud", "revisao", "structs"],
       "tips": [
-        "Peça variações de atividades que reforcem relembrar tópicos centrais (fluxo sequencial, controle, funções, structs).",
-        "Solicite exemplos adicionais relacionados a structs, crud.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem aplicar conhecimento em desafios práticos e quizzes competitivos."
+        "Peça ao assistente variações de exercícios que reforcem relembrar tópicos centrais (fluxo sequencial, controle, funções, structs).",
+        "Solicite exemplos adicionais relacionados a structs, crud para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a aplicar conhecimento em desafios práticos e quizzes competitivos."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-39.json
+++ b/src/content/courses/algi/lessons/lesson-39.json
@@ -65,15 +65,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Avaliação NP3",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 39: Avaliação NP3. Contexto da aula: Avaliação integradora que cobre todo o percurso da disciplina, exigindo aplicação articulada de lógica, estruturas de dados básicas e modularização. Objetivo central: Avaliar de forma global o domínio dos conteúdos trabalhados ao longo do semestre, testando a capacidade do aluno de analisar problemas e implementar soluções completas em C, com estruturas de dados básicas. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 39: Avaliação NP3. Contexto da aula: Avaliação integradora que cobre todo o percurso da disciplina, exigindo aplicação articulada de lógica, estruturas de dados básicas e modularização. Objetivo central: Avaliar de forma global o domínio dos conteúdos trabalhados ao longo do semestre, testando a capacidade do aluno de analisar problemas e implementar soluções completas em C, com estruturas de dados básicas. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "avaliacao", "integrador"],
       "tips": [
-        "Peça variações de atividades que reforcem avaliar domínio de algoritmos sequenciais, condicionais e iterativos.",
-        "Solicite exemplos adicionais relacionados a avaliacao, algoritmos.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem verificar a manipulação correta de vetores, matrizes e registros."
+        "Peça ao assistente variações de exercícios que reforcem avaliar domínio de algoritmos sequenciais, condicionais e iterativos.",
+        "Solicite exemplos adicionais relacionados a avaliacao, algoritmos para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a verificar a manipulação correta de vetores, matrizes e registros."
       ]
     },
     {

--- a/src/content/courses/algi/lessons/lesson-40.json
+++ b/src/content/courses/algi/lessons/lesson-40.json
@@ -127,15 +127,15 @@
     {
       "type": "promptTip",
       "title": "Prompt para planejar Encerramento e Devolutiva",
-      "description": "Use com o assistente para gerar roteiros, exemplos e acompanhamentos alinhados à aula.",
-      "audience": "docentes de Algoritmos I",
-      "prompt": "Você é professor(a) de Algoritmos I preparando Aula 40: Encerramento e Devolutiva. Contexto da aula: Celebra entregas finais, devolve resultados das NPs e orienta trilhas futuras (Git e estruturas de dados) com recursos para estudo contínuo. Objetivo central: Encerrar o semestre consolidando aprendizados, oferecendo devolutivas personalizadas e mapeando próximos passos de desenvolvimento. Monte um plano dividido em preparação, condução em sala e acompanhamento pós-aula, indicando atividades práticas, exemplos em C ou pseudocódigo e perguntas diagnósticas que ajudem os estudantes a consolidar o conteúdo. Destaque estratégias de diferenciação para apoiar quem avança mais rápido e quem precisa de reforço.",
+      "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
+      "audience": "estudantes de Algoritmos I",
+      "prompt": "Você é estudante de Algoritmos I estudando Aula 40: Encerramento e Devolutiva. Contexto da aula: Celebra entregas finais, devolve resultados das NPs e orienta trilhas futuras (Git e estruturas de dados) com recursos para estudo contínuo. Objetivo central: Encerrar o semestre consolidando aprendizados, oferecendo devolutivas personalizadas e mapeando próximos passos de desenvolvimento. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
       "tags": ["algoritmos", "encerramento", "feedback", "planejamento"],
       "tips": [
-        "Peça variações de atividades que reforcem apresentar síntese dos resultados das avaliações (nps) e destacar evidências de evolução.",
-        "Solicite exemplos adicionais relacionados a encerramento, feedback.",
-        "Gere um checklist final com orientações para monitores acompanharem dúvidas recorrentes.",
-        "Peça sugestões de avaliação formativa que evidenciem promover showcase dos projetos finais com feedback estruturado e celebração da turma."
+        "Peça ao assistente variações de exercícios que reforcem apresentar síntese dos resultados das avaliações (nps) e destacar evidências de evolução.",
+        "Solicite exemplos adicionais relacionados a encerramento, feedback para praticar.",
+        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
+        "Peça sugestões de autoavaliação que ajudem você a promover showcase dos projetos finais com feedback estruturado e celebração da turma."
       ]
     },
     {


### PR DESCRIPTION
## Summary
- switch the prompt tip tag list to a responsive CSS grid so chips use horizontal space more efficiently

## Testing
- not run (content-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e11ea27cd4832cbc91071181f8d5f0