### PR TITLE
Ensure teacher features respect environment forcing

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -35,7 +35,7 @@ import Md3Button from './components/Md3Button.vue';
 import { useTeacherMode } from './composables/useTeacherMode';
 
 const showScrollTop = ref(false);
-const { teacherMode, enableTeacherMode, toggleTeacherMode } = useTeacherMode();
+const { teacherMode, toggleTeacherMode, isAuthoringForced } = useTeacherMode();
 
 function handleScroll() {
   showScrollTop.value = window.scrollY > 320;
@@ -48,6 +48,9 @@ function scrollToTop() {
 function handleTeacherShortcut(event: KeyboardEvent) {
   if (event.ctrlKey && event.altKey && event.key.toLowerCase() === 'p') {
     event.preventDefault();
+    if (isAuthoringForced.value) {
+      return;
+    }
     toggleTeacherMode();
     const message = teacherMode.value ? 'Modo professor ativado.' : 'Modo professor desativado.';
     if (typeof window !== 'undefined' && typeof window.alert === 'function') {
@@ -60,13 +63,6 @@ onMounted(() => {
   window.addEventListener('scroll', handleScroll, { passive: true });
   handleScroll();
   window.addEventListener('keydown', handleTeacherShortcut);
-  if (typeof window !== 'undefined') {
-    const params = new URLSearchParams(window.location.search);
-    const teacherParam = params.get('teacher');
-    if (teacherParam === '1' || teacherParam === 'true') {
-      enableTeacherMode();
-    }
-  }
 });
 
 onBeforeUnmount(() => {

--- a/src/components/SiteFooter.vue
+++ b/src/components/SiteFooter.vue
@@ -46,10 +46,12 @@
           Contato
         </Md3Button>
         <Md3Button
+          v-if="showTeacherActions"
           variant="text"
           class="app-footer__teacher-button"
           type="button"
           :aria-pressed="teacherMode ? 'true' : 'false'"
+          :disabled="isAuthoringForced"
           @click="handleTeacherAccess"
         >
           <template #leading>
@@ -73,12 +75,22 @@ import { Globe, Github, Mail, UserCog, LogOut } from 'lucide-vue-next';
 import { useTeacherMode } from '../composables/useTeacherMode';
 import Md3Button from './Md3Button.vue';
 
-const { teacherMode, enableTeacherMode, disableTeacherMode } = useTeacherMode();
+const {
+  teacherMode,
+  enableTeacherMode,
+  disableTeacherMode,
+  isAuthoringEnabled,
+  isAuthoringForced,
+} = useTeacherMode();
 
-const teacherPin = computed(() => import.meta.env.VITE_TEACHER_PIN ?? 'TS-2024');
 const teacherActionLabel = computed(() => (teacherMode.value ? 'Professor' : 'Professor'));
+const showTeacherActions = computed(() => isAuthoringEnabled.value);
 
 function handleTeacherAccess() {
+  if (isAuthoringForced.value) {
+    return;
+  }
+
   if (teacherMode.value) {
     const confirmExit = window.confirm('Deseja sair do modo professor?');
     if (confirmExit) {
@@ -87,17 +99,7 @@ function handleTeacherAccess() {
     return;
   }
 
-  const provided = window.prompt('Digite o código do professor para acessar os relatórios:');
-  if (provided === null) {
-    return;
-  }
-
-  if (provided.trim() === teacherPin.value) {
-    enableTeacherMode();
-    window.alert('Modo professor ativado. Relatórios liberados.');
-  } else {
-    window.alert('Código inválido. Tente novamente.');
-  }
+  enableTeacherMode();
 }
 </script>
 

--- a/src/components/TeacherModeGate.vue
+++ b/src/components/TeacherModeGate.vue
@@ -12,18 +12,20 @@
               {{ description }}
             </p>
           </header>
-          <Md3Button
-            class="w-full md:w-auto"
-            variant="filled"
-            type="button"
-            @click="enableTeacherMode"
-          >
-            {{ ctaLabel }}
-          </Md3Button>
-          <p class="md-typescale-body-small text-on-surface-variant">
-            Também é possível ativar adicionando <code>?teacher=1</code> à URL ou pelo atalho
-            <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>P</kbd>.
-          </p>
+          <template v-if="showCallToAction">
+            <Md3Button
+              class="w-full md:w-auto"
+              variant="filled"
+              type="button"
+              @click="enableTeacherMode"
+            >
+              {{ ctaLabel }}
+            </Md3Button>
+            <p class="md-typescale-body-small text-on-surface-variant">
+              Também é possível ativar adicionando <code>?teacher=1</code> à URL ou pelo atalho
+              <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>P</kbd>.
+            </p>
+          </template>
         </section>
       </slot>
     </template>
@@ -49,9 +51,11 @@ withDefaults(
   }
 );
 
-const { teacherMode, isTeacherModeReady, enableTeacherMode } = useTeacherMode();
+const { isTeacherModeReady, enableTeacherMode, isAuthoringEnabled, isAuthoringForced } =
+  useTeacherMode();
 
-const isGateOpen = computed(() => isTeacherModeReady.value && teacherMode.value);
+const isGateOpen = computed(() => isTeacherModeReady.value && isAuthoringEnabled.value);
+const showCallToAction = computed(() => !isAuthoringForced.value);
 </script>
 
 <style scoped>

--- a/src/composables/useTeacherMode.ts
+++ b/src/composables/useTeacherMode.ts
@@ -1,11 +1,13 @@
-import { readonly, ref } from 'vue';
+import { computed, readonly, ref } from 'vue';
 
-const teacherMode = ref(false);
-const ready = ref(false);
+const authoringForced = import.meta.env.DEV;
+
+const teacherMode = ref(authoringForced);
+const ready = ref(authoringForced);
 let initialized = false;
 
 function persist(value: boolean) {
-  if (typeof window === 'undefined') {
+  if (authoringForced || typeof window === 'undefined') {
     return;
   }
   try {
@@ -16,12 +18,18 @@ function persist(value: boolean) {
 }
 
 function setTeacherMode(value: boolean) {
+  if (authoringForced) {
+    teacherMode.value = true;
+    ready.value = true;
+    return;
+  }
+
   teacherMode.value = value;
   persist(value);
 }
 
 function syncFromQueryString() {
-  if (typeof window === 'undefined') {
+  if (authoringForced || typeof window === 'undefined') {
     return false;
   }
 
@@ -43,7 +51,8 @@ function syncFromQueryString() {
 }
 
 function syncFromStorage() {
-  if (typeof window === 'undefined') {
+  if (authoringForced || typeof window === 'undefined') {
+    ready.value = true;
     return;
   }
   try {
@@ -59,11 +68,19 @@ function syncFromStorage() {
 export function useTeacherMode() {
   if (!initialized) {
     initialized = true;
-    const handledByQuery = syncFromQueryString();
-    if (!handledByQuery) {
-      syncFromStorage();
+    if (!authoringForced) {
+      const handledByQuery = syncFromQueryString();
+      if (!handledByQuery) {
+        syncFromStorage();
+      }
+    } else {
+      teacherMode.value = true;
+      ready.value = true;
     }
   }
+
+  const isAuthoringForced = computed(() => authoringForced);
+  const isAuthoringEnabled = computed(() => authoringForced || teacherMode.value);
 
   return {
     teacherMode: readonly(teacherMode),
@@ -71,5 +88,7 @@ export function useTeacherMode() {
     enableTeacherMode: () => setTeacherMode(true),
     disableTeacherMode: () => setTeacherMode(false),
     toggleTeacherMode: () => setTeacherMode(!teacherMode.value),
+    isAuthoringEnabled,
+    isAuthoringForced,
   } as const;
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -11,6 +11,9 @@ const FacultyEditor = () => import('../pages/faculty/EditorWorkbench.vue');
 const FacultyValidation = () => import('../pages/faculty/ValidationWorkbench.vue');
 const FacultyPublication = () => import('../pages/faculty/PublicationWorkbench.vue');
 
+const isAuthoringBuildEnabled =
+  import.meta.env.DEV || import.meta.env.VITE_ENABLE_AUTHORING === 'true';
+
 export const routes: RouteRecordRaw[] = [
   { path: '/', name: 'home', component: Home },
   {
@@ -28,34 +31,41 @@ export const routes: RouteRecordRaw[] = [
     name: 'validation-report',
     component: ValidationReport,
   },
-  {
-    path: '/faculty',
-    name: 'faculty-dashboard',
-    component: FacultyDashboard,
-  },
-  {
-    path: '/faculty/ingestion',
-    name: 'faculty-ingestion',
-    component: FacultyIngestion,
-  },
-  {
-    path: '/faculty/editor',
-    name: 'faculty-editor',
-    component: FacultyEditor,
-  },
-  {
-    path: '/faculty/validation',
-    name: 'faculty-validation',
-    component: FacultyValidation,
-  },
-  {
-    path: '/faculty/publication',
-    name: 'faculty-publication',
-    component: FacultyPublication,
-  },
   // Fallback to home for unknown routes
   { path: '/:pathMatch(.*)*', redirect: '/' },
 ];
+
+if (isAuthoringBuildEnabled) {
+  routes.splice(
+    routes.length - 1,
+    0,
+    {
+      path: '/faculty',
+      name: 'faculty-dashboard',
+      component: FacultyDashboard,
+    },
+    {
+      path: '/faculty/ingestion',
+      name: 'faculty-ingestion',
+      component: FacultyIngestion,
+    },
+    {
+      path: '/faculty/editor',
+      name: 'faculty-editor',
+      component: FacultyEditor,
+    },
+    {
+      path: '/faculty/validation',
+      name: 'faculty-validation',
+      component: FacultyValidation,
+    },
+    {
+      path: '/faculty/publication',
+      name: 'faculty-publication',
+      component: FacultyPublication,
+    }
+  );
+}
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_ENABLE_AUTHORING?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- force teacher mode on by default during the dev server and expose authoring state helpers
- update gating and footer components to suppress prompts when authoring is forced and hide teacher actions in production
- conditionally register faculty routes behind the dev server or a VITE_ENABLE_AUTHORING flag and declare the new env type

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68e160a1a6a0832c8c47b8145606e82f