### PR TITLE
Refactor Md3Table styling

### DIFF
--- a/src/components/lesson/Md3Table.vue
+++ b/src/components/lesson/Md3Table.vue
@@ -1,14 +1,14 @@
 <template>
-  <div class="card md-elevation-2">
-    <div class="overflow-x-auto -mx-2 sm:mx-0">
-      <table class="w-full md3-table min-w-[480px]">
-        <thead class="bg-surface-variant text-on-surface-variant">
+  <section class="md3-table-card md-elevation-2 card">
+    <div class="md3-table-scroll" role="region" aria-live="polite">
+      <table class="md3-table" role="table">
+        <thead class="md3-table__head bg-surface-variant text-on-surface-variant">
           <tr>
             <th
               v-for="(header, index) in headers"
               :key="index"
-              class="text-left font-semibold"
-              :style="{ padding: 'var(--md-sys-spacing-3)' }"
+              scope="col"
+              class="md3-table__header"
             >
               {{ header }}
             </th>
@@ -18,23 +18,28 @@
           <tr
             v-for="(row, rowIndex) in rows"
             :key="rowIndex"
-            class="border-b border-outline-variant"
+            class="md3-table__row border-b border-outline-variant"
           >
-            <td
-              v-for="(cell, cellIndex) in row"
-              :key="cellIndex"
-              class="text-on-surface"
-              :style="{ padding: 'var(--md-sys-spacing-3)' }"
-            >
-              <span v-if="cell.mono" class="font-mono text-body-small">{{ cell.value }}</span>
-              <span v-else-if="cell.code" class="inline-code">{{ cell.value }}</span>
-              <span v-else>{{ cell.value }}</span>
+            <td v-for="(cell, cellIndex) in row" :key="cellIndex" class="md3-table__cell">
+              <span
+                :class="[
+                  'md3-table__cell-content',
+                  {
+                    'md3-table__cell-content--mono': cell.mono,
+                    'md3-table__cell-content--code': cell.code,
+                    'font-mono': cell.mono,
+                    'inline-code': cell.code,
+                  },
+                ]"
+              >
+                {{ cell.value }}
+              </span>
             </td>
           </tr>
         </tbody>
       </table>
     </div>
-  </div>
+  </section>
 </template>
 
 <script setup lang="ts">
@@ -55,20 +60,110 @@ defineProps<Md3TableProps>();
 </script>
 
 <style scoped>
-.md3-table th,
-.md3-table td {
-  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+.md3-table-card {
+  background: var(--md-sys-color-surface, #fff);
+  border-radius: var(--md-sys-shape-corner-large, 1rem);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  overflow: hidden;
 }
 
-.md3-table tbody tr:last-child td {
+.md3-table-scroll {
+  overflow-x: auto;
+  padding: var(--md-sys-spacing-2) var(--md-sys-spacing-3);
+  scrollbar-width: thin;
+}
+
+.md3-table-scroll::-webkit-scrollbar {
+  height: 8px;
+}
+
+.md3-table-scroll::-webkit-scrollbar-thumb {
+  background-color: color-mix(in srgb, var(--md-sys-color-outline) 60%, transparent);
+  border-radius: 9999px;
+}
+
+.md3-table {
+  width: 100%;
+  min-width: clamp(360px, 100%, 960px);
+  border-collapse: collapse;
+}
+
+.md3-table thead {
+  background: var(--md-sys-color-surface-container-highest);
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.md3-table__header {
+  text-align: left;
+  font: var(
+    --md-sys-typescale-title-small-font,
+    600 1rem/1.5 var(--md-ref-typeface-plain, 'Roboto', sans-serif)
+  );
+  letter-spacing: var(--md-sys-typescale-title-small-tracking, 0.005em);
+  padding: var(--md-sys-spacing-4) var(--md-sys-spacing-5);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  white-space: nowrap;
+}
+
+.md3-table__row {
+  background: var(--md-sys-color-surface);
+  transition: background-color 120ms ease-in-out;
+}
+
+.md3-table__row:nth-child(even) {
+  background: var(--md-sys-color-surface-container-high);
+}
+
+.md3-table__row:hover {
+  background: var(--md-sys-color-surface-container-highest);
+}
+
+.md3-table__cell {
+  padding: var(--md-sys-spacing-4) var(--md-sys-spacing-5);
+  color: var(--md-sys-color-on-surface);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  vertical-align: top;
+  word-break: break-word;
+}
+
+.md3-table__row:last-child .md3-table__cell {
   border-bottom: none;
 }
 
-.md3-table .inline-code {
+.md3-table__cell-content {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--md-sys-spacing-2);
+  font: var(
+    --md-sys-typescale-body-medium-font,
+    400 0.9375rem/1.5 var(--md-ref-typeface-plain, 'Roboto', sans-serif)
+  );
+}
+
+.md3-table__cell-content--mono,
+.font-mono {
+  font-family: var(--md-ref-typeface-code, 'Roboto Mono', monospace);
+  font-size: var(--md-sys-typescale-body-small-size, 0.875rem);
+}
+
+.md3-table__cell-content--code,
+.inline-code {
+  font-family: var(--md-ref-typeface-code, 'Roboto Mono', monospace);
   background-color: var(--md-sys-color-surface-variant);
+  color: var(--md-sys-color-on-surface-variant);
   padding: var(--md-sys-spacing-1) var(--md-sys-spacing-2);
-  border-radius: 0.25rem;
-  font-family: var(--md-sys-typescale-body-small-font);
-  font-size: var(--md-sys-typescale-body-small-size);
+  border-radius: var(--md-sys-shape-corner-extra-small, 0.375rem);
+  font-size: var(--md-sys-typescale-body-small-size, 0.875rem);
+}
+
+@media (max-width: 640px) {
+  .md3-table-scroll {
+    padding-inline: var(--md-sys-spacing-2);
+  }
+
+  .md3-table__header,
+  .md3-table__cell {
+    padding-inline: var(--md-sys-spacing-3);
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- restyle Md3Table with an MD3 card container, responsive scroll area, and zebra-row feedback to prevent overflowing content
- align cell rendering with dedicated MD3 typography while retaining legacy class hooks for mono and code cells

## Testing
- npm run test -- Md3Table

------
https://chatgpt.com/codex/tasks/task_e_68e11f782928832ca4b63c576e2f02b5