### PR TITLE
Align ALGI lessons 33-37 with boletim and estoque arcs

### DIFF
--- a/public/courses/algi/estacao-boletim-analises.md
+++ b/public/courses/algi/estacao-boletim-analises.md
@@ -1,0 +1,19 @@
+# Estação 2 — Indicadores do Boletim TechED
+
+## Objetivo
+Produzir visões analíticas do boletim consolidando turmas, disciplinas e pesos.
+
+## Operações obrigatórias
+- **Transposição**: gere `boletimT[DISCIPLINAS][ALUNOS]` preservando cabeçalhos.
+- **Agregações**: some matrizes de turmas A e B armazenando o resultado em `boletimTotal`.
+- **Índice ponderado**: calcule `indiceDesempenho[ALUNOS]` multiplicando notas pelos pesos informados em `pesos-bimestres.csv`.
+
+## Perguntas-guia
+1. Como os novos indicadores alimentam o relatório textual da Aula 34?
+2. Quais validações de dimensão precisam ser logadas antes da multiplicação?
+3. Como evidenciar estudantes com maior variação entre bimestres?
+
+## Checklist rápido
+- [ ] Transposição validada (`linhas == colunasT`).
+- [ ] Somas normalizadas pelo número de turmas agregadas.
+- [ ] Índices ponderados registrados com duas casas decimais e explicação de metodologia.

--- a/public/courses/algi/estacao-boletim-matriz.md
+++ b/public/courses/algi/estacao-boletim-matriz.md
@@ -1,0 +1,19 @@
+# Estação 1 — Boletim TechED (Matriz Base)
+
+## Objetivo
+Construir e validar a matriz `boletim[ALUNOS][DISCIPLINAS]` com dados reais da turma TechED.
+
+## Operações obrigatórias
+- **Declaração e inicialização**: copie 5 estudantes × 4 disciplinas do arquivo `boletim-tech-ed.csv`.
+- **Cálculo de médias**: use dois loops `for` para somar notas por estudante e atualizar a coluna `media`.
+- **Classificação de status**: adicione coluna `status` preenchida com `Aprovado`, `Recuperação` ou `Acompanhamento` usando média ≥ 6.0.
+
+## Perguntas-guia
+1. Como garantir que índices `[aluno][disciplina]` permaneçam alinhados com os cabeçalhos?
+2. Quais campos precisam aparecer no relatório textual da Aula 33?
+3. Como registrar no log as alterações feitas manualmente na matriz?
+
+## Checklist rápido
+- [ ] Matriz declarada com limites corretos.
+- [ ] Médias arredondadas para uma casa decimal (`%.1f`).
+- [ ] Status escrito exatamente como solicitado para alimentar o relatório da coordenação.

--- a/public/courses/algi/estacao-estoque-auditoria.md
+++ b/public/courses/algi/estacao-estoque-auditoria.md
@@ -1,0 +1,19 @@
+# Estação 5 — Auditoria e Atualizações TechParts
+
+## Objetivo
+Finalizar o módulo de estoque garantindo buscas confiáveis, atualizações auditadas e documentação completa.
+
+## Operações obrigatórias
+- **Busca composta**: implemente `int buscarProduto(Produto estoque[], int total, int sku, const char *lote)` retornando índice ou -1.
+- **Atualização auditada**: crie função `bool atualizarProduto(Produto *p, float novoPreco, int novoMinimo, FILE *log)` que grava motivo e horário da alteração.
+- **Remoção**: desenvolva `bool removerProduto(Produto estoque[], int *total, int sku)` permitindo remoção lógica (flag) ou física (compactação).
+
+## Perguntas-guia
+1. Como garantir que o log contenha usuário, campo alterado e justificativa?
+2. Quais políticas da TechParts precisam aparecer no relatório textual final?
+3. Como organizar rollback caso a atualização comprometa indicadores?
+
+## Checklist rápido
+- [ ] Funções de busca cobrem casos inexistentes com mensagens claras.
+- [ ] Atualizações rejeitam valores incoerentes (preço negativo, estoque mínimo maior que capacidade).
+- [ ] Logs armazenados no formato `YYYY-MM-DD;SKU;campo;valor_antigo;valor_novo;responsavel`.

--- a/public/courses/algi/estacao-estoque-operacoes.md
+++ b/public/courses/algi/estacao-estoque-operacoes.md
@@ -1,0 +1,19 @@
+# Estação 4 — Operações em Vetor de Produtos
+
+## Objetivo
+Ampliar o catálogo TechParts para suportar ordenações, cálculos de reposição e relatórios executivos.
+
+## Operações obrigatórias
+- **Inserção**: implemente função `bool inserirProduto(Produto estoque[], int *total, Produto novo)` que valida capacidade e SKU duplicado.
+- **Ordenação**: aplique Bubble ou Insertion Sort ordenando por `quantidade` ascendente e registre o número de trocas.
+- **Relatórios**: gere resumo com produtos abaixo do `estoqueMinimo`, valor total para reposição e top 3 itens com maior giro.
+
+## Perguntas-guia
+1. Como reutilizar o vetor inicial da Aula 35 sem perder registros já cadastrados?
+2. Quais métricas devem alimentar o relatório textual e o fórum da Aula 36?
+3. Como estruturar o código para facilitar as buscas e atualizações da Aula 37?
+
+## Checklist rápido
+- [ ] Inserções e ordenações atualizam o contador corretamente.
+- [ ] Relatórios exportados em CSV ou texto com data/hora.
+- [ ] Logs de ordenação anexados ao diretório do projeto.

--- a/public/courses/algi/estacao-estoque-struct.md
+++ b/public/courses/algi/estacao-estoque-struct.md
@@ -1,0 +1,19 @@
+# Estação 3 — Catálogo Inicial TechParts
+
+## Objetivo
+Modelar o registro `Produto` e montar o catálogo base que servirá de insumo para as aulas 36 e 37.
+
+## Operações obrigatórias
+- **Declaração**: defina `typedef struct { int sku; char nome[40]; int quantidade; int estoqueMinimo; float preco; } Produto;`.
+- **Cadastro**: leia entradas do arquivo `estoque-techparts.csv` populando um vetor local com até 20 itens.
+- **Impressão**: crie função `void imprimirProduto(const Produto*)` exibindo SKU, nome, quantidade atual e alerta de reposição.
+
+## Perguntas-guia
+1. Quais campos adicionais serão necessários para as próximas aulas (ex.: categoria, fornecedor)?
+2. Como validar entradas repetidas de SKU antes de inserir no vetor?
+3. Quais registros devem ser destacados no relatório textual da Aula 35?
+
+## Checklist rápido
+- [ ] Vetor inicializado com contador separado de capacidade.
+- [ ] Função de impressão utilizada no mini-CRUD da aula.
+- [ ] Log textual descrevendo cada cadastro realizado.

--- a/public/courses/algi/memory-diagrama-boletim.md
+++ b/public/courses/algi/memory-diagrama-boletim.md
@@ -1,0 +1,22 @@
+# Diagrama de Memória — Boletim TechED (Matriz 2D)
+
+```
+Endereço base -> boletim[0][0]
++-------------------------------+
+| Aluno 0 | Disc 0 | Nota 7.5   |
+|         | Disc 1 | Nota 6.0   |
+|         | Disc 2 | Nota 8.0   |
+|         | Disc 3 | Nota 7.0   |
++-------------------------------+
+| Aluno 1 | Disc 0 | Nota 5.0   |
+|         | Disc 1 | Nota 6.5   |
+|         | Disc 2 | Nota 6.8   |
+|         | Disc 3 | Nota 7.2   |
++-------------------------------+
+| ...                             |
++-------------------------------+
+```
+
+- As notas são armazenadas de forma contígua em memória (linha major order).
+- A transposição cria uma segunda matriz `boletimT` que reorganiza os blocos por disciplina para os slides das aulas 33 e 34.
+- Inclua os rótulos de cabeçalho nos slides: linha = estudante, coluna = disciplina.

--- a/public/courses/algi/memory-diagrama-estoque.md
+++ b/public/courses/algi/memory-diagrama-estoque.md
@@ -1,0 +1,21 @@
+# Diagrama de Memória — Vetor de Produtos TechParts
+
+```
+Endereço base -> estoque[0]
++---------------------------------------------------------+
+| Produto[0]                                              |
+|  sku:101 | nome:"Kit Sensor" | qtd:12 | min:5 | preço:189.90 |
++---------------------------------------------------------+
+| Produto[1]                                              |
+|  sku:205 | nome:"Controlador" | qtd:4 | min:6 | preço:249.00  |
++---------------------------------------------------------+
+| Produto[2]                                              |
+|  sku:310 | nome:"Cabo HDMI"   | qtd:25 | min:8 | preço:39.90  |
++---------------------------------------------------------+
+| ...                                                      |
++---------------------------------------------------------+
+```
+
+- Cada bloco `Produto` ocupa espaço contínuo contendo campos primitivos e strings.
+- O ponteiro para `estoque` é utilizado nas aulas 35-37: Aula 35 (cadastro), Aula 36 (ordenação/reposição), Aula 37 (busca/atualização).
+- Nos slides, represente ponteiros retornados por funções de busca apontando para o bloco correspondente.

--- a/src/content/courses/algi/lessons/lesson-33.json
+++ b/src/content/courses/algi/lessons/lesson-33.json
@@ -1,31 +1,31 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-33",
-  "title": "Matrizes 2D e Geração de Tabelas",
-  "summary": "Apresenta matrizes bidimensionais em C para organizar dados tabulares e gerar relatórios estruturados.",
-  "description": "Introduz matrizes 2D, loops aninhados e geração de tabelas formatadas com dados de presença.",
-  "objective": "Compreender a representação de matrizes 2D, percorrer linhas e colunas com loops aninhados e montar tabelas formatadas.",
+  "title": "Matrizes 2D e Geração de Boletins",
+  "summary": "Apresenta matrizes bidimensionais em C para organizar boletins de uma turma e gerar relatórios evolutivos.",
+  "description": "Introduz matrizes 2D, loops aninhados e geração de tabelas formatadas com notas bimestrais que serão refinadas nas aulas seguintes.",
+  "objective": "Compreender a representação de matrizes 2D, percorrer linhas e colunas com loops aninhados e montar o boletim base da turma TechED.",
   "objectives": [
-    "Declarar matrizes estáticas e inicializá-las com dados reais.",
-    "Percorrer linhas e colunas utilizando loops aninhados.",
-    "Gerar tabelas formatadas a partir de matrizes."
+    "Declarar matrizes estáticas representando notas por estudante e disciplina.",
+    "Percorrer linhas e colunas utilizando loops aninhados para consolidar médias.",
+    "Gerar o boletim inicial com cabeçalhos e espaçamento alinhado para leitura rápida."
   ],
   "competencies": ["05", "11"],
   "skills": [
-    "Mapear dados tabulares para estruturas de matrizes em C.",
-    "Construir laços aninhados que preencham e apresentem tabelas formatadas.",
-    "Explicar resultados obtidos conectando-os ao problema de negócio proposto."
+    "Mapear o boletim fornecido pela coordenação pedagógica para uma matriz em C.",
+    "Construir laços aninhados que calculem totais por aluno e disciplina.",
+    "Explicar resultados conectando-os às ações de acompanhamento sugeridas no cenário TechED."
   ],
   "outcomes": [
-    "Entrega programa que gera matriz 2D com cabeçalhos e alinhamento adequado.",
-    "Registra checklist de validação garantindo preenchimento correto por linha e coluna.",
-    "Realiza apresentação breve relacionando a tabela gerada com decisões possíveis no cenário estudado."
+    "Entrega programa que gera o boletim base com cabeçalhos e médias por disciplina.",
+    "Registra checklist validando preenchimento de cada aluno e apontando lacunas de dados.",
+    "Produz relato curto conectando os indicadores do boletim às decisões sugeridas para a turma TechED."
   ],
   "prerequisites": [
     "Domínio de vetores e loops (Aulas 30-31).",
     "Capacidade de formatar saídas com printf."
   ],
-  "tags": ["matrizes", "arrays", "loops-aninhados"],
+  "tags": ["matrizes", "arrays", "loops-aninhados", "boletins"],
   "duration": 100,
   "modality": "in-person",
   "resources": [
@@ -46,18 +46,18 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Em duplas ou trios, resolvam as questões a seguir para reforçar o aprendizado durante a aula."
+          "text": "Em duplas ou trios, atualizem o boletim da turma TechED seguindo as questões abaixo para reforçar o aprendizado durante a aula."
         },
         {
           "type": "orderedList",
           "items": [
             {
-              "title": "Questão teórica",
-              "text": "Explique com suas palavras os principais conceitos abordados em \"Matrizes 2D e Geração de Tabelas\" e destaque por que eles são importantes para a resolução de problemas."
+              "title": "Questão teórica — Boletim em matriz",
+              "text": "Explique com suas palavras como uma matriz 2D representa estudantes e disciplinas no boletim da turma TechED e aponte cuidados ao mapear índices."
             },
             {
-              "title": "Questão prática",
-              "text": "Implemente ou descreva um exemplo curto relacionado a \"Matrizes 2D e Geração de Tabelas\" utilizando OnlineGDB ou Dev-C++ e compartilhe o resultado com o grupo."
+              "title": "Questão prática — Linha de acompanhamento",
+              "text": "Implemente, no OnlineGDB ou Dev-C++, um trecho que imprime a linha completa de um estudante incluindo médias parciais e compartilhe com o grupo."
             }
           ]
         }
@@ -84,16 +84,16 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Revise os materiais desta aula aqui no site e anote os pontos-chave que precisam de atenção. Identifique dúvidas ou conceitos que merecem ser revisitados durante o encontro."
+          "text": "Revise o boletim parcial enviado pela coordenação TechED e anote quais disciplinas exigem atenção especial antes da aula."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Reserve alguns minutos para tentar resolver mentalmente um exemplo relacionado ao tema da aula."
+              "text": "Reserve alguns minutos para estimar mentalmente a média de um estudante usando a matriz do boletim."
             },
             {
-              "text": "Garanta acesso ao OnlineGDB ou ao Dev-C++ para experimentar os códigos durante a aula."
+              "text": "Separe o dataset boletim-tech-ed.csv disponibilizado no AVA para usar durante a aula."
             }
           ]
         }
@@ -106,42 +106,42 @@
         {
           "icon": "book-open",
           "title": "Contexto",
-          "content": "Por que representar tabelas como matrizes? (10 min)."
+          "content": "Contextualizar o boletim TechED e metas de acompanhamento (10 min)."
         },
         {
           "icon": "code",
           "title": "Sintaxe",
-          "content": "Declaração e inicialização de matrizes (25 min)."
+          "content": "Modelar matriz notas[ALUNOS][DISCIPLINAS] com cabeçalhos do boletim (25 min)."
         },
         {
           "icon": "gears",
           "title": "Loops aninhados",
-          "content": "Percorrer linhas e colunas (25 min)."
+          "content": "Percorrer linhas para calcular médias por estudante e destacar risco (25 min)."
         },
         {
           "icon": "database",
           "title": "Formatação",
-          "content": "Construir relatório com printf (25 min)."
+          "content": "Formatar saída com colunas alinhadas e legendas do boletim (25 min)."
         },
         {
           "icon": "check-circle",
           "title": "Aplicação",
-          "content": "Mini-projeto com dataset de presença (20 min)."
+          "content": "Mini-projeto: gerar boletim parcial com alertas de recuperação (15 min)."
         }
       ]
     },
     {
       "type": "promptTip",
-      "title": "Prompt para planejar Matrizes 2D e Geração de Tabelas",
+      "title": "Prompt para planejar o Boletim TechED",
       "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
-      "audience": "estudantes de Algoritmos I",
-      "prompt": "Você é estudante de Algoritmos I estudando Matrizes 2D e Geração de Tabelas. Contexto da aula: Apresenta matrizes bidimensionais em C para organizar dados tabulares e gerar relatórios estruturados. Objetivo central: Compreender a representação de matrizes 2D, percorrer linhas e colunas com loops aninhados e montar tabelas formatadas. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
-      "tags": ["algoritmos", "arrays", "loops-aninhados", "matrizes"],
+      "audience": "estudantes de Algoritmos I focados em matrizes",
+      "prompt": "Você é estudante de Algoritmos I responsável por gerar o boletim da turma TechED usando matrizes 2D. Contexto da aula: Apresenta matrizes bidimensionais em C para organizar boletins e gerar relatórios evolutivos. Objetivo central: Compreender a representação de matrizes 2D, percorrer linhas e colunas com loops aninhados e montar o boletim base da turma TechED. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando leituras, exercícios em C e perguntas que ajudem a consolidar cálculos de médias e destaques de recuperação. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
+      "tags": ["algoritmos", "arrays", "loops-aninhados", "matrizes", "boletins"],
       "tips": [
-        "Peça ao assistente variações de exercícios que reforcem declarar matrizes estáticas e inicializá-las com dados reais.",
-        "Solicite exemplos adicionais relacionados a matrizes, arrays para praticar.",
-        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
-        "Peça sugestões de autoavaliação que ajudem você a percorrer linhas e colunas utilizando loops aninhados."
+        "Peça ao assistente exercícios que reforcem a leitura de linhas completas do boletim e cálculo de médias.",
+        "Solicite variações com colunas extras para registrar frequência e observações.",
+        "Peça um checklist final para validar cabeçalhos, alinhamento e totais do boletim.",
+        "Peça sugestões de perguntas para orientar feedback aos estudantes em risco."
       ]
     },
     {
@@ -151,32 +151,32 @@
         {
           "icon": "check-circle",
           "title": "9 min",
-          "content": "Warm-up com quiz sobre índices."
+          "content": "Warm-up com quiz sobre índices do boletim TechED."
         },
         {
           "icon": "check-circle",
           "title": "17 min",
-          "content": "Aula expositiva com slides e md3Table de sintaxe."
+          "content": "Aula expositiva com slides apresentando a matriz do boletim e layout de cabeçalhos."
         },
         {
           "icon": "check-circle",
           "title": "22 min",
-          "content": "Demonstração de loops aninhados em C."
+          "content": "Demonstração de loops aninhados calculando médias e status por estudante."
         },
         {
           "icon": "check-circle",
-          "title": "(26 min) Oficina",
-          "content": "gerar tabela de presença a partir do CSV."
+          "title": "(26 min) Oficina colaborativa",
+          "content": "gerar boletim parcial e destacar estudantes com média < 6.0."
         },
         {
           "icon": "check-circle",
           "title": "17 min",
-          "content": "Revisão de código em duplas."
+          "content": "Revisão de código em duplas com checklist do boletim."
         },
         {
           "icon": "check-circle",
           "title": "9 min",
-          "content": "Orientação da prática pós-aula."
+          "content": "Orientação da prática pós-aula conectando com TED sobre boletim."
         }
       ]
     },
@@ -188,16 +188,16 @@
           "type": "unorderedList",
           "items": [
             {
-              "text": "Elemento: Declaração | Exemplo: int matriz[3][4]; | Descrição: 3 linhas, 4 colunas não inicializadas."
+              "text": "Elemento: Declaração | Exemplo: float boletim[30][5]; | Descrição: 30 estudantes, 5 disciplinas sem notas iniciais."
             },
             {
-              "text": "Elemento: Inicialização | Exemplo: int notas[2][3] = {{7,8,9},{6,5,10}}; | Descrição: Valores linha a linha."
+              "text": "Elemento: Inicialização | Exemplo: float boletim[2][3] = {{7.5,6.0,8.0},{5.0,6.5,7.0}}; | Descrição: Inserção linha a linha com notas bimestrais."
             },
             {
-              "text": "Elemento: Acesso | Exemplo: matriz[i][j] | Descrição: Primeiro índice = linha, segundo = coluna."
+              "text": "Elemento: Acesso | Exemplo: boletim[aluno][disciplina] | Descrição: Linha = estudante, coluna = disciplina."
             },
             {
-              "text": "Elemento: Percurso | Exemplo: for (i) for (j) | Descrição: Loops aninhados para percorrer todos os elementos."
+              "text": "Elemento: Percurso | Exemplo: for (aluno) for (disciplina) | Descrição: Loops aninhados para calcular médias por aluno e por disciplina."
             },
             {
               "text": "Elemento: Constante de coluna | Exemplo: #define COL 4 | Descrição: Facilita manutenção de dimensões."
@@ -334,9 +334,9 @@
         {
           "type": "list",
           "items": [
-            "Adicionar coluna de porcentagem de presença na tabela.",
-            "Criar função que retorna a linha com maior frequência de presenças.",
-            "Postar captura do relatório gerado no fórum da disciplina."
+            "Adicionar coluna com situação (Aprovado/Recuperação) baseada na média >= 6.0.",
+            "Criar função que retorna o estudante com maior evolução entre bimestres.",
+            "Postar captura do boletim formatado e checklist de validação no fórum da disciplina."
           ]
         }
       ]
@@ -348,16 +348,16 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Reserve um momento após a aula para concluir a atividade descrita a seguir. Ela complementa os estudos e ajuda a consolidar o que foi trabalhado em sala."
+          "text": "Reserve um momento após a aula para consolidar o boletim TechED e registrar as conclusões abaixo. A entrega alimenta o dossiê de acompanhamento da turma."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Desenvolva a prática proposta na aula registrando os passos e resultados no caderno ou no editor de sua preferência."
+              "text": "Gere o boletim completo com médias por disciplina e exporte um relatório textual (máx. 2 páginas) destacando três estudantes em risco e as ações sugeridas."
             },
             {
-              "text": "Anote dúvidas e insights que surgirem para discutirmos na próxima aula."
+              "text": "Anote dúvidas sobre cálculos ou alinhamento e registre-as no relatório para discussão na Aula 34."
             }
           ]
         }
@@ -365,17 +365,17 @@
     },
     {
       "type": "md3Table",
-      "headers": ["i", "j", "v[i][j]"],
+      "headers": ["Aluno", "Disciplina", "Nota"],
       "rows": [
         [
           {
             "value": "0"
           },
           {
-            "value": "0"
+            "value": "Matemática"
           },
           {
-            "value": "1"
+            "value": "6.5"
           }
         ],
         [
@@ -383,10 +383,21 @@
             "value": "0"
           },
           {
+            "value": "Ciências"
+          },
+          {
+            "value": "7.0"
+          }
+        ],
+        [
+          {
             "value": "1"
           },
           {
-            "value": "2"
+            "value": "Matemática"
+          },
+          {
+            "value": "5.0"
           }
         ]
       ]
@@ -413,8 +424,25 @@
       "content": [
         {
           "type": "code",
-          "code": "# Matriz 2x2\n[[1,2],[3,4]] -> imprime em tabela",
+          "code": "# Boletim 2x3\n{{7.0, 8.5, 6.0}, {5.0, 6.0, 7.0}} -> imprime tabela com médias e status",
           "language": "plaintext"
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Anexos para slides",
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Diagrama de memória do boletim 2D — /courses/algi/memory-diagrama-boletim.md"
+            },
+            {
+              "text": "Cartaz Estação Matriz — /courses/algi/estacao-boletim-matriz.md"
+            }
+          ]
         }
       ]
     },

--- a/src/content/courses/algi/lessons/lesson-34.json
+++ b/src/content/courses/algi/lessons/lesson-34.json
@@ -1,28 +1,28 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-34",
-  "title": "Manipulações com Matrizes",
-  "summary": "Aprofunda o trabalho com matrizes 2D realizando transposição, somas e multiplicação para resolver problemas de relatórios e transformações.",
-  "description": "Aprofunda manipulações matriciais com transposição, somas e multiplicação aplicada a indicadores.",
-  "objective": "Aplicar operações clássicas de matrizes para gerar indicadores combinados e preparar o terreno para algoritmos de processamento de imagens e dados.",
+  "title": "Manipulações com Matrizes — Boletim Evolutivo",
+  "summary": "Aprofunda o boletim TechED com transposição, agregações e análises comparativas a partir de matrizes 2D.",
+  "description": "Estende a matriz do boletim da Aula 33 aplicando transposição, somas e multiplicação para gerar indicadores por disciplina, bimestre e turma.",
+  "objective": "Transformar o boletim TechED em um painel analítico, combinando operações matriciais para revelar padrões e priorizar intervenções pedagógicas.",
   "objectives": [
-    "Implementar funções para transpor e somar matrizes.",
-    "Executar multiplicação matricial com três loops.",
-    "Validar dimensões e tratar entradas inválidas."
+    "Implementar funções para transpor o boletim e destacar notas por disciplina.",
+    "Somar matrizes para consolidar médias por bimestre e turmas paralelas.",
+    "Multiplicar matriz de notas por pesos para calcular índices de desempenho."
   ],
   "competencies": ["05", "08"],
   "skills": [
-    "Implementar transposição, somas e multiplicação de matrizes controlando dimensões.",
-    "Testar compatibilidade entre matrizes antes de executar operações.",
-    "Comparar desempenho e precisão das operações realizadas em cenários distintos."
+    "Aplicar transposição no boletim para comparar turmas e disciplinas.",
+    "Executar agregações que combinam notas e pesos pedagógicos.",
+    "Interpretar indicadores gerados e propor ações para cada estudante."
   ],
   "outcomes": [
-    "Disponibiliza funções que executam operações matriciais retornando resultados corretos.",
-    "Entrega conjunto de testes automatizados ou planilhas que validam dimensões e saídas.",
-    "Documenta análise descrevendo tempo de execução e limitações observadas."
+    "Disponibiliza módulo que gera boletins transpostos e agregados com pesos.",
+    "Entrega planilha ou testes que validam dimensões e resultados das operações.",
+    "Documenta análise destacando prioridades de intervenção para a turma TechED."
   ],
   "prerequisites": ["Compreensão de matrizes 2D (Aula 33).", "Conforto com loops for aninhados."],
-  "tags": ["matrizes", "arrays", "multiplicacao"],
+  "tags": ["matrizes", "arrays", "multiplicacao", "boletins"],
   "duration": 100,
   "modality": "in-person",
   "resources": [
@@ -51,18 +51,18 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Em duplas ou trios, resolvam as questões a seguir para reforçar o aprendizado durante a aula."
+          "text": "Em duplas ou trios, transformem o boletim da Aula 33 nos indicadores solicitados a seguir."
         },
         {
           "type": "orderedList",
           "items": [
             {
-              "title": "Questão teórica",
-              "text": "Explique com suas palavras os principais conceitos abordados em \"Manipulações com Matrizes\" e destaque por que eles são importantes para a resolução de problemas."
+              "title": "Questão teórica — Indicadores do boletim",
+              "text": "Explique como transposição, soma e multiplicação matricial ajudam a revelar padrões no boletim TechED."
             },
             {
-              "title": "Questão prática",
-              "text": "Implemente ou descreva um exemplo curto relacionado a \"Manipulações com Matrizes\" utilizando OnlineGDB ou Dev-C++ e compartilhe o resultado com o grupo."
+              "title": "Questão prática — Painel por disciplina",
+              "text": "Implemente uma função que transponha o boletim e gere médias por disciplina para compartilhar com o grupo."
             }
           ]
         }
@@ -89,16 +89,16 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Revise os materiais desta aula aqui no site e anote os pontos-chave que precisam de atenção. Identifique dúvidas ou conceitos que merecem ser revisitados durante o encontro."
+          "text": "Revise os apontamentos produzidos no relatório do boletim TechED (Aula 33) e identifique quais indicadores precisam ser recalculados."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Reserve alguns minutos para tentar resolver mentalmente um exemplo relacionado ao tema da aula."
+              "text": "Projete como ficará a matriz transposta (disciplinas x estudantes) e traga dúvidas sobre dimensões."
             },
             {
-              "text": "Garanta acesso ao OnlineGDB ou ao Dev-C++ para experimentar os códigos durante a aula."
+              "text": "Garanta acesso aos datasets boletim-tech-ed.csv e pesos-bimestres.csv para cruzar informações durante a aula."
             }
           ]
         }
@@ -111,42 +111,42 @@
         {
           "icon": "clock",
           "title": "Revisão",
-          "content": "Recapitular declaração de matrizes e loops (10 min)."
+          "content": "Revisar boletim base e relatório entregue na Aula 33 (10 min)."
         },
         {
           "icon": "settings",
           "title": "Transposição",
-          "content": "Converter linhas em colunas com matriz auxiliar (25 min)."
+          "content": "Transpor boletim para visualizar disciplinas por estudante (25 min)."
         },
         {
           "icon": "database",
           "title": "Soma e diferença",
-          "content": "Construir funções elementwise (20 min)."
+          "content": "Construir funções de soma para comparar turmas e bimestres (20 min)."
         },
         {
           "icon": "cpu",
           "title": "Multiplicação",
-          "content": "Multiplicar matrizes A(m x n) e B(n x p) (35 min)."
+          "content": "Multiplicar boletim por pesos dos projetos integradores (35 min)."
         },
         {
           "icon": "check-circle",
           "title": "Aplicação guiada",
-          "content": "Usar dataset para combinar indicadores e gerar insights (30 min)."
+          "content": "Aplicar indicadores para priorizar intervenções e montar plano de ação (30 min)."
         }
       ]
     },
     {
       "type": "promptTip",
-      "title": "Prompt para planejar Manipulações com Matrizes",
+      "title": "Prompt para planejar o Boletim Evolutivo",
       "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
-      "audience": "estudantes de Algoritmos I",
-      "prompt": "Você é estudante de Algoritmos I estudando Manipulações com Matrizes. Contexto da aula: Aprofunda o trabalho com matrizes 2D realizando transposição, somas e multiplicação para resolver problemas de relatórios e transformações. Objetivo central: Aplicar operações clássicas de matrizes para gerar indicadores combinados e preparar o terreno para algoritmos de processamento de imagens e dados. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
-      "tags": ["algoritmos", "arrays", "matrizes", "multiplicacao"],
+      "audience": "estudantes de Algoritmos I aprofundando matrizes",
+      "prompt": "Você é estudante de Algoritmos I responsável por transformar o boletim TechED em um painel analítico. Contexto da aula: Aprofunda o boletim com transposição, agregações e multiplicação por pesos. Objetivo central: Transformar o boletim TechED em um painel analítico combinando operações matriciais para revelar padrões e priorizar intervenções pedagógicas. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando leituras, exercícios em C e perguntas que ajudem a validar dimensões e resultados. Sugira estratégias para interpretar indicadores e propor ações pedagógicas.",
+      "tags": ["algoritmos", "arrays", "matrizes", "multiplicacao", "boletins"],
       "tips": [
-        "Peça ao assistente variações de exercícios que reforcem implementar funções para transpor e somar matrizes.",
-        "Solicite exemplos adicionais relacionados a matrizes, arrays para praticar.",
-        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
-        "Peça sugestões de autoavaliação que ajudem você a executar multiplicação matricial com três loops."
+        "Peça ao assistente variações de exercícios que reforcem a transposição do boletim e verificação de dimensões.",
+        "Solicite exemplos de multiplicação por pesos para calcular índices de desempenho.",
+        "Peça checklists para validar se as somas preservam médias corretas por bimestre.",
+        "Peça sugestões de perguntas para comunicar os resultados às coordenações."
       ]
     },
     {
@@ -156,32 +156,32 @@
         {
           "icon": "check-circle",
           "title": "8 min",
-          "content": "Check-in com quiz sobre matrizes."
+          "content": "Check-in com quiz sobre compatibilidade de dimensões no boletim."
         },
         {
           "icon": "check-circle",
           "title": "17 min",
-          "content": "Código ao vivo da função transpose."
+          "content": "Código ao vivo das funções transpose_boletim e soma_bimestres."
         },
         {
           "icon": "check-circle",
           "title": "(13 min) Exercício individual",
-          "content": "soma de matrizes."
+          "content": "(13 min) Exercício individual — gerar quadro comparativo por disciplina."
         },
         {
           "icon": "check-circle",
           "title": "(29 min) Workshop",
-          "content": "multiplicação com validação de dimensões."
+          "content": "(29 min) Workshop — aplicar pesos e consolidar índice de desempenho."
         },
         {
           "icon": "check-circle",
           "title": "(21 min) Estudo de caso",
-          "content": "combinar matrizes de indicadores do JSON."
+          "content": "(21 min) Estudo de caso — redigir recomendações com base nos indicadores."
         },
         {
           "icon": "check-circle",
           "title": "12 min",
-          "content": "Apresentação rápida dos resultados por squads."
+          "content": "12 min — Apresentação rápida dos insights por squads para o boletim."
         }
       ]
     },
@@ -193,16 +193,16 @@
           "type": "unorderedList",
           "items": [
             {
-              "text": "Operação: Transposição | Pré-condição: Matriz m x n | Assinatura sugerida: void transpose(int src[m][n], int dst[n][m]) | Observações: Usar matrizes distintas para evitar sobrescrita."
+              "text": "Operação: Transposição | Contexto: boletim disciplinas x estudantes | Assinatura sugerida: void transpose_boletim(float origem[ALUNOS][DISCIPLINAS], float destino[DISCIPLINAS][ALUNOS]) | Observações: Reaproveite cabeçalhos das disciplinas."
             },
             {
-              "text": "Operação: Soma | Pré-condição: Mesmas dimensões | Assinatura sugerida: void add(int A[m][n], int B[m][n], int C[m][n]) | Observações: Executar operação elemento a elemento."
+              "text": "Operação: Soma | Contexto: combinar boletins de turmas paralelas | Assinatura sugerida: void somar_boletins(float A[ALUNOS][DISCIPLINAS], float B[ALUNOS][DISCIPLINAS], float R[ALUNOS][DISCIPLINAS]) | Observações: Normalize por quantidade de turmas."
             },
             {
-              "text": "Operação: Subtração | Pré-condição: Mesmas dimensões | Assinatura sugerida: void subtract(int A[m][n], int B[m][n], int C[m][n]) | Observações: Útil para variação entre indicadores."
+              "text": "Operação: Multiplicação | Contexto: aplicar pesos de avaliações | Assinatura sugerida: void aplicar_pesos(float boletim[ALUNOS][DISCIPLINAS], float pesos[DISCIPLINAS][AVALIACOES], float indice[ALUNOS][AVALIACOES]) | Observações: Conferir compatibilidade antes do cálculo."
             },
             {
-              "text": "Operação: Multiplicação | Pré-condição: A m x n, B n x p | Assinatura sugerida: void multiply(int A[m][n], int B[n][p], int C[m][p]) | Observações: Três loops e acumulador local."
+              "text": "Operação: Validação | Contexto: relatório final do boletim | Assinatura sugerida: int validar_dimensoes(int linhasA, int colunasA, int linhasB, int colunasB) | Observações: Documente mensagens claras para o time pedagógico."
             },
             {
               "text": "Operação: Escalonamento | Pré-condição: Qualquer dimensão | Assinatura sugerida: void scale(float A[m][n], float fator) | Observações: Multiplica cada elemento pelo fator."
@@ -380,7 +380,12 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Utilize a planilha do Campus Vale para justificar cada decisão técnica com base na bibliografia."
+          "text": "Utilize a planilha do Campus Vale para justificar cada decisão técnica com base na bibliografia.",
+          "items": [
+            "Gerar relatório comparando médias de cada disciplina entre as turmas A e B.",
+            "Construir função que identifica disciplinas com maior variação entre bimestres.",
+            "Compartilhar gráfico ou tabela com os indicadores no fórum do boletim."
+          ]
         },
         {
           "type": "list",
@@ -399,16 +404,16 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Reserve um momento após a aula para concluir a atividade descrita a seguir. Ela complementa os estudos e ajuda a consolidar o que foi trabalhado em sala."
+          "text": "Finalize os indicadores do boletim TechED e registre um relatório textual que dê continuidade ao envio da Aula 33."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Desenvolva a prática proposta na aula registrando os passos e resultados no caderno ou no editor de sua preferência."
+              "text": "Compile um relatório (máx. 3 páginas) com tabelas transpostas, médias por bimestre e ranking de estudantes, justificando prioridades."
             },
             {
-              "text": "Anote dúvidas e insights que surgirem para discutirmos na próxima aula."
+              "text": "Liste dúvidas sobre pesos ou interpretação e proponha perguntas para validação na Aula 35."
             }
           ]
         }
@@ -464,8 +469,25 @@
       "content": [
         {
           "type": "code",
-          "code": "# Soma por linha\n[[1,2],[3,4]] -> L1=3, L2=7",
+          "code": "# Transposição boletim 3x2\n{ {7.0, 6.0}, {8.5, 7.5}, {6.5, 5.5} } -> gera disciplinas x estudantes com médias.",
           "language": "plaintext"
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Materiais para estações e slides",
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Cartaz Estação Indicadores do Boletim — /courses/algi/estacao-boletim-analises.md"
+            },
+            {
+              "text": "Diagrama de memória — matrizes com pesos — /courses/algi/memory-diagrama-boletim.md"
+            }
+          ]
         }
       ]
     },

--- a/src/content/courses/algi/lessons/lesson-35.json
+++ b/src/content/courses/algi/lessons/lesson-35.json
@@ -1,31 +1,31 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-35",
-  "title": "Introdução a Structs (Registros)",
-  "summary": "Apresenta structs em C como registros compostos e conduz um CRUD básico em memória para consolidar o modelo de dados.",
-  "description": "Apresenta structs em C como registros compostos e organiza um CRUD inicial para consolidar o modelo de dados.",
-  "objective": "Compreender a declaração, instância e manipulação inicial de structs em C, preparando-se para coleções de registros.",
+  "title": "Introdução a Structs — Catálogo de Estoque",
+  "summary": "Apresenta structs em C para representar produtos do estoque TechParts e prepara o catálogo base para as próximas aulas.",
+  "description": "Constrói o registro Produto do estoque TechParts e estabelece operações iniciais de cadastro e consulta que serão expandidas nas Aulas 36 e 37.",
+  "objective": "Compreender como modelar um produto em C com structs, inicializar registros e preparar um mini-CRUD focado em criação e leitura para o estoque TechParts.",
   "objectives": [
-    "Declarar structs com campos adequados ao domínio proposto.",
-    "Inicializar e acessar membros por ponto e ponteiros.",
-    "Construir um mini-CRUD em memória com ênfase em criação e leitura."
+    "Declarar a struct Produto com campos essenciais para controle de estoque.",
+    "Inicializar registros e acessar membros por ponto e ponteiros em operações de cadastro e consulta.",
+    "Construir um mini-CRUD em memória que registre entradas iniciais de produtos."
   ],
   "competencies": ["05", "11"],
   "skills": [
-    "Definir structs representando registros compostos com campos coerentes.",
-    "Implementar operações CRUD em memória validando entrada e saída de dados.",
-    "Registrar casos de teste que comprovem a integridade do fluxo de operações."
+    "Definir structs coerentes com políticas de estoque e SKU.",
+    "Implementar operações de criação e leitura validando dados obrigatórios.",
+    "Registrar casos de teste que comprovem o cadastro inicial do catálogo TechParts."
   ],
   "outcomes": [
-    "Entrega módulo com definição de struct e funções para criar, ler, atualizar e remover registros.",
-    "Anexa log de testes cobrindo operações bem-sucedidas e tratamento de erros.",
-    "Apresenta documentação resumida orientando como utilizar o CRUD implementado."
+    "Entrega módulo com struct Produto e funções para cadastrar e listar itens do estoque.",
+    "Anexa log de testes cobrindo cenários de cadastro e validação de campos obrigatórios.",
+    "Apresenta documento resumo orientando como o catálogo inicial alimenta o controle de estoque das aulas seguintes."
   ],
   "prerequisites": [
     "Conhecimento de vetores simples (Aula 30).",
     "Noções de funções e passagem de parâmetros."
   ],
-  "tags": ["structs", "crud", "revisao"],
+  "tags": ["structs", "crud", "revisao", "estoque"],
   "duration": 100,
   "modality": "in-person",
   "resources": [
@@ -46,18 +46,18 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Em duplas ou trios, resolvam as questões a seguir para reforçar o aprendizado durante a aula."
+          "text": "Em duplas ou trios, elaborem o catálogo inicial da TechParts seguindo as questões abaixo."
         },
         {
           "type": "orderedList",
           "items": [
             {
-              "title": "Questão teórica",
-              "text": "Explique com suas palavras os principais conceitos abordados em \"Introdução a Structs (Registros)\" e destaque por que eles são importantes para a resolução de problemas."
+              "title": "Questão teórica — Modelagem de produto",
+              "text": "Explique como os campos da struct Produto garantem rastreabilidade no estoque TechParts e como isso se conecta às aulas seguintes."
             },
             {
-              "title": "Questão prática",
-              "text": "Implemente ou descreva um exemplo curto relacionado a \"Introdução a Structs (Registros)\" utilizando OnlineGDB ou Dev-C++ e compartilhe o resultado com o grupo."
+              "title": "Questão prática — Cadastro inicial",
+              "text": "Implemente uma função que recebe dados de um novo SKU e adiciona ao vetor base, exibindo confirmação formatada."
             }
           ]
         }
@@ -84,16 +84,16 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Revise os materiais desta aula aqui no site e anote os pontos-chave que precisam de atenção. Identifique dúvidas ou conceitos que merecem ser revisitados durante o encontro."
+          "text": "Revise o inventário parcial enviado pela gerência TechParts com 15 SKUs prioritários e identifique campos obrigatórios."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Reserve alguns minutos para tentar resolver mentalmente um exemplo relacionado ao tema da aula."
+              "text": "Liste três atributos que não podem faltar em Produto e traga justificativas."
             },
             {
-              "text": "Garanta acesso ao OnlineGDB ou ao Dev-C++ para experimentar os códigos durante a aula."
+              "text": "Confirme acesso ao arquivo estoque-techparts.csv para importar dados durante a aula."
             }
           ]
         }
@@ -106,42 +106,42 @@
         {
           "icon": "clock",
           "title": "Aquecimento",
-          "content": "Quiz com cinco cenários para identificar campos de dados (10 min)."
+          "content": "Aquecimento com quiz sobre atributos de produtos TechParts (10 min)."
         },
         {
           "icon": "database",
           "title": "Sintaxe de struct",
-          "content": "Declaração, typedef e alinhamento na memória (25 min)."
+          "content": "Sintaxe de struct Produto, typedef e alinhamento para estoque (25 min)."
         },
         {
           "icon": "code",
           "title": "Manipulação",
-          "content": "Atribuições, acesso por ponto/seta e funções auxiliares (20 min)."
+          "content": "Manipulação de campos, leitura e impressão formatada do catálogo (20 min)."
         },
         {
           "icon": "gears",
           "title": "Mini-CRUD",
-          "content": "Criar e listar registros de Empresas em vetor fixo (35 min)."
+          "content": "Mini-CRUD: cadastrar e listar SKUs com vetor local (35 min)."
         },
         {
           "icon": "check-circle",
           "title": "Retrospectiva",
-          "content": "Mapa mental com principais boas práticas (15 min)."
+          "content": "Retrospectiva conectando catálogo inicial às necessidades da Aula 36 (15 min)."
         }
       ]
     },
     {
       "type": "promptTip",
-      "title": "Prompt para planejar Introdução a Structs (Registros)",
+      "title": "Prompt para planejar o Catálogo TechParts",
       "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
-      "audience": "estudantes de Algoritmos I",
-      "prompt": "Você é estudante de Algoritmos I estudando Introdução a Structs (Registros). Contexto da aula: Apresenta structs em C como registros compostos e conduz um CRUD básico em memória para consolidar o modelo de dados. Objetivo central: Compreender a declaração, instância e manipulação inicial de structs em C, preparando-se para coleções de registros. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
-      "tags": ["algoritmos", "crud", "revisao", "structs"],
+      "audience": "estudantes de Algoritmos I focados em structs",
+      "prompt": "Você é estudante de Algoritmos I encarregado de montar o catálogo de estoque da TechParts usando structs. Contexto da aula: Apresenta structs em C para representar produtos e montar um mini-CRUD inicial. Objetivo central: Compreender a declaração, instância e manipulação inicial de structs em C, preparando o catálogo que será expandido nas Aulas 36 e 37. Monte um plano de estudo com revisão teórica, prática guiada e autoavaliação incluindo exercícios em C, validações de dados e perguntas de checagem para os campos obrigatórios.",
+      "tags": ["algoritmos", "crud", "structs", "estoque"],
       "tips": [
-        "Peça ao assistente variações de exercícios que reforcem declarar structs com campos adequados ao domínio proposto.",
-        "Solicite exemplos adicionais relacionados a structs, crud para praticar.",
-        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
-        "Peça sugestões de autoavaliação que ajudem você a inicializar e acessar membros por ponto e ponteiros."
+        "Peça ao assistente checklists de campos obrigatórios para o produto TechParts.",
+        "Solicite exemplos de funções que retornem ponteiros para Produto cadastrado.",
+        "Peça orientações para documentar o fluxo de cadastro e preparar logs para a Aula 36.",
+        "Peça perguntas para validar com a gerência a qualidade dos dados inseridos."
       ]
     },
     {
@@ -151,32 +151,32 @@
         {
           "icon": "check-circle",
           "title": "9 min",
-          "content": "Icebreaker com cartões de atributos empresariais."
+          "content": "Icebreaker: cartões com categorias do estoque TechParts."
         },
         {
           "icon": "check-circle",
           "title": "(18 min) Live coding",
-          "content": "declaração e inicialização de Empresa."
+          "content": "(18 min) Live coding — declaração e inicialização da struct Produto."
         },
         {
           "icon": "check-circle",
           "title": "(13 min) Exercício individual",
-          "content": "função para imprimir struct formatada."
+          "content": "(13 min) Exercício individual — função para imprimir Produto formatado com status de reposição."
         },
         {
           "icon": "check-circle",
           "title": "(26 min) Laboratório guiado",
-          "content": "operações create/list com vetor local."
+          "content": "(26 min) Laboratório guiado — cadastrar itens no vetor base e salvar log."
         },
         {
           "icon": "check-circle",
           "title": "(17 min) Debriefing",
-          "content": "decisões de modelagem e validação de dados."
+          "content": "(17 min) Debriefing — validar campos e preparar plano de reabastecimento."
         },
         {
           "icon": "check-circle",
           "title": "17 min",
-          "content": "Check-out com quiz interativo (Kahoot) sobre sintaxe de structs."
+          "content": "17 min — Quiz interativo sobre regras de estoque e sintaxe de structs."
         }
       ]
     },
@@ -237,7 +237,7 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Utilize dados de perfil do Microempreendedor Individual disponíveis no portal do SEBRAE para sugerir campos realistas e discutir ética no uso de dados."
+          "text": "Utilize o inventário público da TechParts (planilha fornecida) para sugerir campos realistas e discutir ética na atualização de dados de estoque."
         }
       ]
     },
@@ -248,16 +248,16 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Reserve um momento após a aula para concluir a atividade descrita a seguir. Ela complementa os estudos e ajuda a consolidar o que foi trabalhado em sala."
+          "text": "Finalize o cadastro inicial da TechParts e produza a documentação textual solicitada para alimentar a base do módulo de estoque."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Desenvolva a prática proposta na aula registrando os passos e resultados no caderno ou no editor de sua preferência."
+              "text": "Cadastre ao menos 10 produtos e entregue um relatório textual (1-2 páginas) descrevendo campos, validações e pendências para o estoque."
             },
             {
-              "text": "Anote dúvidas e insights que surgirem para discutirmos na próxima aula."
+              "text": "Liste dúvidas sobre campos complementares ou regras de negócio para discutirmos na Aula 36."
             }
           ]
         }
@@ -265,17 +265,34 @@
     },
     {
       "type": "tabs",
-      "title": "Struct — definição × uso",
+      "title": "Struct Produto — definição × uso",
       "tabs": [
         {
           "label": "Definição",
-          "code": "typedef struct { char nome[50]; int idade; } Pessoa;",
+          "code": "typedef struct {\n  int sku;\n  char nome[40];\n  int quantidade;\n  float preco;\n} Produto;",
           "language": "c"
         },
         {
           "label": "Uso",
-          "code": "Pessoa p; scanf(\"%s %d\", p.nome, &p.idade);",
+          "code": "Produto p = {101, \"Kit Sensor\", 12, 189.90f};\nprintProduto(p);",
           "language": "c"
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Materiais para estações e slides",
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Cartaz Estação Catálogo TechParts — /courses/algi/estacao-estoque-struct.md"
+            },
+            {
+              "text": "Diagrama de memória — vetor de structs (base) — /courses/algi/memory-diagrama-estoque.md"
+            }
+          ]
         }
       ]
     },
@@ -301,7 +318,7 @@
       "content": [
         {
           "type": "code",
-          "code": "# Struct Pessoa\nEntrada: Ana 20 -> Pessoa{nome=Ana, idade=20}",
+          "code": "# Produto\nEntrada: SKU 5001, \"Cabo HDMI\", quantidade 20, preço 39.90 -> imprime linha formatada.",
           "language": "plaintext"
         }
       ]

--- a/src/content/courses/algi/lessons/lesson-36.json
+++ b/src/content/courses/algi/lessons/lesson-36.json
@@ -1,31 +1,31 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-36",
-  "title": "Vetores de Structs",
-  "summary": "Constrói coleções de registros com structs em vetor e prepara o terreno para operações CRUD completas.",
-  "description": "Organiza coleções de registros com structs em vetor, adicionando ordenação e relatórios.",
-  "objective": "Estruturar vetores de structs para representar catálogos de dados e aplicar operações coletivas de ordenação e agregação.",
+  "title": "Vetores de Structs — Operações de Estoque",
+  "summary": "Expande o catálogo TechParts para vetores de structs com ordenação e relatórios de estoque.",
+  "description": "Organiza coleções de produtos TechParts em vetores de structs, adicionando ordenação, reabastecimento e relatórios que serão usados na Aula 37.",
+  "objective": "Estruturar vetores de structs para representar o estoque completo da TechParts e aplicar operações coletivas de ordenação, reposição e auditoria.",
   "objectives": [
-    "Armazenar múltiplos registros em vetores de structs com limites configuráveis.",
-    "Aplicar ordenação simples para organizar a coleção.",
-    "Documentar o estado da coleção com relatórios resumidos."
+    "Armazenar múltiplos produtos em vetores de structs com limites configuráveis e status de reposição.",
+    "Aplicar ordenação simples para priorizar reposição e análise de giro.",
+    "Documentar o estado da coleção com relatórios resumidos enviados à gerência."
   ],
   "competencies": ["05", "12"],
   "skills": [
-    "Organizar vetores de structs definindo estratégias de inserção e busca.",
-    "Garantir consistência dos dados ao realizar atualizações em lote.",
-    "Conduzir revisão em pares verificando aderência a padrões de dados da turma."
+    "Organizar vetores de structs definindo estratégias de inserção, busca e atualização de estoque.",
+    "Garantir consistência dos dados ao realizar ordenações e atualizações em lote.",
+    "Conduzir revisão em pares verificando aderência às políticas de estoque da TechParts."
   ],
   "outcomes": [
-    "Entrega repositório em memória com operações de listagem e inserção validadas.",
-    "Registra testes que comprovam manutenção da integridade após múltiplas atualizações.",
-    "Documenta feedback trocado com o par e ajustes implementados na estrutura de dados."
+    "Entrega repositório em memória com operações de listagem, inserção e ordenação validadas.",
+    "Registra testes que comprovam manutenção da integridade após múltiplas atualizações de estoque.",
+    "Documenta feedback trocado com o par e ajustes implementados na estrutura de dados do estoque."
   ],
   "prerequisites": [
     "Domínio da declaração e uso de structs (Aula 35).",
     "Conhecimento prévio de ordenação básica."
   ],
-  "tags": ["structs", "crud", "revisao"],
+  "tags": ["structs", "crud", "revisao", "estoque"],
   "duration": 100,
   "modality": "in-person",
   "resources": [
@@ -54,18 +54,18 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Em duplas ou trios, resolvam as questões a seguir para reforçar o aprendizado durante a aula."
+          "text": "Em duplas ou trios, ampliem o catálogo TechParts criado na Aula 35 para suportar as operações de ordenação e auditoria abaixo."
         },
         {
           "type": "orderedList",
           "items": [
             {
-              "title": "Questão teórica",
-              "text": "Explique com suas palavras os principais conceitos abordados em \"Vetores de Structs\" e destaque por que eles são importantes para a resolução de problemas."
+              "title": "Questão teórica — Vetores de produtos",
+              "text": "Explique como armazenar múltiplos Produtos em vetor garante rastreabilidade e como isso será usado na Aula 37."
             },
             {
-              "title": "Questão prática",
-              "text": "Implemente ou descreva um exemplo curto relacionado a \"Vetores de Structs\" utilizando OnlineGDB ou Dev-C++ e compartilhe o resultado com o grupo."
+              "title": "Questão prática — Ordenação por estoque crítico",
+              "text": "Implemente uma rotina que ordena o vetor de produtos pelo nível de estoque crescente destacando itens críticos."
             }
           ]
         }
@@ -92,16 +92,16 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Revise os materiais desta aula aqui no site e anote os pontos-chave que precisam de atenção. Identifique dúvidas ou conceitos que merecem ser revisitados durante o encontro."
+          "text": "Revise o relatório textual da Aula 35 e traga o vetor inicial com os produtos cadastrados para evoluirmos as operações."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Reserve alguns minutos para tentar resolver mentalmente um exemplo relacionado ao tema da aula."
+              "text": "Verifique se o vetor possui capacidade e contador separados para facilitar inserções."
             },
             {
-              "text": "Garanta acesso ao OnlineGDB ou ao Dev-C++ para experimentar os códigos durante a aula."
+              "text": "Atualize o arquivo estoque-techparts.csv com novos campos (estoque mínimo, status) para uso na aula."
             }
           ]
         }
@@ -114,42 +114,42 @@
         {
           "icon": "clock",
           "title": "Check-in",
-          "content": "Revisão relâmpago sobre structs individuais (10 min)."
+          "content": "Check-in: validar catálogo da Aula 35 e definir metas de reposição (10 min)."
         },
         {
           "icon": "database",
           "title": "Coleções",
-          "content": "Configuração de vetores de structs e contadores de uso (25 min)."
+          "content": "Configurar vetor de Produto com limites, contadores e status (25 min)."
         },
         {
           "icon": "settings",
           "title": "Ordenação",
-          "content": "Comparadores personalizados com Bubble/Insertion Sort (30 min)."
+          "content": "Implementar ordenação por estoque e giro (30 min)."
         },
         {
           "icon": "database",
           "title": "Relatórios",
-          "content": "Geração de ranking de faturamento e segmentação por setor (25 min)."
+          "content": "Gerar relatórios de ranking, reabastecimento e indicadores (25 min)."
         },
         {
           "icon": "check-circle",
           "title": "Wrap-up",
-          "content": "Debate sobre limitações de armazenamento estático (20 min)."
+          "content": "Wrap-up: preparar backlog de buscas e atualizações para a Aula 37 (20 min)."
         }
       ]
     },
     {
       "type": "promptTip",
-      "title": "Prompt para planejar Vetores de Structs",
+      "title": "Prompt para planejar operações de estoque",
       "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
-      "audience": "estudantes de Algoritmos I",
-      "prompt": "Você é estudante de Algoritmos I estudando Vetores de Structs. Contexto da aula: Constrói coleções de registros com structs em vetor e prepara o terreno para operações CRUD completas. Objetivo central: Estruturar vetores de structs para representar catálogos de dados e aplicar operações coletivas de ordenação e agregação. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
-      "tags": ["algoritmos", "crud", "revisao", "structs"],
+      "audience": "estudantes de Algoritmos I evoluindo structs",
+      "prompt": "Você é estudante de Algoritmos I responsável por ampliar o catálogo da TechParts para um vetor de structs com ordenação e relatórios. Contexto da aula: Constrói coleções de registros com structs em vetor, adicionando ordenação e relatórios. Objetivo central: Estruturar vetores de structs para representar o estoque completo da TechParts e aplicar operações coletivas de ordenação e agregação. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação com exercícios em C, casos de teste e perguntas para validar consistência após ordenações.",
+      "tags": ["algoritmos", "crud", "structs", "estoque"],
       "tips": [
-        "Peça ao assistente variações de exercícios que reforcem armazenar múltiplos registros em vetores de structs com limites configuráveis.",
-        "Solicite exemplos adicionais relacionados a structs, crud para praticar.",
-        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
-        "Peça sugestões de autoavaliação que ajudem você a aplicar ordenação simples para organizar a coleção."
+        "Peça ao assistente roteiros para ordenar produtos por estoque e preço.",
+        "Solicite exemplos de relatórios em texto para comunicar resultados à diretoria.",
+        "Peça checklists para garantir que contadores de itens e estoques mínimos sejam atualizados corretamente.",
+        "Peça perguntas para revisar com o par eventuais inconsistências antes da Aula 37."
       ]
     },
     {
@@ -159,32 +159,32 @@
         {
           "icon": "check-circle",
           "title": "12 min",
-          "content": "Icebreaker com cards de dados reais SEBRAE."
+          "content": "Icebreaker com cards de demanda TechParts."
         },
         {
           "icon": "check-circle",
           "title": "(17 min) Live coding",
-          "content": "carga inicial do vetor com dados fictícios."
+          "content": "(17 min) Live coding — carga inicial do vetor com produtos e estoques."
         },
         {
           "icon": "check-circle",
           "title": "(21 min) Oficina",
-          "content": "implementar função de ordenação crescente por faturamento."
+          "content": "(21 min) Oficina — implementar ordenação crescente por estoque atual."
         },
         {
           "icon": "check-circle",
           "title": "(25 min) Laboratório orientado",
-          "content": "integrar ordenação ao menu CRUD."
+          "content": "(25 min) Laboratório orientado — integrar ordenação e cálculo de reposição mínima."
         },
         {
           "icon": "check-circle",
           "title": "(17 min) Relato rápido por squads",
-          "content": "métricas derivadas do vetor."
+          "content": "(17 min) Relato rápido — métricas derivadas do vetor para a diretoria."
         },
         {
           "icon": "check-circle",
           "title": "8 min",
-          "content": "Quiz interativo sobre complexidade e estabilidade de ordenações."
+          "content": "8 min — Quiz interativo sobre complexidade e políticas de estoque."
         }
       ]
     },
@@ -196,19 +196,19 @@
           "type": "unorderedList",
           "items": [
             {
-              "text": "Algoritmo: Bubble Sort | Quando usar: Listas pequenas e necessidade de implementação rápida | Custo: O(n^2) | Observações: Fácil de adaptar para ordenação decrescente."
+              "text": "Algoritmo: Bubble Sort | Contexto: ordenar produtos por estoque para identificar reposição imediata | Custo: O(n^2) | Observações: Fácil de adaptar para ordenar por preço."
             },
             {
-              "text": "Algoritmo: Insertion Sort | Quando usar: Coleções quase ordenadas | Custo: O(n^2) | Observações: Bom para inserir novos registros mantendo a ordem."
+              "text": "Algoritmo: Insertion Sort | Contexto: ajustar vetor quase ordenado após importação de poucos SKUs | Custo: O(n^2) | Observações: Mantém vetor estável para relatórios diários."
             },
             {
-              "text": "Algoritmo: qsort (stdlib) | Quando usar: Quando o custo de implementação importa | Custo: O(n log n) | Observações: Exige comparador consistente e inclui ponteiros void."
+              "text": "Algoritmo: qsort (stdlib) | Contexto: gerar relatórios de grande volume para a diretoria | Custo: O(n log n) | Observações: Exige comparador consistente (estoque, SKU)."
             },
             {
-              "text": "Algoritmo: Selection Sort | Quando usar: Situações de memória crítica | Custo: O(n^2) | Observações: Poucas trocas, útil para dados estáticos."
+              "text": "Algoritmo: Selection Sort | Contexto: ambiente com memória limitada para kits legados | Custo: O(n^2) | Observações: Poucas trocas, útil para inventários estáticos."
             },
             {
-              "text": "Algoritmo: Counting Sort | Quando usar: Campos inteiros com domínio pequeno | Custo: O(n + k) | Observações: Requer estrutura auxiliar e limites bem definidos."
+              "text": "Algoritmo: Counting Sort | Contexto: classificar produtos por faixa de estoque mínimo | Custo: O(n + k) | Observações: Requer conhecer limites de estoque mínimo previamente."
             }
           ]
         }
@@ -216,23 +216,23 @@
     },
     {
       "type": "contentBlock",
-      "title": "Estudo de caso: Cooperativa TechSul",
+      "title": "Estudo de caso: TechParts em expansão",
       "content": [
         {
           "type": "paragraph",
-          "text": "A Cooperativa TechSul atende pequenos negócios de tecnologia e precisa auditar contratos trimestrais. Forbellone & Eberspächer (Cap. 12) defendem separar contadores ativos, enquanto Santos (Cap. 14) recomenda registrar logs das operações CRUD."
+          "text": "A TechParts expandiu para vendas on-line e precisa auditar o giro trimestral do estoque. Forbellone & Eberspächer (Cap. 12) recomendam separar contadores ativos, enquanto Santos (Cap. 14) reforça logs das operações CRUD."
         },
         {
           "type": "unorderedList",
           "items": [
             {
-              "text": "Implemente funções de ordenação conforme Backes (Cap. 12) para classificar por faturamento e nível de risco."
+              "text": "Implemente funções de ordenação conforme Backes (Cap. 12) para priorizar reposição por estoque e giro."
             },
             {
-              "text": "Relacione cada atualização ao checklist de auditoria de Ascencio & Campos (Cap. 9), anexando evidências."
+              "text": "Relacione cada atualização ao checklist de auditoria e registre motivo da reposição no relatório enviado à gerência."
             },
             {
-              "text": "Documente métricas de tempo e trocas na planilha do case, inspirando-se em Manzano & Oliveira (Cap. 13) para análise crítica."
+              "text": "Documente métricas de tempo e trocas inspiradas em Manzano & Oliveira (Cap. 13) para justificar investimentos em automação."
             }
           ]
         }
@@ -245,7 +245,7 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Ascencio & Campos (Cap. 9) orientam anonimizar campos sensíveis. Registre na planilha de auditoria o protocolo seguido, alinhando-se às recomendações de Santos (Cap. 14) sobre logs."
+          "text": "Ascencio & Campos (Cap. 9) orientam anonimizar campos sensíveis (margem, custo). Registre no relatório de auditoria da TechParts o protocolo seguido, alinhando-se às recomendações de Santos (Cap. 14) sobre logs."
         }
       ]
     },
@@ -256,16 +256,16 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Reserve um momento após a aula para concluir a atividade descrita a seguir. Ela complementa os estudos e ajuda a consolidar o que foi trabalhado em sala."
+          "text": "Consolide o vetor de produtos com ordenação e produza o relatório textual solicitado pela diretoria TechParts."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Desenvolva a prática proposta na aula registrando os passos e resultados no caderno ou no editor de sua preferência."
+              "text": "Entregue relatório (até 3 páginas) com ranking de produtos críticos, totais de reposição e metodologia utilizada no código."
             },
             {
-              "text": "Anote dúvidas e insights que surgirem para discutirmos na próxima aula."
+              "text": "Registre dúvidas sobre performance ou consistência e leve-as para a Aula 37 (buscas e atualizações)."
             }
           ]
         }
@@ -273,19 +273,19 @@
     },
     {
       "type": "stepper",
-      "title": "Vetor de structs",
+      "title": "Vetor de Produto TechParts",
       "steps": [
         {
           "title": "Declaração",
-          "description": "Pessoa turma[50];"
+          "description": "Produto estoque[MAX_ITENS]; contador = 0;"
         },
         {
           "title": "Preenchimento",
-          "description": "for ... scanf(...)"
+          "description": "for (...) carregar dados do CSV estoque-techparts.csv"
         },
         {
           "title": "Consulta",
-          "description": "Buscar por matrícula"
+          "description": "Buscar por SKU e gerar relatório de reposição"
         }
       ]
     },
@@ -311,8 +311,25 @@
       "content": [
         {
           "type": "code",
-          "code": "# Vetor de produtos (3) -> lista formatada",
+          "code": "# Ordenação por estoque\nEntrada: {Produto{sku=101, qtd=5}, Produto{sku=102, qtd=12}} -> ordenar crescente e sinalizar reposição.",
           "language": "plaintext"
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Materiais para estações e slides",
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Cartaz Estação Operações de Estoque — /courses/algi/estacao-estoque-operacoes.md"
+            },
+            {
+              "text": "Diagrama de memória — vetor ordenado — /courses/algi/memory-diagrama-estoque.md"
+            }
+          ]
         }
       ]
     },

--- a/src/content/courses/algi/lessons/lesson-37.json
+++ b/src/content/courses/algi/lessons/lesson-37.json
@@ -1,31 +1,31 @@
 {
   "formatVersion": "md3.lesson.v1",
   "id": "lesson-37",
-  "title": "Busca e Atualização em Vetores de Structs",
-  "summary": "Refina o CRUD em memória adicionando buscas flexíveis, atualização de campos e estratégias de auditoria.",
-  "description": "Aprofunda operações de busca, atualização e remoção em vetores de structs com foco em integridade.",
-  "objective": "Desenvolver habilidades para localizar, atualizar e remover registros em vetores de structs, garantindo integridade dos dados.",
+  "title": "Busca e Atualização — Estoque TechParts",
+  "summary": "Refina o CRUD do estoque TechParts com buscas flexíveis, atualizações de preço e controle de auditoria.",
+  "description": "Aprofunda operações de busca, atualização e remoção no vetor de produtos TechParts garantindo integridade e rastreabilidade.",
+  "objective": "Desenvolver habilidades para localizar, atualizar e remover produtos no vetor de estoque TechParts garantindo integridade dos dados e histórico.",
   "objectives": [
-    "Implementar buscas lineares e por chave composta.",
-    "Atualizar campos selecionados mantendo histórico mínimo.",
-    "Realizar remoção lógica e física comparando abordagens."
+    "Implementar buscas lineares e por chave composta em produtos do estoque.",
+    "Atualizar campos selecionados (preço, estoque mínimo, status) mantendo histórico.",
+    "Realizar remoção lógica e física comparando impactos no relatório da TechParts."
   ],
   "competencies": ["05", "12"],
   "skills": [
-    "Implementar buscas flexíveis em vetores de structs utilizando filtros variados.",
-    "Aplicar auditoria registrando histórico de alterações e validações.",
-    "Facilitar revisão coletiva alinhando critérios de atualização e rollback."
+    "Implementar buscas flexíveis com filtros por SKU, categoria e status de reposição.",
+    "Aplicar auditoria registrando histórico de alterações, inclusive ajustes de preço.",
+    "Facilitar revisão coletiva alinhando critérios de atualização, rollback e políticas da TechParts."
   ],
   "outcomes": [
-    "Disponibiliza módulo que localiza e atualiza registros com base em múltiplos campos.",
-    "Entrega log de auditoria descrevendo cada alteração realizada e testes associados.",
-    "Coordena reunião de alinhamento documentando decisões sobre políticas de atualização."
+    "Disponibiliza módulo que localiza e atualiza produtos com base em múltiplos campos.",
+    "Entrega log de auditoria descrevendo cada alteração e testes associados.",
+    "Coordena reunião de alinhamento documentando decisões sobre políticas de atualização do estoque."
   ],
   "prerequisites": [
     "Vetores de structs com ordenação básica (Aula 36).",
     "Entendimento de CRUD sequencial."
   ],
-  "tags": ["structs", "crud", "revisao"],
+  "tags": ["structs", "crud", "revisao", "estoque"],
   "duration": 100,
   "modality": "in-person",
   "resources": [
@@ -54,18 +54,18 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Em duplas ou trios, resolvam as questões a seguir para reforçar o aprendizado durante a aula."
+          "text": "Em duplas ou trios, finalize o módulo de estoque TechParts com as buscas e atualizações abaixo."
         },
         {
           "type": "orderedList",
           "items": [
             {
-              "title": "Questão teórica",
-              "text": "Explique com suas palavras os principais conceitos abordados em \"Busca e Atualização em Vetores de Structs\" e destaque por que eles são importantes para a resolução de problemas."
+              "title": "Questão teórica — Políticas de atualização",
+              "text": "Explique como chaves compostas (SKU + lote) evitam inconsistências no estoque TechParts e como registrar histórico de alterações."
             },
             {
-              "title": "Questão prática",
-              "text": "Implemente ou descreva um exemplo curto relacionado a \"Busca e Atualização em Vetores de Structs\" utilizando OnlineGDB ou Dev-C++ e compartilhe o resultado com o grupo."
+              "title": "Questão prática — Atualização guiada",
+              "text": "Implemente uma função que atualiza preço e estoque mínimo de um produto encontrado por SKU, registrando o log correspondente."
             }
           ]
         }
@@ -92,16 +92,16 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Revise os materiais desta aula aqui no site e anote os pontos-chave que precisam de atenção. Identifique dúvidas ou conceitos que merecem ser revisitados durante o encontro."
+          "text": "Revise o relatório da Aula 36 e identifique produtos que exigem atualização imediata (preço ou estoque mínimo)."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Reserve alguns minutos para tentar resolver mentalmente um exemplo relacionado ao tema da aula."
+              "text": "Liste os campos que precisarão de validação cruzada antes da atualização (ex.: SKU, lote, fornecedor)."
             },
             {
-              "text": "Garanta acesso ao OnlineGDB ou ao Dev-C++ para experimentar os códigos durante a aula."
+              "text": "Sincronize o log de auditoria iniciado na Aula 36 para continuar registrando alterações."
             }
           ]
         }
@@ -114,42 +114,42 @@
         {
           "icon": "clock",
           "title": "Kick-off",
-          "content": "Desafio relâmpago com buscas sobre vetor já ordenado (10 min)."
+          "content": "Kick-off: revisar métricas da Aula 36 e mapear necessidades de atualização (10 min)."
         },
         {
           "icon": "target",
           "title": "Estratégias de busca",
-          "content": "Busca linear, sentinela e comparação com busca binária (30 min)."
+          "content": "Explorar estratégias de busca (linear, sentinela, filtros compostos) para localizar produtos (30 min)."
         },
         {
           "icon": "code",
           "title": "Atualizações seguras",
-          "content": "Validação de domínio e campos derivados (30 min)."
+          "content": "Atualizar campos críticos (preço, estoque mínimo) com validações e logs (30 min)."
         },
         {
           "icon": "tasks",
           "title": "Remoções",
-          "content": "Remoção lógica vs física e implicações no ranking (25 min)."
+          "content": "Comparar remoção lógica e física simulando impactos no relatório TechParts (25 min)."
         },
         {
           "icon": "check-circle",
           "title": "Debriefing",
-          "content": "Retro coletiva com métricas de cobertura das operações (20 min)."
+          "content": "Debriefing: consolidar plano de monitoramento contínuo e checklist de auditoria (20 min)."
         }
       ]
     },
     {
       "type": "promptTip",
-      "title": "Prompt para planejar Busca e Atualização em Vetores de Structs",
+      "title": "Prompt para planejar buscas e atualizações do estoque",
       "description": "Use com o assistente para organizar seus estudos, revisar conteúdos e praticar com exercícios.",
-      "audience": "estudantes de Algoritmos I",
-      "prompt": "Você é estudante de Algoritmos I estudando Busca e Atualização em Vetores de Structs. Contexto da aula: Refina o CRUD em memória adicionando buscas flexíveis, atualização de campos e estratégias de auditoria. Objetivo central: Desenvolver habilidades para localizar, atualizar e remover registros em vetores de structs, garantindo integridade dos dados. Monte um plano de estudo dividido em revisão teórica, prática guiada e autoavaliação, indicando atividades de leitura, exercícios resolvidos em C ou pseudocódigo e perguntas de checagem que ajudem você a consolidar o conteúdo. Sugira estratégias para aprofundar o aprendizado, reforçar pontos frágeis e buscar ajuda quando necessário.",
-      "tags": ["algoritmos", "crud", "revisao", "structs"],
+      "audience": "estudantes de Algoritmos I finalizando módulo de structs",
+      "prompt": "Você é estudante de Algoritmos I responsável por finalizar o módulo de estoque da TechParts com buscas flexíveis, atualizações e auditoria. Contexto da aula: Refina o CRUD em memória adicionando buscas flexíveis, atualização de campos e estratégias de auditoria. Objetivo central: Desenvolver habilidades para localizar, atualizar e remover produtos no vetor de structs garantindo integridade. Monte um plano de estudo com revisão teórica, prática guiada e autoavaliação incluindo exercícios em C, registros de auditoria e perguntas para validação de políticas.",
+      "tags": ["algoritmos", "crud", "structs", "estoque"],
       "tips": [
-        "Peça ao assistente variações de exercícios que reforcem implementar buscas lineares e por chave composta.",
-        "Solicite exemplos adicionais relacionados a structs, crud para praticar.",
-        "Peça um checklist final para acompanhar suas dúvidas recorrentes e organizar revisões.",
-        "Peça sugestões de autoavaliação que ajudem você a atualizar campos selecionados mantendo histórico mínimo."
+        "Peça ao assistente exemplos de logs de auditoria detalhados para atualizações de estoque.",
+        "Solicite checklists para testar buscas com múltiplos filtros (SKU, categoria, status).",
+        "Peça sugestões de perguntas para a reunião de alinhamento com a gerência TechParts.",
+        "Peça estratégias para organizar rollback e versionamento das alterações."
       ]
     },
     {
@@ -159,32 +159,32 @@
         {
           "icon": "check-circle",
           "title": "(12 min) Estudo de caso",
-          "content": "empresas que cresceram segundo IBGE."
+          "content": "(12 min) Estudo de caso — produtos com reajuste urgente."
         },
         {
           "icon": "check-circle",
           "title": "(20 min) Live coding",
-          "content": "busca por id com retorno de ponteiro."
+          "content": "(20 min) Live coding — busca por SKU retornando ponteiro para Produto."
         },
         {
           "icon": "check-circle",
           "title": "(24 min) Oficina",
-          "content": "atualização de faturamento com logs de alterações."
+          "content": "(24 min) Oficina — atualização de preço/estoque mínimo com logs detalhados."
         },
         {
           "icon": "check-circle",
           "title": "(20 min) Laboratório",
-          "content": "remoção e compactação do vetor com relatório automático."
+          "content": "(20 min) Laboratório — remoção lógica, compactação e relatório automático do estoque."
         },
         {
           "icon": "check-circle",
           "title": "16 min",
-          "content": "Testes cruzados entre squads (pair review)."
+          "content": "16 min — Testes cruzados entre squads avaliando consistência das operações."
         },
         {
           "icon": "check-circle",
           "title": "8 min",
-          "content": "Reflexão escrita sobre integridade e auditoria."
+          "content": "8 min — Reflexão escrita sobre integridade, auditoria e próximos passos."
         }
       ]
     },
@@ -224,19 +224,19 @@
           "type": "unorderedList",
           "items": [
             {
-              "text": "Operação: create | Retorno sugerido: int (novo tamanho) | Descrição: Incrementa contador e retorna total de registros. | Quando aplicar: Ao inserir no fim do vetor."
+              "text": "Operação: create | Retorno sugerido: int (novo tamanho) | Descrição: Incrementa contador de produtos e retorna total. | Quando aplicar: Ao inserir novo SKU no fim do vetor."
             },
             {
-              "text": "Operação: read | Retorno sugerido: int (índice) ou ponteiro | Descrição: Localiza registro e permite inspeção. | Quando aplicar: Quando busca por id ou prefixo."
+              "text": "Operação: read | Retorno sugerido: int (índice) ou ponteiro | Descrição: Localiza produto e permite inspeção. | Quando aplicar: Busca por SKU ou categoria."
             },
             {
-              "text": "Operação: update | Retorno sugerido: bool | Descrição: Indica sucesso/falha após validações. | Quando aplicar: Atualização de campos sensíveis."
+              "text": "Operação: update | Retorno sugerido: bool | Descrição: Indica sucesso/falha após validar preço e estoque mínimo. | Quando aplicar: Ajuste de políticas de reposição."
             },
             {
-              "text": "Operação: delete | Retorno sugerido: bool | Descrição: Retorna sucesso após compactação. | Quando aplicar: Remoção física movendo elementos."
+              "text": "Operação: delete | Retorno sugerido: bool | Descrição: Retorna sucesso após compactação do vetor. | Quando aplicar: Remover SKU descontinuado."
             },
             {
-              "text": "Operação: auditLog | Retorno sugerido: void | Descrição: Gera linha de log com contexto da alteração. | Quando aplicar: Chamar após operações críticas."
+              "text": "Operação: auditLog | Retorno sugerido: void | Descrição: Gera linha de log com contexto da alteração (SKU, campo, usuário). | Quando aplicar: Após atualizações críticas."
             }
           ]
         }
@@ -245,23 +245,40 @@
     {
       "type": "callout",
       "variant": "good-practice",
-      "title": "Estudo de caso: Atendimento SEBRAE",
+      "title": "Estudo de caso: Auditoria TechParts",
       "content": [
         {
           "type": "paragraph",
-          "text": "Use o dataset do Cadastro Central de Empresas e a planilha de logs para simular a triagem de atendimentos. Forbellone & Eberspächer (Cap. 8) recomendam registrar motivo de cada alteração antes de persistir os dados."
+          "text": "Use o dataset do estoque TechParts e a planilha de logs para simular auditoria de alterações. Forbellone & Eberspächer (Cap. 8) recomendam registrar motivo de cada alteração antes de persistir os dados."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Implemente atualizações condicionais com validações de domínio inspiradas em Santos (Cap. 11)."
+              "text": "Implemente atualizações condicionais com validações de domínio inspiradas em Santos (Cap. 11) para preços e estoques."
             },
             {
-              "text": "Gere logs estruturados destacando id, campo alterado e responsável conforme Backes (Cap. 12)."
+              "text": "Gere logs estruturados destacando SKU, campo alterado e responsável conforme Backes (Cap. 12)."
             },
             {
-              "text": "Explique na retro como as métricas de atendimento se conectam ao modelo de Ascencio & Campos (Cap. 10)."
+              "text": "Explique na retro como os indicadores de reposição se conectam ao modelo de Ascencio & Campos (Cap. 10)."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "contentBlock",
+      "title": "Materiais para estações e slides",
+      "content": [
+        {
+          "type": "unorderedList",
+          "items": [
+            {
+              "text": "Cartaz Estação Auditoria TechParts — /courses/algi/estacao-estoque-auditoria.md"
+            },
+            {
+              "text": "Diagrama de memória — vetor pós-atualização — /courses/algi/memory-diagrama-estoque.md"
             }
           ]
         }
@@ -275,9 +292,9 @@
         {
           "type": "list",
           "items": [
-            "Busca inexistente retorna NULL/índice -1?",
-            "Atualização rejeita valores negativos?",
-            "Remoção mantém coleção ordenada após compactação?"
+            "Busca por SKU inexistente retorna NULL/índice -1?",
+            "Atualização rejeita valores negativos e registra log?",
+            "Remoção mantém coleção ordenada e atualiza contador de estoque?"
           ]
         }
       ]
@@ -289,16 +306,16 @@
       "content": [
         {
           "type": "paragraph",
-          "text": "Reserve um momento após a aula para concluir a atividade descrita a seguir. Ela complementa os estudos e ajuda a consolidar o que foi trabalhado em sala."
+          "text": "Finalize o módulo de estoque entregando a narrativa textual exigida pela gerência TechParts."
         },
         {
           "type": "list",
           "items": [
             {
-              "text": "Desenvolva a prática proposta na aula registrando os passos e resultados no caderno ou no editor de sua preferência."
+              "text": "Elabore relatório (3-4 páginas) contendo logs de atualização, políticas adotadas (preço, estoque mínimo) e próximos passos para automação."
             },
             {
-              "text": "Anote dúvidas e insights que surgirem para discutirmos na próxima aula."
+              "text": "Liste dúvidas ou riscos pendentes e indique como serão acompanhados no pós-aula."
             }
           ]
         }
@@ -306,16 +323,16 @@
     },
     {
       "type": "tabs",
-      "title": "Atualização de registros",
+      "title": "Atualização de produto",
       "tabs": [
         {
           "label": "Buscar",
-          "code": "int idx = buscaCPF(clientes, n, cpf);",
+          "code": "int idx = buscarProdutoPorSku(estoque, total, sku);",
           "language": "c"
         },
         {
           "label": "Atualizar",
-          "code": "clientes[idx].saldo += valor;",
+          "code": "if (idx >= 0) {\n  estoque[idx].preco += ajuste;\n  registrarLog(estoque[idx], \"preco\");\n}",
           "language": "c"
         }
       ]
@@ -342,7 +359,7 @@
       "content": [
         {
           "type": "code",
-          "code": "# Busca/atualização\nCPF=123 atualiza saldo +100 -> novo saldo esperado",
+          "code": "# Busca/atualização\nSKU=5001 atualiza preço +10% e estoque mínimo 20 -> verificar log e valores.",
           "language": "plaintext"
         }
       ]


### PR DESCRIPTION
## Summary
- align ALGI lessons 33-34 around the boletim TechED storyline, updating objectives, activities, and TED deliverables to evolve the analytical problem across sessions
- extend lessons 35-37 with the TechParts inventory arc, revising lesson plans, warm-ups, and TEDs so the CRUD challenge deepens from structs to full searches and updates
- add learning-station posters and memory diagrams for matrices and struct vectors to support in-class stations and slide attachments

## Testing
- npm run validate:content -- --no-report src/content/courses/algi/lessons/lesson-33.json src/content/courses/algi/lessons/lesson-34.json src/content/courses/algi/lessons/lesson-35.json src/content/courses/algi/lessons/lesson-36.json src/content/courses/algi/lessons/lesson-37.json

------
https://chatgpt.com/codex/tasks/task_e_68e159515500832c8d50f774b6cfe60a