### PR TITLE
Redesenha hackathon da aula 38 e materiais da NP3

### DIFF
--- a/public/courses/tgs/hackathon-aula38-briefing.md
+++ b/public/courses/tgs/hackathon-aula38-briefing.md
@@ -1,0 +1,35 @@
+# Hackathon Aula 38 — Roadmap, Mudança e Comunicação
+
+## Contexto
+- **Cenário**: O PESI está pronto para liberar as ondas 3 e 4 do roadmap, com forte dependência das áreas de Operações e Customer Success.
+- **Patrocinador**: Diretoria Executiva (CIO + COO).
+- **Objetivo**: Demonstrar, em 110 minutos, que o time possui plano consistente para executar o roadmap, sustentar a adoção e comunicar decisões críticas ao board.
+
+## Entregáveis obrigatórios
+1. **Canvas do Roadmap Revisado**
+   - Prioridades das ondas 3 e 4 com dependências críticas e critérios de sucesso.
+   - Indicadores de ROI, valor esperado e riscos principais.
+2. **Plano de Mudança e Adoção**
+   - Ações por público-alvo, indicadores leading/lagging e donos definidos.
+   - Checkpoints futuros alinhados aos fóruns de governança.
+3. **Roteiro de Comunicação Executiva**
+   - Mensagens-chave por stakeholder (Board, Gestores, Times Operacionais, Parceiros).
+   - Call-to-action, canal e métrica de sucesso para cada mensagem.
+4. **Registro de Feedback 360°**
+   - Lições aprendidas, ajustes assumidos e dúvidas para a NP3.
+
+## Regras do hackathon
+- Squads de 4–5 pessoas com papéis rotativos (roadmap, mudança, comunicação, relatoria).
+- Checkpoints obrigatórios em 35' e 75' com validação do professor/monitor.
+- Pitch final de 3 minutos com foco em decisão executiva; máximo de 3 slides.
+- Toda a documentação deve ser anexada à planilha de checkpoints (`hackathon-aula38-checkpoints.csv`) antes do encerramento da aula.
+
+## Critérios de avaliação formativa
+| Pilar                     | Evidências esperadas                                                                 | Perguntas-guia                                                |
+|---------------------------|--------------------------------------------------------------------------------------|----------------------------------------------------------------|
+| Roadmap priorizado        | Dependências mapeadas, análise de riscos, indicadores financeiros atualizados       | "Quais decisões precisam ser tomadas nesta onda?"            |
+| Gestão da mudança         | Ações, owners, indicadores leading/lagging e plano de engajamento por stakeholder   | "Como garantimos adoção sustentável após o go-live?"         |
+| Comunicação executiva     | Narrativa consistente, dados de suporte e chamadas claras para cada stakeholder     | "Qual mensagem cada público precisa ouvir agora?"            |
+| Feedback e aprendizagem   | Registro de aprendizados, ajustes combinados e próximos passos individuais/coletivos | "Que reforços precisamos antes da NP3?"                      |
+
+> **Lembrete**: As mesmas dimensões serão utilizadas no simulado da Aula 39 e na banca da NP3 (Aula 40).

--- a/public/courses/tgs/hackathon-aula38-checkpoints.csv
+++ b/public/courses/tgs/hackathon-aula38-checkpoints.csv
@@ -1,0 +1,5 @@
+Checkpoint,Responsável,Sintonia com o pilar,Evidências anexadas,Status,Feedback imediato
+"CP1 – Hipóteses",Squad Leader,"Roadmap","Canvas atualizado, matriz de riscos, estimativa de ROI",Pendente,
+"CP2 – Prototipação",Change Owner,"Gestão da mudança","Backlog de ações com owners e indicadores leading",Pendente,
+"Pitch final",Comunicação,"Comunicação executiva","Script do pitch + deck de 3 slides",Pendente,
+"Retrospectiva",Relatoria,"Feedback e aprendizagem","Notas do feedback 360° e ações individuais",Pendente,

--- a/public/courses/tgs/modelo-plano-estudo-pos-np3.md
+++ b/public/courses/tgs/modelo-plano-estudo-pos-np3.md
@@ -1,0 +1,33 @@
+# Modelo de Plano de Estudo Pós-NP3
+
+Preencha as seções a seguir após receber o feedback do simulado (Aula 39) e da banca oficial (Aula 40).
+
+## 1. Diagnóstico rápido
+- **Pontos fortes identificados**:
+- **Lacunas prioritárias**:
+- **Evidências utilizadas (indicadores, feedbacks, rubricas)**:
+
+## 2. Metas para as próximas 4 semanas
+| Semana | Foco principal | Entrega esperada | Evidência de conclusão |
+|--------|----------------|------------------|------------------------|
+| 1 | | | |
+| 2 | | | |
+| 3 | | | |
+| 4 | | | |
+
+## 3. Trilhas e recursos complementares
+- Leituras (capítulo/página):
+- Vídeos/podcasts:
+- Mentorias ou monitorias agendadas:
+
+## 4. Aplicação prática
+- Estudos de caso / simulados adicionais:
+- Indicadores a monitorar:
+- Checklist de revisão antes da próxima avaliação:
+
+## 5. Plano de acompanhamento com a coordenação
+- Data da próxima checagem:
+- Responsável pelo acompanhamento:
+- Evidências que serão compartilhadas (planilhas, fóruns, relatórios):
+
+> **Dica**: Anexe este plano ao fórum "Plano de continuidade" no Moodle e atualize o status a cada semana.

--- a/public/courses/tgs/moodle-continuacao-estudos.md
+++ b/public/courses/tgs/moodle-continuacao-estudos.md
@@ -1,0 +1,26 @@
+# Postagem Moodle — Continuidade dos Estudos (Aulas 39 e 40)
+
+Cole este texto no tópico "Plano de continuidade pós-NP3" no Moodle imediatamente após a Aula 40.
+
+---
+
+**Título do tópico**: Continuidade dos estudos e recursos complementares — NP3
+
+**Mensagem para os estudantes:**
+
+Olá, pessoal! 👋
+
+Parabéns pelo empenho no hackathon (Aula 38), no simulado da NP3 (Aula 39) e na banca oficial (Aula 40). Para manter o ritmo de aprendizagem, sigam as orientações abaixo:
+
+1. **Preencha a planilha de rubrica e feedback** (`planilha-feedback-np3.csv`). Registre os pontos fortes, as lacunas e as ações de reforço combinadas com o squad.
+2. **Monte ou atualize o seu Plano de Estudo Pós-NP3** usando o modelo disponível (`modelo-plano-estudo-pos-np3.md`). Publique o arquivo preenchido neste fórum até **sexta-feira, 23h59**.
+3. **Solicite devolutivas adicionais**: use o espaço de comentários para indicar quais temas gostariam que fossem retomados em monitoria ou mentoring.
+4. **Consulte a biblioteca de recursos complementares**:
+   - Guia de revisão geral da NP3 (link já no plano de aula).
+   - Vídeos curtos sobre roadmap, mudança e comunicação executiva.
+   - Planilha de checkpoints do hackathon e registros do simulado.
+5. **Planejem encontros de estudo**: compartilhem datas e horários das sessões de estudo colaborativas (presenciais ou online). Usem a planilha para registrar presença e tópicos discutidos.
+
+> **Compromisso**: Atualizem este tópico semanalmente com progresso, dúvidas e indicadores monitorados. A coordenação acompanhará os registros para sugerir reforços personalizados.
+
+Bons estudos!

--- a/public/courses/tgs/planilha-feedback-np3.csv
+++ b/public/courses/tgs/planilha-feedback-np3.csv
@@ -1,0 +1,5 @@
+Squad,Integrante,Pilar,Indicador observado,Nível (Excelente/Adequado/Em desenvolvimento),Evidências anotadas,Ações de reforço,Perguntas para a banca NP3
+,,Roadmap priorizado,Descrever ROI/risco validado,,Registrar fontes e data,Planejar ajuste no roadmap,
+,,Gestão da mudança,Descrever indicador leading monitorado,,Anotar feedback de stakeholders,Definir reforço de capacitação,
+,,Comunicação executiva,Descrever métrica de clareza/compreensão,,Anotar dúvidas da diretoria,Planejar ensaio adicional,
+,,Feedback e aprendizagem,Descrever insight individual ou coletivo,,Registrar compromisso assumido,Definir apoio ou recurso extra,

--- a/src/content/courses/tgs/lessons/lesson-38.json
+++ b/src/content/courses/tgs/lessons/lesson-38.json
@@ -1,182 +1,185 @@
 {
   "id": "lesson-38",
-  "title": "Aula 38: Oficina Integrada – Roadmap, Mudança e Comunicação",
-  "objective": "Conectar roadmap estratégico à gestão de mudança e comunicação executiva do PESI.",
+  "title": "Aula 38: Hackathon Integrado – Roadmap, Mudança e Comunicação",
+  "objective": "Conduzir um hackathon curto que conecte roadmap estratégico, gestão de mudança e comunicação executiva do PESI.",
   "content": [
     {
-      "type": "representations",
-      "title": "Alavancas de mudança",
-      "items": [
+      "type": "lessonPlan",
+      "title": "Plano da aula hackathon (110 min)",
+      "cards": [
         {
-          "title": "Patrocínio visível",
-          "content": "Executivos comunicam visão e desbloqueiam recursos.",
-          "language": "plaintext",
-          "code": "Executivos comunicam visão e desbloqueiam recursos."
+          "icon": "bullseye",
+          "title": "Briefing",
+          "content": "Resolver um desafio do PESI consolidando roadmap priorizado, plano de mudança e kit de comunicação executiva em 110 minutos."
         },
         {
-          "title": "Gestão de impactos",
-          "content": "Mapeamento de processos, personas e riscos de adoção.",
-          "language": "plaintext",
-          "code": "Mapeamento de processos, personas e riscos de adoção."
+          "icon": "clock",
+          "title": "Estrutura",
+          "content": "Check-in de contexto (10’), Sprint 1 – ajuste de hipóteses (25’), Checkpoint 1, Sprint 2 – prototipação (30’), Checkpoint 2, Sprint 3 – pitch e feedback rápido (30’), Retrospectiva e próximas ações (15’)."
         },
         {
-          "title": "Capacitação",
-          "content": "Trilhas de aprendizagem e suporte contínuo.",
-          "language": "plaintext",
-          "code": "Trilhas de aprendizagem e suporte contínuo."
-        },
-        {
-          "title": "Comunicação segmentada",
-          "content": "Mensagens personalizadas por stakeholder.",
-          "language": "plaintext",
-          "code": "Mensagens personalizadas por stakeholder."
-        }
-      ]
-    },
-    {
-      "type": "contentBlock",
-      "title": "Plano de comunicação",
-      "content": [
-        {
-          "type": "unorderedList",
-          "items": [
-            {
-              "text": "Stakeholder: Conselho | Mensagem-chave: Status do roadmap e resultados | Canal: Relatório executivo | Frequência: Mensal"
-            },
-            {
-              "text": "Stakeholder: Gestores | Mensagem-chave: Impactos operacionais e decisões | Canal: Reuniões de liderança | Frequência: Quinzenal"
-            },
-            {
-              "text": "Stakeholder: Colaboradores | Mensagem-chave: Benefícios e suporte | Canal: Intranet, newsletters | Frequência: Semanal"
-            },
-            {
-              "text": "Stakeholder: Parceiros | Mensagem-chave: Integrações e mudanças contratuais | Canal: Workshops dedicados | Frequência: Trimestral"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "systemMapper",
-      "title": "Gestão de mudança integrada",
-      "summary": "Mostra como comunicação, capacitação e suporte sustentam a adoção do roadmap.",
-      "factors": [
-        {
-          "id": "comunicacao",
-          "name": "Comunicação",
-          "summary": "Mensagens direcionadas",
-          "kind": "flow",
-          "indicators": ["alcance_mensagens"]
-        },
-        {
-          "id": "capacitacao",
-          "name": "Capacitação",
-          "summary": "Treinamentos e coaching",
-          "kind": "capability",
-          "indicators": ["horas_treinamento"]
-        },
-        {
-          "id": "suporte",
-          "name": "Suporte",
-          "summary": "Canais e help desk",
-          "kind": "resource",
-          "indicators": ["chamados_resolvidos"]
-        },
-        {
-          "id": "adocao",
-          "name": "Adoção",
-          "summary": "Uso efetivo das novas soluções",
-          "kind": "outcome",
-          "indicators": ["usuarios_ativos"]
-        }
-      ],
-      "connections": [
-        {
-          "from": "comunicacao",
-          "to": "capacitacao",
-          "description": "Comunicação convoca públicos para trilhas de aprendizado."
-        },
-        {
-          "from": "capacitacao",
-          "to": "adocao",
-          "description": "Treinamentos aumentam confiança no uso."
-        },
-        {
-          "from": "suporte",
-          "to": "adocao",
-          "description": "Suporte rápido remove barreiras pós-go-live."
-        },
-        {
-          "from": "capacitacao",
-          "to": "suporte",
-          "description": "Insights dos treinamentos orientam base de conhecimento."
-        }
-      ]
-    },
-    {
-      "type": "contentBlock",
-      "title": "Cronograma da oficina",
-      "content": [
-        {
-          "type": "orderedList",
-          "items": [
-            {
-              "text": "Bloco 1 – Atualização do roadmap e dependências críticas."
-            },
-            {
-              "text": "Bloco 2 – Mapeamento de impactos e stakeholders."
-            },
-            {
-              "text": "Bloco 3 – Definição de mensagens e canais por segmento."
-            },
-            {
-              "text": "Bloco 4 – Plano de capacitação e métricas de adoção."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "videos",
-      "title": "Gestão de mudança em ação",
-      "videos": [
-        {
-          "url": "https://example.edu/tgs/videos/change-management-ti",
-          "title": "Transformação digital orientada à mudança",
-          "caption": "Como comunicar roadmap de TI em escala."
-        },
-        {
-          "url": "https://example.edu/tgs/videos/case-capacitacao-pesi",
-          "title": "Capacitação contínua",
-          "caption": "Case de onboarding digital com academias internas."
+          "icon": "tasks",
+          "title": "Saídas esperadas",
+          "content": "Canvas de roadmap revisado, plano de mudança com indicadores de adoção e roteiro de comunicação segmentado. Todos os entregáveis precisam alimentar o estudo para a NP3."
         }
       ]
     },
     {
       "type": "callout",
-      "variant": "task",
-      "title": "TED 38 — Plano de engajamento",
+      "variant": "info",
+      "title": "Briefing express do desafio",
       "content": [
         {
           "type": "paragraph",
-          "text": "Produza um plano de engajamento resumido com stakeholders críticos, mensagens-chave e indicadores de adoção. Entregue no fórum e responda à banca de perguntas em aula seguinte."
+          "text": "A diretoria do PESI precisa validar se a próxima onda do roadmap está sustentada por evidências de impacto, estratégia de adoção e mensagens claras para cada stakeholder-chave."
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "items": [
+            "Contexto: ondas 3 e 4 priorizadas em aula 37, com dependências críticas com Operações e Customer Success.",
+            "Desafio: montar kit executivo que demonstre prontidão da equipe e antecipe riscos de adoção.",
+            "Formato: squads de 4–5 pessoas com papéis rotativos (líder de roadmap, líder de mudança, líder de comunicação)."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "timeline",
+      "title": "Sprints e checkpoints",
+      "steps": [
+        {
+          "time": "00:00–00:10",
+          "title": "Kick-off",
+          "content": "Contextualização do problema, leitura rápida do briefing e alinhamento dos papéis do squad."
+        },
+        {
+          "time": "00:10–00:35",
+          "title": "Sprint 1 – Hipóteses e riscos",
+          "content": "Mapeamento das lacunas do roadmap, riscos de adoção e indicadores obrigatórios."
+        },
+        {
+          "time": "00:35–00:45",
+          "title": "Checkpoint 1",
+          "content": "Facilitador revisa matriz de riscos e garante alinhamento com expectativas da NP3."
+        },
+        {
+          "time": "00:45–01:15",
+          "title": "Sprint 2 – Prototipação do kit",
+          "content": "Construção dos artefatos: quadro de indicadores, plano de mudança e roteiro de comunicação."
+        },
+        {
+          "time": "01:15–01:25",
+          "title": "Checkpoint 2",
+          "content": "Squads apresentam progresso com foco em métricas e mensagens críticas; feedback 360° em 3 minutos."
+        },
+        {
+          "time": "01:25–01:55",
+          "title": "Sprint 3 – Pitch final",
+          "content": "Refinamento do pitch executivo (3 minutos) e registro das lições para o plano de estudos pré-NP3."
+        },
+        {
+          "time": "01:55–02:05",
+          "title": "Retro & próximos passos",
+          "content": "Síntese coletiva, registro de decisões na planilha de feedback e definição das ações individuais."
+        }
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Checkpoints e evidências",
+      "headers": ["Checkpoint", "Foco", "Evidências mínimas", "Ferramentas"],
+      "rows": [
+        [
+          "CP1 – Hipóteses",
+          "Consistência do roadmap",
+          "Mapa de dependências revisado + riscos classificados (alto/médio/baixo)",
+          "Canvas roadmap (Miro/Slides)"
+        ],
+        [
+          "CP2 – Prototipação",
+          "Plano de mudança",
+          "Backlog de ações com owner, indicador leading e próximo checkpoint",
+          "Planilha de mudança (Google Sheets)"
+        ],
+        [
+          "Pitch final",
+          "Comunicação executiva",
+          "Roteiro com mensagem-chave por stakeholder + indicador de sucesso",
+          "Script de pitch + deck 3 slides"
+        ]
+      ]
+    },
+    {
+      "type": "md3Table",
+      "title": "Rubrica formativa do hackathon",
+      "headers": ["Critério", "Excelente", "Adequado", "Em desenvolvimento"],
+      "rows": [
+        [
+          "Integração dos pilares",
+          "Roadmap, mudança e comunicação conectados com métricas cruzadas.",
+          "Pilares citados, mas com indicadores parcialmente alinhados.",
+          "Trata pilares isoladamente sem justificar dependências."
+        ],
+        [
+          "Evidências e dados",
+          "Usa indicadores leading/lagging com fontes e limites definidos.",
+          "Apresenta indicadores, porém sem escala ou fonte explícita.",
+          "Indicadores ausentes ou desconectados do desafio."
+        ],
+        [
+          "Clareza do pitch",
+          "Narrativa executiva objetiva com chamadas para decisão.",
+          "Pitch compreensível, mas com lacunas de priorização.",
+          "Mensagem confusa ou sem direcionamento para o board."
+        ]
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "task",
+      "title": "TED 38 — Pitch executivo (3 min)",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Grave o pitch do squad (máx. 3 minutos) apresentando decisão-chave, riscos mitigados e plano de comunicação. Publique no fórum ‘Hackathon Roadmap & Mudança’ no Moodle até 24h após a aula."
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "items": [
+            "Nome do arquivo: Squad-XX_Pitch-Hackathon38.mp4.",
+            "Anexe também a planilha de checkpoints atualizada.",
+            "Responda ao menos um feedback de outro squad com sugestões objetivas."
+          ]
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Feedback 360°",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Cada integrante deve registrar três aprendizados e duas ações individuais na planilha de feedback compartilhada. Esse registro alimenta o plano de estudos personalizado para a NP3 (aula 40)."
         }
       ]
     }
   ],
   "formatVersion": "md3.lesson.v1",
-  "slug": "aula-38-oficina-integrada-roadmap-mudanca",
-  "summary": "Integra roadmap estratégico com gestão de mudança, comunicação e engajamento de stakeholders.",
+  "slug": "aula-38-hackathon-integrado-roadmap-mudanca",
+  "summary": "Hackathon curto que integra roadmap, mudança e comunicação para preparar os squads para a NP3.",
   "objectives": [
-    "Relacionar roadmap do PESI às necessidades de comunicação e mudança.",
-    "Elaborar plano de comunicação segmentado por stakeholder.",
-    "Definir indicadores de adoção e suporte contínuo."
+    "Aplicar os pilares de roadmap, mudança e comunicação em uma sprint integrada.",
+    "Produzir artefatos executivos com indicadores e mensagens orientados à decisão.",
+    "Registrar aprendizados e próximos passos para o estudo da NP3."
   ],
   "competencies": ["Gestão de mudança", "Comunicação executiva", "Engajamento de stakeholders"],
   "outcomes": [
-    "Entrega plano de engajamento alinhado ao roadmap.",
-    "Mapeia impactos e planos de capacitação por público.",
-    "Define métricas de adoção para monitoramento contínuo."
+    "Entrega kit executivo (roadmap + mudança + comunicação) validado nos checkpoints.",
+    "Evidencia indicadores de adoção e riscos com planos de mitigação.",
+    "Registra ações individuais para continuidade dos estudos."
   ],
   "prerequisites": [
     "Roadmap priorizado (aula 33) e governança definida (aula 34).",
@@ -187,8 +190,13 @@
   "modality": "in-person",
   "resources": [
     {
-      "label": "Template de plano de engajamento",
-      "url": "https://example.edu/tgs/templates/plano-engajamento",
+      "label": "Briefing oficial do hackathon",
+      "url": "https://static.md3.education/courses/tgs/hackathon-aula38-briefing.md",
+      "type": "guide"
+    },
+    {
+      "label": "Planilha de checkpoints e feedbacks",
+      "url": "https://static.md3.education/courses/tgs/hackathon-aula38-checkpoints.csv",
       "type": "template"
     },
     {
@@ -203,12 +211,16 @@
   ],
   "assessment": {
     "type": "formative",
-    "description": "Plano de engajamento com indicadores de adoção."
+    "description": "Kit executivo validado com feedback 360° e pitch registrado."
   },
   "metadata": {
-    "status": "draft",
-    "updatedAt": "2025-03-10T00:00:00.000Z",
+    "status": "in-review",
+    "updatedAt": "2025-03-18T00:00:00.000Z",
     "owners": ["Profa. Marina Duarte"],
-    "sources": ["Plano de ensino TGS 2025.1", "Playbook Change Management 2024"]
+    "sources": [
+      "Plano de ensino TGS 2025.1",
+      "Playbook Change Management 2024",
+      "Notas do Hackathon 2025"
+    ]
   }
 }

--- a/src/content/courses/tgs/lessons/lesson-39.json
+++ b/src/content/courses/tgs/lessons/lesson-39.json
@@ -1,27 +1,47 @@
 {
   "id": "lesson-39",
-  "title": "Aula 39: Síntese Estratégica e Painel Futuro de SI",
-  "objective": "Consolidar aprendizados do ciclo de planejamento estratégico e projetar próximos passos para o PESI.",
+  "title": "Aula 39: Simulado NP3 – Roadmap, Mudança e Comunicação",
+  "objective": "Realizar simulado orientado à NP3 reforçando os pilares praticados no hackathon da aula 38.",
   "content": [
     {
       "type": "cardGrid",
-      "title": "Entregáveis consolidados",
+      "title": "Pilares do simulado NP3",
       "cards": [
         {
-          "title": "Diagnóstico",
-          "content": "SWOT, inventário de capacidades e análise de riscos."
+          "title": "Roadmap priorizado",
+          "content": "Validar ondas 3 e 4 com dependências, valor esperado e decisão do patrocinador."
         },
         {
-          "title": "Mapa estratégico",
-          "content": "Balanced Scorecard, objetivos e indicadores."
+          "title": "Gestão da mudança",
+          "content": "Atualizar planos de adoção, indicadores leading e rituais de acompanhamento."
         },
         {
-          "title": "Roadmap & governança",
-          "content": "Sequenciamento, fóruns e métricas de acompanhamento."
+          "title": "Comunicação executiva",
+          "content": "Construir narrativa de 3 minutos com mensagens segmentadas por stakeholder."
         },
         {
-          "title": "Planos de mudança",
-          "content": "Engajamento, comunicação e monitoramento da adoção."
+          "title": "Evidências e métricas",
+          "content": "Reunir dados de performance, riscos e compromissos assumidos no hackathon."
+        }
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Conexão com o Hackathon 38",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Tragam os artefatos validados nos checkpoints (canvas de roadmap, plano de mudança e roteiro de comunicação). Eles serão a base para o simulado e para a revisão da NP3."
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "items": [
+            "Cada squad escolhe uma pessoa porta-voz e uma pessoa responsável por atualizar a planilha de rubrica.",
+            "Indiquem no pitch quais ajustes pós-hackathon foram incorporados ao kit executivo.",
+            "Registrem dúvidas para a banca da NP3 na seção específica da planilha de feedback."
+          ]
         }
       ]
     },
@@ -241,6 +261,31 @@
       ]
     },
     {
+      "type": "md3Table",
+      "title": "Rubrica NP3 – pilares do hackathon",
+      "headers": ["Critério", "Excelente", "Adequado", "Em desenvolvimento"],
+      "rows": [
+        [
+          "Roadmap priorizado",
+          "Ondas priorizadas com dependências, ROI e decisões da diretoria documentadas.",
+          "Ondas descritas com riscos apontados, porém sem vínculo explícito a decisões.",
+          "Entregáveis incompletos ou sem atualização pós-hackathon."
+        ],
+        [
+          "Plano de mudança",
+          "Plano de adoção com indicadores leading/lagging, responsáveis e próximos ritos.",
+          "Plano apresenta ações e responsáveis, mas indicadores ou cadências estão superficiais.",
+          "Sem definição de indicadores ou responsáveis para acompanhar a adoção."
+        ],
+        [
+          "Comunicação executiva",
+          "Pitch conecta mensagem, dados e chamada para decisão em 3 minutos.",
+          "Narrativa cobre os pontos principais, mas sem dados de suporte consistentes.",
+          "Mensagem dispersa ou sem direcionamento para a diretoria."
+        ]
+      ]
+    },
+    {
       "type": "timeline",
       "title": "Preparação para o painel futuro",
       "steps": [
@@ -338,28 +383,37 @@
     {
       "type": "callout",
       "variant": "task",
-      "title": "TED 39 — Fórum de síntese",
+      "title": "TED 39 — Simulado NP3 (fórum de síntese)",
       "content": [
         {
           "type": "paragraph",
-          "text": "Prepare um resumo executivo (máx. 2 páginas) com os principais aprendizados, riscos e próximos passos do PESI. Compartilhe no fórum e faça peer review com dois grupos."
+          "text": "Produza um resumo executivo (máx. 2 páginas) evidenciando como cada pilar do hackathon sustenta a entrega da NP3. Publique no fórum ‘Simulado NP3’ e realize peer review com dois squads."
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "items": [
+            "Anexe o checklist atualizado na planilha de rubrica NP3.",
+            "Inclua perguntas direcionadas para a banca oficial da NP3 (aula 40).",
+            "Sugira ações de reforço individual com base no feedback 360° do hackathon."
+          ]
         }
       ]
     }
   ],
   "formatVersion": "md3.lesson.v1",
-  "slug": "aula-39-sintese-estrategica-e-painel-futuro",
-  "summary": "Consolida entregáveis do PESI, prepara painel futuro e alinha próximos passos estratégicos.",
+  "slug": "aula-39-simulado-np3-roadmap-mudanca-comunicacao",
+  "summary": "Simulado da NP3 alinhado aos pilares do hackathon, com foco em roadmap, mudança e comunicação executiva.",
   "objectives": [
-    "Revisitar entregáveis críticos do PESI com visão integrada.",
-    "Planejar painel futuro e critérios de avaliação executiva.",
-    "Sintetizar aprendizados e riscos em resumo executivo."
+    "Reforçar decisões do roadmap utilizando as evidências coletadas no hackathon.",
+    "Ensaiar planos de mudança e comunicação com base na rubrica oficial da NP3.",
+    "Sintetizar aprendizados em resumo executivo e checklist compartilhado."
   ],
-  "competencies": ["Comunicação estratégica", "Gestão de riscos", "Síntese executiva"],
+  "competencies": ["Planejamento de portfólio", "Gestão da mudança", "Comunicação executiva"],
   "outcomes": [
-    "Apresenta checklist final com status dos entregáveis.",
-    "Organiza painel futuro com atores e temas críticos.",
-    "Produz resumo executivo compartilhado para peer review."
+    "Atualiza kit executivo com ajustes pós-hackathon e registra pendências.",
+    "Aplica rubrica NP3 para identificar lacunas de adoção e comunicação.",
+    "Documenta recomendações e próximos passos para a banca da NP3."
   ],
   "prerequisites": [
     "Planos de mudança e indicadores estruturados (aulas 35 e 38).",
@@ -375,9 +429,14 @@
       "type": "template"
     },
     {
-      "label": "Checklist final do PESI",
-      "url": "https://example.edu/tgs/checklists/final-pesi",
-      "type": "checklist"
+      "label": "Planilha de rubrica e feedback NP3",
+      "url": "https://static.md3.education/courses/tgs/planilha-feedback-np3.csv",
+      "type": "template"
+    },
+    {
+      "label": "Modelo de plano de estudo pós-simulado",
+      "url": "https://static.md3.education/courses/tgs/modelo-plano-estudo-pos-np3.md",
+      "type": "guide"
     }
   ],
   "bibliography": [
@@ -386,12 +445,16 @@
   ],
   "assessment": {
     "type": "formative",
-    "description": "Resumo executivo e participação em fórum de síntese."
+    "description": "Simulado NP3 com resumo executivo, checklist validado e registro na planilha de rubrica."
   },
   "metadata": {
-    "status": "draft",
-    "updatedAt": "2025-03-10T00:00:00.000Z",
+    "status": "in-review",
+    "updatedAt": "2025-03-18T00:00:00.000Z",
     "owners": ["Profa. Marina Duarte"],
-    "sources": ["Plano de ensino TGS 2025.1", "Toolkit Painel Futuro 2024"]
+    "sources": [
+      "Plano de ensino TGS 2025.1",
+      "Toolkit Painel Futuro 2024",
+      "Notas do Hackathon 2025"
+    ]
   }
 }

--- a/src/content/courses/tgs/lessons/lesson-40.json
+++ b/src/content/courses/tgs/lessons/lesson-40.json
@@ -87,6 +87,26 @@
       ]
     },
     {
+      "type": "contentBlock",
+      "title": "Sessão de feedback e continuidade",
+      "content": [
+        {
+          "type": "orderedList",
+          "items": [
+            {
+              "text": "Preencha a planilha de rubrica e feedback NP3 registrando evidências de cada pilar (roadmap, mudança, comunicação, aprendizagem)."
+            },
+            {
+              "text": "Defina, em squad, duas ações coletivas e duas individuais para as próximas semanas utilizando o modelo de plano de estudo."
+            },
+            {
+              "text": "Agende a atualização do fórum no Moodle com o texto padrão e anexos (planilha preenchida + plano de estudo)."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "type": "callout",
       "variant": "warning",
       "title": "Procedimentos",
@@ -104,6 +124,17 @@
         "Revisar resumos das unidades e exercícios de loops de feedback.",
         "Organizar referências rápidas de conceitos-chave (glossário pessoal).",
         "Preparar perguntas para a sessão de devolutiva pós-avaliação."
+      ]
+    },
+    {
+      "type": "callout",
+      "variant": "info",
+      "title": "Postagem no Moodle",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Após a prova, publique no tópico 'Plano de continuidade pós-NP3' o texto base disponível no repositório, anexando a planilha de feedback e o plano de estudo atualizado."
+        }
       ]
     }
   ],
@@ -143,6 +174,21 @@
       "label": "Planilha de autoavaliação (checklist NP3)",
       "url": "https://static.md3.education/courses/tgs/autoavaliacao-np3.md",
       "type": "template"
+    },
+    {
+      "label": "Planilha de rubrica e feedback NP3",
+      "url": "https://static.md3.education/courses/tgs/planilha-feedback-np3.csv",
+      "type": "template"
+    },
+    {
+      "label": "Modelo de plano de estudo pós-NP3",
+      "url": "https://static.md3.education/courses/tgs/modelo-plano-estudo-pos-np3.md",
+      "type": "guide"
+    },
+    {
+      "label": "Texto base para postagem no Moodle",
+      "url": "https://static.md3.education/courses/tgs/moodle-continuacao-estudos.md",
+      "type": "guide"
     }
   ],
   "bibliography": [


### PR DESCRIPTION
## Summary
- redesenha a aula 38 como hackathon com briefing, cronograma em sprints, checkpoints e rubrica formativa
- alinha a aula 39 como simulado da NP3 reforçando os pilares de roadmap, mudança e comunicação e conectando aos novos materiais
- adiciona planilhas, modelos e texto para Moodle usados na devolutiva da aula 40 e referencia-os no plano da avaliação final

## Testing
- `jq '.' src/content/courses/tgs/lessons/lesson-38.json`
- `jq '.' src/content/courses/tgs/lessons/lesson-39.json`
- `jq '.' src/content/courses/tgs/lessons/lesson-40.json`


------
https://chatgpt.com/codex/tasks/task_e_68e15952dbb4832c82dc437193733e9e