### PR TITLE
Atualiza aulas 28 e 30-32 com estudos de caso e datasets

### DIFF
--- a/src/content/courses/ddm/lessons/lesson-28.json
+++ b/src/content/courses/ddm/lessons/lesson-28.json
@@ -86,7 +86,7 @@
         {
           "icon": "check-circle",
           "title": "(30 min) Estudo de caso",
-          "content": "benchmark de apps brasileiros e internacionais."
+          "content": "benchmark de apps brasileiros e internacionais + refatoração com protótipos e escopos."
         },
         {
           "icon": "check-circle",
@@ -97,6 +97,45 @@
           "icon": "check-circle",
           "title": "20 min",
           "content": "Socialização e feedback cruzado + alinhamento da TED da semana."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Estudo de caso de refatoração com protótipos e escopos",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Analise um app legado que será migrado para uma arquitetura multiplataforma, observando como os protótipos e os escopos de cada squad orientam a refatoração."
+        },
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Contexto: marketplace de varejo com telas duplicadas em Android nativo e React Native, sofrendo com inconsistências de layout."
+            },
+            {
+              "text": "Escopo original: squads separados por plataforma, pouca sincronia em componentes compartilhados."
+            },
+            {
+              "text": "Escopo proposto: squad unificado responsável pelo design system e pelas features críticas, com capítulos de plataforma apoiando integrações específicas."
+            }
+          ]
+        },
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Slide Antes – Protótipo fragmentado com componentes divergentes entre Android e iOS; responsabilidades difusas entre squads."
+            },
+            {
+              "text": "Slide Depois – Protótipo consolidado em Figma com tokens MD3 reutilizados e escopos revisados destacando owners de cada módulo."
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "text": "Oriente a turma a comparar os slides antes/depois, mapeando o impacto nos fluxos críticos e na definição de responsabilidades para a refatoração incremental."
         }
       ]
     },

--- a/src/content/courses/ddm/lessons/lesson-30.json
+++ b/src/content/courses/ddm/lessons/lesson-30.json
@@ -213,6 +213,49 @@
     },
     {
       "type": "contentBlock",
+      "title": "Dataset base para revisão manual",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Antes da avaliação, revise arrays e manipulação de dados utilizando o mini dataset de métricas coletadas na sprint anterior."
+        },
+        {
+          "type": "codeBlock",
+          "language": "plaintext",
+          "code": "tela,tempo_render_ms,erros_ui,feedbacks_positivos\nHome,180,2,14\nCarrinho,240,5,9\nCheckout,310,3,11\nPerfil,150,1,7"
+        },
+        {
+          "type": "paragraph",
+          "text": "Transcreva manualmente os valores para vetores (ex.: `const tempos = [180, 240, 310, 150]`) e confirme se consegue calcular médias e desvios simples sem depender de bibliotecas adicionais."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Exercício guiado de estatísticas resumidas",
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "1. Organize os vetores `tempos`, `erros` e `feedbacks` a partir do dataset e valide-os com `console.log`."
+            },
+            {
+              "text": "2. Calcule tempo médio de renderização, taxa de erro por tela e porcentagem de feedbacks positivos usando apenas operações com arrays."
+            },
+            {
+              "text": "3. Registre os resultados em uma tabela no caderno ou editor de texto, identificando telas críticas para refatoração."
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "text": "Tarefa complementar: replique a tabela em uma planilha, gere um gráfico de colunas com `tempo_render_ms` e uma linha de tendência para `erros_ui`, anexando a visualização na reflexão pós-prova."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
       "title": "Exemplo de código comentado",
       "content": [
         {

--- a/src/content/courses/ddm/lessons/lesson-31.json
+++ b/src/content/courses/ddm/lessons/lesson-31.json
@@ -191,15 +191,58 @@
           "type": "unorderedList",
           "items": [
             {
-              "text": "Design do fluxo | Refinar mapa de telas e estados. | Responsáveis: Grupo | Duração: 1.5h | Atividades: Atualizar wireflow | Entregáveis: Wireflow atualizado | Riscos: Fluxo divergente (Validar com o professor orientador antes de codificar.) | Checkpoints: Fluxo aprovado"
+              "text": "Design do fluxo | Refinar mapa de telas e estados. | Responsáveis: Grupo | Duração: 1.5h | Atividades: Atualizar wireflow; Planejar coleta de eventos em vetores | Entregáveis: Wireflow atualizado | Riscos: Fluxo divergente (Validar com o professor orientador antes de codificar.) | Checkpoints: Fluxo aprovado, Vetores planejados"
             },
             {
-              "text": "Implementação | Codificar rotas e componentes. | Responsáveis: Grupo | Duração: 4h | Atividades: Criar Stack principal; Configurar Tabs | Entregáveis: Pull request aberto | Riscos: Conflitos de merge (Sincronizar branches diariamente e usar feature flags.) | Checkpoints: Rotas principais funcionais"
+              "text": "Implementação | Codificar rotas e componentes. | Responsáveis: Grupo | Duração: 4h | Atividades: Criar Stack principal; Configurar Tabs; Registrar arrays de acessos e tempos de tela | Entregáveis: Pull request aberto | Riscos: Conflitos de merge (Sincronizar branches diariamente e usar feature flags.) | Checkpoints: Rotas principais funcionais, Arrays preenchidos"
             },
             {
-              "text": "Validação | Revisar acessibilidade e deep linking. | Responsáveis: Grupo | Duração: 1h | Atividades: Rodar testes; Solicitar revisão | Entregáveis: Checklist de acessibilidade | Riscos: Itens não conformes (Usar leitores de tela e ajustes sugeridos na aula.) | Checkpoints: Deep link ok, Checklist aprovado"
+              "text": "Validação | Revisar acessibilidade e deep linking. | Responsáveis: Grupo | Duração: 1h | Atividades: Rodar testes; Solicitar revisão; Interpretar estatísticas de navegação armazenadas em vetores | Entregáveis: Checklist de acessibilidade | Riscos: Itens não conformes (Usar leitores de tela e ajustes sugeridos na aula.) | Checkpoints: Deep link ok, Checklist aprovado, Estatísticas interpretadas"
             }
           ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Dataset amostral de navegação",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Utilize o conjunto abaixo para praticar leitura manual e popular vetores com dados de navegação coletados via analytics caseiro."
+        },
+        {
+          "type": "codeBlock",
+          "language": "plaintext",
+          "code": "rota,acessos,duracao_media_seg,erros_acessibilidade\n/home,420,48,1\n/catalogo,310,67,3\n/carrinho,185,75,4\n/perfil,260,52,2"
+        },
+        {
+          "type": "paragraph",
+          "text": "Transfira manualmente as colunas para vetores (`const acessos = [420, 310, 185, 260]`) e avalie em qual rota a refatoração de escopo deve priorizar ajustes de navegação."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Exercício guiado: estatísticas de navegação",
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "1. Monte vetores com acessos, duração média e erros, conferindo se o índice de cada vetor corresponde à mesma rota."
+            },
+            {
+              "text": "2. Calcule médias, máximo/mínimo e uma taxa de erro (`erros_acessibilidade / acessos`) utilizando apenas métodos nativos de arrays."
+            },
+            {
+              "text": "3. Documente insights (ex.: rotas com tempo acima de 60s) para direcionar a revisão de protótipos e escopos."
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "text": "Tarefa complementar: replique o dataset em uma planilha, crie um gráfico combinado (colunas para acessos, linha para erros) e compartilhe a visualização na thread da turma."
         }
       ]
     },

--- a/src/content/courses/ddm/lessons/lesson-32.json
+++ b/src/content/courses/ddm/lessons/lesson-32.json
@@ -191,15 +191,58 @@
           "type": "unorderedList",
           "items": [
             {
-              "text": "Briefing com o backend | Entender contratos e limites. | Responsáveis: Grupo | Duração: 1h | Atividades: Reunião com squad backend | Entregáveis: Notas compartilhadas | Riscos: Mudança de contrato (Registrar versão e acompanhar change log do backend.) | Checkpoints: Contratos confirmados"
+              "text": "Briefing com o backend | Entender contratos e limites. | Responsáveis: Grupo | Duração: 1h | Atividades: Reunião com squad backend; Definir vetores para armazenar amostras de dados | Entregáveis: Notas compartilhadas | Riscos: Mudança de contrato (Registrar versão e acompanhar change log do backend.) | Checkpoints: Contratos confirmados, Vetores planejados"
             },
             {
-              "text": "Desenvolvimento | Codificar hooks, componentes e estados. | Responsáveis: Grupo | Duração: 4h | Atividades: Criar hook; Atualizar UI | Entregáveis: Branch `feature/api-integration` | Riscos: Instabilidade da API (Configurar retries exponenciais e mocks locais.) | Checkpoints: Hook funcional, UI atualizada"
+              "text": "Desenvolvimento | Codificar hooks, componentes e estados. | Responsáveis: Grupo | Duração: 4h | Atividades: Criar hook; Atualizar UI; Popular vetores com respostas e tempos de sincronização | Entregáveis: Branch `feature/api-integration` | Riscos: Instabilidade da API (Configurar retries exponenciais e mocks locais.) | Checkpoints: Hook funcional, UI atualizada, Vetores preenchidos"
             },
             {
-              "text": "Qualidade | Testes e documentação. | Responsáveis: Grupo | Duração: 1.5h | Atividades: Rodar testes; Atualizar docs | Entregáveis: Relatório de integração | Riscos: Atraso na documentação (Designar responsável específico para documentação desde o início.) | Checkpoints: Testes rodados, Relatório anexado"
+              "text": "Qualidade | Testes e documentação. | Responsáveis: Grupo | Duração: 1.5h | Atividades: Rodar testes; Atualizar docs; Interpretar métricas agregadas dos vetores (latência, taxa de erro) | Entregáveis: Relatório de integração | Riscos: Atraso na documentação (Designar responsável específico para documentação desde o início.) | Checkpoints: Testes rodados, Relatório anexado, Estatísticas interpretadas"
             }
           ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Dataset para leitura manual",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Simule respostas de API com o dataset abaixo e pratique a criação de vetores para análise offline antes da implementação definitiva."
+        },
+        {
+          "type": "codeBlock",
+          "language": "plaintext",
+          "code": "task_id,status,tempo_sync_ms,retries\n101,completed,420,1\n102,pending,610,2\n103,failed,890,3\n104,completed,530,1"
+        },
+        {
+          "type": "paragraph",
+          "text": "A partir do CSV, preencha vetores como `const temposSync = [420, 610, 890, 530]` e `const tentativas = [1, 2, 3, 1]` para validar cálculos de médias e limites antes de consumir o endpoint real."
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Exercício guiado de estatísticas de sincronização",
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "1. Monte vetores para `tempo_sync_ms`, `retries` e um vetor booleano indicando sucesso (`status === 'completed'`)."
+            },
+            {
+              "text": "2. Calcule média, mediana simples e maior tempo de sincronização utilizando apenas operações de array."
+            },
+            {
+              "text": "3. Registre percentuais de sucesso e falha para orientar estratégias de retry e cache."
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "text": "Tarefa complementar: exporte os vetores para uma planilha, crie um gráfico de barras empilhadas com status por tarefa e acrescente uma linha destacando a média de `tempo_sync_ms`."
         }
       ]
     },


### PR DESCRIPTION
## Summary
- acrescenta estudo de caso de refatoração com protótipos e escopos na aula 28, com comparação antes/depois
- prepara datasets manuais e exercícios guiados nas aulas 30 a 32 para reforçar análise de dados com vetores
- ajusta orientações das TEDs para incluir coleta, interpretação e visualizações em planilhas

## Testing
- not run (content changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e1594fe4a8832c90350c1f8827bf84