### PR TITLE
Estruturar squads e testes incrementais nas aulas 23-27 de ALGI

### DIFF
--- a/docs/didactics/modularizacao-boas-praticas.md
+++ b/docs/didactics/modularizacao-boas-praticas.md
@@ -1,0 +1,43 @@
+# Boas Práticas de Modularização para Moodle
+
+Este material deve ser disponibilizado no Moodle junto com os recursos das aulas 25 a 27 de Algoritmos I.
+
+## 1. Nomes Expressivos
+
+- Use verbos no infinitivo para funções que executam ações (`calcular_media`, `validar_paciente`).
+- Prefira substantivos claros para estruturas de dados (`Paciente`, `RelatorioFluxo`).
+- Evite abreviações enigmáticas; se precisar abreviar, registre o significado no comentário inicial do arquivo.
+
+## 2. Responsabilidade Única
+
+- Cada função deve ter um único motivo para mudar.
+- Evite mesclar leitura, processamento e saída na mesma função.
+- Utilize comentários curtos explicando o "porquê" da função, não o "como".
+
+## 3. Escopo Controlado
+
+- Limite variáveis globais a constantes ou configurações imutáveis.
+- Prefira variáveis locais e parâmetros explícitos para tornar dependências visíveis.
+- Use `static` em funções auxiliares declaradas no mesmo arquivo `.c` quando não forem reutilizadas externamente.
+
+## 4. Contratos Claros
+
+- Documente pré-condições e pós-condições antes da implementação.
+- Ao usar ponteiros, explique no comentário quem é responsável por alocar e liberar memória.
+- Anote efeitos colaterais relevantes (ex.: "atualiza contador global de pacientes").
+
+## 5. Integração Contínua de Testes
+
+- Inclua chamadas a `assert` imediatamente após implementar uma função para garantir comportamento esperado.
+- Mantenha suites de teste curtas dentro do arquivo de implementação enquanto o módulo está em desenvolvimento.
+- Registre no relatório de squad quais funções foram validadas automaticamente.
+
+## 6. Checklist para Revisão em Squad
+
+1. Funções nomeadas de forma consistente? (verbo no infinitivo)
+2. Responsabilidade única evidenciada no comentário inicial?
+3. Escopo das variáveis mais restrito possível?
+4. Há asserts cobrindo casos principais e limites?
+5. Documentação atualizada no relatório de fluxos e pseudocódigos?
+
+> Atualize este guia conforme feedbacks das squads e publique o link correspondente em cada aula no Moodle.

--- a/docs/didactics/templates/pseudocode-incremental-template.md
+++ b/docs/didactics/templates/pseudocode-incremental-template.md
@@ -1,0 +1,36 @@
+# Template de Pseudocódigo Incremental
+
+Este roteiro apoia a escrita de pseudocódigos por squads nas aulas 23 e 24.
+
+## Cabeçalho
+
+- **Objetivo do algoritmo:**
+- **Entradas:**
+- **Saídas:**
+- **Requisitos de validação:**
+
+## Versão Atual (vX)
+
+```
+PASSO 1: ...
+PASSO 2: ...
+```
+
+## Incremento Planejado
+
+1. **Hipótese de melhoria:** qual problema ou oportunidade o incremento resolve?
+2. **Funções impactadas:** liste nomes e responsabilidades.
+3. **Testes a rodar após o incremento:** descreva entradas, saídas esperadas e assertivas.
+
+## Comentários de Responsabilidade
+
+- Função `...`: responsabilidade principal, autor(a), revisor(a).
+- Função `...`: responsabilidade principal, autor(a), revisor(a).
+
+## Histórico de Atualizações
+
+| Data | Incremento | Responsável | Observações |
+| ---- | ---------- | ----------- | ----------- |
+|      |            |             |             |
+
+> Publique o pseudocódigo atualizado junto com o relatório de fluxos e referências aos commits no Moodle.

--- a/docs/didactics/templates/squad-flow-report-template.md
+++ b/docs/didactics/templates/squad-flow-report-template.md
@@ -1,0 +1,43 @@
+# Template de Relatório de Fluxos em Squad
+
+Use este modelo para documentar fluxos desenvolvidos pelas squads durante as aulas 23 e 24 de Algoritmos I.
+
+## 1. Identificação do Squad
+
+- **Nome da squad:**
+- **Integrantes e funções:** (facilitador/a, relator/a de testes, responsável por integração)
+- **Data da iteração:**
+
+## 2. Objetivo do Fluxo
+
+- Descreva o problema abordado e o resultado esperado pelo algoritmo.
+- Liste requisitos funcionais e não funcionais considerados pelo time.
+
+## 3. Visão Geral
+
+| Etapa                   | Responsável | Descrição resumida | Evidência (arquivo/link) |
+| ----------------------- | ----------- | ------------------ | ------------------------ |
+| Leitura de dados        |             |                    |                          |
+| Processamento principal |             |                    |                          |
+| Saída/relatório         |             |                    |                          |
+
+## 4. Fluxograma ou Mapa de Decisão
+
+Cole aqui o fluxograma exportado (imagem) ou o link para o diagrama colaborativo usado pela squad.
+
+## 5. Incrementos Entregues
+
+Para cada incremento, registre:
+
+- **Checkpoint:** descrição curta (ex.: "Validação de prioridade clínica").
+- **Alterações realizadas:** arquivos, funções ou pseudocódigos atualizados.
+- **Testes executados:** lista ou referência aos casos cobertos.
+- **Responsáveis:** quem desenvolveu e quem revisou.
+
+## 6. Aprendizados e Próximos Passos
+
+- O que funcionou bem na colaboração?
+- Quais funções precisam de nova refatoração?
+- Pendências para a próxima aula.
+
+> Compartilhe o relatório no Moodle anexando este arquivo em PDF ou Markdown junto aos códigos e pseudocódigos.

--- a/reports/content-validation-report.json
+++ b/reports/content-validation-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-10-03T19:06:50.490Z",
+  "generatedAt": "2025-10-04T17:34:01.666Z",
   "status": "passed-with-warnings",
   "totals": {
     "courses": 5,

--- a/src/content/courses/algi/lessons/lesson-23.json
+++ b/src/content/courses/algi/lessons/lesson-23.json
@@ -33,6 +33,16 @@
       "label": "Moodle — AVA (Unichristus)",
       "type": "plataforma",
       "url": "https://ava.unichristus.edu.br/"
+    },
+    {
+      "label": "Template de relatório de fluxos em squad",
+      "type": "template",
+      "url": "https://raw.githubusercontent.com/md3-content/edu/main/docs/didactics/templates/squad-flow-report-template.md"
+    },
+    {
+      "label": "Template de pseudocódigo incremental",
+      "type": "template",
+      "url": "https://raw.githubusercontent.com/md3-content/edu/main/docs/didactics/templates/pseudocode-incremental-template.md"
     }
   ],
   "bibliography": [
@@ -115,12 +125,45 @@
         {
           "icon": "tasks",
           "title": "Entregáveis",
-          "content": "Código C, CSV de saída, relatório de testes, reflexão no fórum."
+          "content": "Código C, CSV de saída, relatório de fluxos da squad, pseudocódigo incremental e reflexão no fórum."
         },
         {
           "icon": "users",
           "title": "Canais",
-          "content": "Fórum da disciplina + plantão remoto de 30 min na quarta-feira."
+          "content": "Fórum da disciplina + plantão remoto de 30 min na quarta-feira. Use para desbloquear squads e validar incrementos."
+        }
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Squads e papéis",
+      "cards": [
+        {
+          "title": "Facilitador/a",
+          "content": "Orienta checkpoints, garante uso dos templates e evita gargalos."
+        },
+        {
+          "title": "Responsável por testes",
+          "content": "Executa casos automatizados, registra asserts e evidências no relatório de fluxos."
+        },
+        {
+          "title": "Relator/a de pseudocódigo",
+          "content": "Atualiza o pseudocódigo incremental e comenta responsabilidades de cada função."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "good-practice",
+      "title": "Como organizar os incrementos",
+      "content": [
+        {
+          "type": "list",
+          "items": [
+            "Divida o backlog em incrementos de até 30 minutos registrados no template de fluxos.",
+            "Após cada incremento, valide a função tocada com `assert` e registre evidências.",
+            "Use o pseudocódigo incremental para planejar refatorações antes de alterar o C."
+          ]
         }
       ]
     },
@@ -304,19 +347,19 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Compacte código, fluxograma, planilha, relatório e reflexões em ALG1_A23_Nome.zip."
+          "text": "Compacte código, fluxograma, relatório de squad e pseudocódigos em ALG1_A23_SquadNome.zip."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Código em C com logs."
+              "text": "Código em C com commits incrementais e comentários nas funções explicando responsabilidades."
             },
             {
-              "text": "Fluxograma atualizado e checklist de testes."
+              "text": "Fluxograma atualizado utilizando o template de relatório de fluxos com evidências de testes."
             },
             {
-              "text": "Relatório final com métricas e autoavaliação."
+              "text": "Pseudocódigo incremental com histórico de incrementos e asserts executados."
             }
           ]
         }
@@ -359,16 +402,16 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Reserve um momento após a aula para concluir a atividade descrita a seguir. Ela complementa os estudos e ajuda a consolidar o que foi trabalhado em sala."
+          "text": "Planeje com sua squad a próxima rodada de refatoração incremental, registrando responsabilidades das funções e evidências de testes."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Desenvolva a prática proposta na aula registrando os passos e resultados no caderno ou no editor de sua preferência."
+              "text": "Atualize o pseudocódigo incremental com o próximo incremento, responsabilidades e asserts previstos."
             },
             {
-              "text": "Anote dúvidas e insights que surgirem para discutirmos na próxima aula."
+              "text": "Reforce no relatório de fluxos quais funções precisarão de novos comentários de propósito e quem irá executá-los."
             }
           ]
         }

--- a/src/content/courses/algi/lessons/lesson-24.json
+++ b/src/content/courses/algi/lessons/lesson-24.json
@@ -33,6 +33,16 @@
       "label": "Moodle — AVA (Unichristus)",
       "type": "plataforma",
       "url": "https://ava.unichristus.edu.br/"
+    },
+    {
+      "label": "Template de relatório de fluxos em squad",
+      "type": "template",
+      "url": "https://raw.githubusercontent.com/md3-content/edu/main/docs/didactics/templates/squad-flow-report-template.md"
+    },
+    {
+      "label": "Template de pseudocódigo incremental",
+      "type": "template",
+      "url": "https://raw.githubusercontent.com/md3-content/edu/main/docs/didactics/templates/pseudocode-incremental-template.md"
     }
   ],
   "bibliography": [
@@ -50,7 +60,7 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Em duplas ou trios, resolvam as questões a seguir para reforçar o aprendizado durante a aula."
+          "text": "Organizem-se em squads (até 4 pessoas) mantendo os papéis definidos na aula 23 e utilizem os templates publicados no repositório para registrar decisões."
         },
         {
           "type": "orderedList",
@@ -115,17 +125,17 @@
         {
           "icon": "book-open",
           "title": "Showcase",
-          "content": "Times apresentam artefatos da triagem (20 min)."
+          "content": "Squads apresentam fluxos e pseudocódigos atualizados (20 min)."
         },
         {
           "icon": "users",
           "title": "Feedback cruzado",
-          "content": "Trocar percepções usando Start/Stop/Continue (25 min)."
+          "content": "Trocar percepções usando Start/Stop/Continue com foco nos incrementos e responsabilidades (25 min)."
         },
         {
           "icon": "check-circle",
           "title": "Painel 360°",
-          "content": "Registrar evidências no board colaborativo (20 min)."
+          "content": "Registrar evidências no board colaborativo e anexar links para templates (20 min)."
         },
         {
           "icon": "target",
@@ -136,6 +146,24 @@
           "icon": "tasks",
           "title": "Encerramento",
           "content": "Orientar entrega no Moodle e próximos passos (10 min)."
+        }
+      ]
+    },
+    {
+      "type": "cardGrid",
+      "title": "Rotina das squads na retrospectiva",
+      "cards": [
+        {
+          "title": "Antes",
+          "content": "Atualize relatório de fluxos e pseudocódigo incremental com indicadores coletados."
+        },
+        {
+          "title": "Durante",
+          "content": "Apresente incrementos, compartilhe asserts executados e colete feedback 360°."
+        },
+        {
+          "title": "Depois",
+          "content": "Liste ações de refatoração incremental e responsáveis por cada função."
         }
       ]
     },
@@ -391,16 +419,16 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Reserve um momento após a aula para concluir a atividade descrita a seguir. Ela complementa os estudos e ajuda a consolidar o que foi trabalhado em sala."
+          "text": "Aplique a retrospectiva para planejar a próxima iteração de refatoração incremental registrando responsabilidades de cada função."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Desenvolva a prática proposta na aula registrando os passos e resultados no caderno ou no editor de sua preferência."
+              "text": "Atualize o relatório de fluxos indicando quais incrementos serão entregues na aula 25 e quem lidera cada um."
             },
             {
-              "text": "Anote dúvidas e insights que surgirem para discutirmos na próxima aula."
+              "text": "Revise o pseudocódigo incremental adicionando comentários de responsabilidade por função e testes planejados."
             }
           ]
         }

--- a/src/content/courses/algi/lessons/lesson-25.json
+++ b/src/content/courses/algi/lessons/lesson-25.json
@@ -32,6 +32,11 @@
       "label": "Moodle — AVA (Unichristus)",
       "type": "plataforma",
       "url": "https://ava.unichristus.edu.br/"
+    },
+    {
+      "label": "Boas práticas de modularização (Moodle)",
+      "type": "guide",
+      "url": "https://raw.githubusercontent.com/md3-content/edu/main/docs/didactics/modularizacao-boas-praticas.md"
     }
   ],
   "bibliography": [
@@ -216,6 +221,12 @@
       "code": "double calcular_media(double soma, int quantidade) {\n  if (quantidade <= 0) {\n    return 0.0;\n  }\n  return soma / quantidade;\n}\n\nint main(void) {\n  double media = calcular_media(42.0, 6);\n  printf(\"Media: %.2f\\n\", media);\n  return 0;\n}\n"
     },
     {
+      "type": "code",
+      "language": "c",
+      "title": "Testando imediatamente com assert.h",
+      "code": "#include <assert.h>\n\ndouble calcular_media(double soma, int quantidade); // protótipo conhecido do módulo\n\nvoid testar_calcular_media(void) {\n  assert(calcular_media(10.0, 2) == 5.0);\n  assert(calcular_media(0.0, 5) == 0.0);\n  assert(calcular_media(10.0, 0) == 0.0);\n}\n\nint main(void) {\n  testar_calcular_media();\n  // implementação segue com o restante do programa\n  return 0;\n}\n"
+    },
+    {
       "type": "checklist",
       "title": "Antes de entregar",
       "items": [
@@ -231,16 +242,16 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Reserve um momento após a aula para concluir a atividade descrita a seguir. Ela complementa os estudos e ajuda a consolidar o que foi trabalhado em sala."
+          "text": "Refatore incrementalmente o exercício da triagem dividindo responsabilidades em funções e registrando os testes com `assert` após cada alteração."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Desenvolva a prática proposta na aula registrando os passos e resultados no caderno ou no editor de sua preferência."
+              "text": "Atualize comentários de propósito nas funções criadas indicando responsabilidade e autor/a do incremento."
             },
             {
-              "text": "Anote dúvidas e insights que surgirem para discutirmos na próxima aula."
+              "text": "Anexe no Moodle o relatório de fluxos da squad destacando os commits e asserts executados."
             }
           ]
         }

--- a/src/content/courses/algi/lessons/lesson-26.json
+++ b/src/content/courses/algi/lessons/lesson-26.json
@@ -32,6 +32,11 @@
       "label": "Moodle — AVA (Unichristus)",
       "type": "plataforma",
       "url": "https://ava.unichristus.edu.br/"
+    },
+    {
+      "label": "Boas práticas de modularização (Moodle)",
+      "type": "guide",
+      "url": "https://raw.githubusercontent.com/md3-content/edu/main/docs/didactics/modularizacao-boas-praticas.md"
     }
   ],
   "bibliography": [
@@ -187,6 +192,12 @@
       ]
     },
     {
+      "type": "code",
+      "language": "c",
+      "title": "Suite rápida de asserts",
+      "code": "#include <assert.h>\n\nint validar_idade(int idade); // protótipo declarado em header\nvoid atualizar_saldo(double *saldo, double deposito);\n\nvoid testar_validacoes(void) {\n  assert(validar_idade(18) == 1);\n  assert(validar_idade(-1) == 0);\n\n  double carteira = 100.0;\n  atualizar_saldo(&carteira, 50.0);\n  assert(carteira == 150.0);\n}\n"
+    },
+    {
       "type": "checklist",
       "title": "Checklist de contratos",
       "items": [
@@ -202,16 +213,16 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Reserve um momento após a aula para concluir a atividade descrita a seguir. Ela complementa os estudos e ajuda a consolidar o que foi trabalhado em sala."
+          "text": "Implemente e refatore incrementalmente funções parametrizadas, documentando responsabilidades e anexando asserts que validem cada incremento."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Desenvolva a prática proposta na aula registrando os passos e resultados no caderno ou no editor de sua preferência."
+              "text": "No relatório da squad, descreva a sequência de incrementos (dados, processamento, saída) e respectivos responsáveis."
             },
             {
-              "text": "Anote dúvidas e insights que surgirem para discutirmos na próxima aula."
+              "text": "Atualize comentários das funções explicando contratos e cite os asserts usados para confirmar o comportamento."
             }
           ]
         }

--- a/src/content/courses/algi/lessons/lesson-27.json
+++ b/src/content/courses/algi/lessons/lesson-27.json
@@ -32,6 +32,11 @@
       "label": "Moodle — AVA (Unichristus)",
       "type": "plataforma",
       "url": "https://ava.unichristus.edu.br/"
+    },
+    {
+      "label": "Boas práticas de modularização (Moodle)",
+      "type": "guide",
+      "url": "https://raw.githubusercontent.com/md3-content/edu/main/docs/didactics/modularizacao-boas-praticas.md"
     }
   ],
   "bibliography": [
@@ -223,6 +228,12 @@
       ]
     },
     {
+      "type": "code",
+      "language": "c",
+      "title": "Asserts por módulo",
+      "code": "#include <assert.h>\n#include \"dominio.h\"\n#include \"relatorios.h\"\n\nstatic void testar_dominio(void) {\n  Paciente paciente = criar_paciente(\"Ana\", 32, 85);\n  assert(paciente.prioridade == PRIORIDADE_ALTA);\n}\n\nstatic void testar_relatorios(void) {\n  Relatorio rel = gerar_relatorio_resumo();\n  assert(rel.total_processado > 0);\n}\n\nvoid rodar_testes_modulares(void) {\n  testar_dominio();\n  testar_relatorios();\n}\n"
+    },
+    {
       "type": "checklist",
       "title": "Pronto para integrar",
       "items": [
@@ -238,16 +249,16 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Reserve um momento após a aula para concluir a atividade descrita a seguir. Ela complementa os estudos e ajuda a consolidar o que foi trabalhado em sala."
+          "text": "Estruture o mini-sistema em múltiplos arquivos realizando refatoração incremental e descrevendo a responsabilidade de cada função nos comentários e no relatório de squad."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Desenvolva a prática proposta na aula registrando os passos e resultados no caderno ou no editor de sua preferência."
+              "text": "Inclua na entrega um arquivo de testes com asserts agrupados por módulo e explique como executar cada bloco."
             },
             {
-              "text": "Anote dúvidas e insights que surgirem para discutirmos na próxima aula."
+              "text": "Atualize o relatório de fluxos destacando integrações realizadas, responsáveis e próximos incrementos planejados."
             }
           ]
         }


### PR DESCRIPTION
## Summary
- organizei as aulas 23 e 24 de Algoritmos I em squads, com novos papéis, templates de fluxo e orientações de documentação incremental
- acrescentei exemplos de testes com `assert.h` nas aulas 25 a 27 e ajustei os TEDs para exigir refatoração incremental com comentários de responsabilidade
- publiquei material de apoio sobre boas práticas de modularização para distribuição via Moodle

## Testing
- npm run validate:content

------
https://chatgpt.com/codex/tasks/task_e_68e159336a30832cb388adbf09506000