### PR TITLE
feat: add teacher content editing support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:teacher": "node scripts/dev-teacher.mjs",
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview --base /edu/",
     "test": "vitest",

--- a/scripts/dev-teacher.mjs
+++ b/scripts/dev-teacher.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = resolve(__dirname, '..');
+
+function createSpawnOptions(extraEnv = {}) {
+  return {
+    cwd: projectRoot,
+    stdio: 'inherit',
+    env: { ...process.env, ...extraEnv },
+  };
+}
+
+function spawnProcess(command, args, options) {
+  const child = spawn(command, args, options);
+  return child;
+}
+
+const viteArgs = process.argv.slice(2);
+const children = new Set();
+let shuttingDown = false;
+
+function shutdown(code = 0) {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+  for (const child of children) {
+    if (!child.killed) {
+      child.kill('SIGINT');
+    }
+  }
+  process.exit(code);
+}
+
+const teacherProcess = spawnProcess(
+  process.execPath,
+  [resolve(__dirname, 'teacher-automation-server.mjs')],
+  createSpawnOptions()
+);
+children.add(teacherProcess);
+
+const viteBinary = resolve(projectRoot, 'node_modules/vite/bin/vite.js');
+const viteProcess = spawnProcess(
+  process.execPath,
+  [viteBinary, ...viteArgs],
+  createSpawnOptions({ VITE_TEACHER_API_URL: process.env.VITE_TEACHER_API_URL || '/teacher-api' })
+);
+children.add(viteProcess);
+
+function handleChildExit(child, code, signal) {
+  children.delete(child);
+  if (shuttingDown) {
+    return;
+  }
+  if (code !== null && code !== 0) {
+    console.error(`Processo ${child.pid} finalizou com código ${code}.`);
+    shutdown(code);
+    return;
+  }
+  if (signal) {
+    console.warn(`Processo ${child.pid} interrompido com sinal ${signal}.`);
+  }
+  if (child === teacherProcess) {
+    shutdown(code ?? 0);
+  }
+}
+
+teacherProcess.on('exit', (code, signal) => handleChildExit(teacherProcess, code, signal));
+viteProcess.on('exit', (code, signal) => handleChildExit(viteProcess, code, signal));
+
+process.on('SIGINT', () => shutdown(0));
+process.on('SIGTERM', () => shutdown(0));

--- a/src/components/exercise/ExerciseAuthoringPanel.vue
+++ b/src/components/exercise/ExerciseAuthoringPanel.vue
@@ -10,12 +10,36 @@
             página imediatamente.
           </p>
         </div>
-        <div class="flex items-center gap-2 text-sm" :class="statusTone">
-          <component :is="statusIcon" class="md-icon md-icon--sm" aria-hidden="true" />
-          <span>{{ statusLabel }}</span>
+        <div class="flex items-center gap-2">
+          <div class="flex items-center gap-2 text-sm" :class="statusTone">
+            <component :is="statusIcon" class="md-icon md-icon--sm" aria-hidden="true" />
+            <span>{{ statusLabel }}</span>
+          </div>
+          <Md3Button
+            v-if="showRevertButton"
+            type="button"
+            variant="text"
+            class="text-sm"
+            @click="handleRevert"
+          >
+            Reverter alterações
+          </Md3Button>
         </div>
       </div>
     </header>
+
+    <div
+      v-if="props.errorMessage"
+      class="rounded-lg border border-error/40 bg-error/10 p-3 text-sm text-error"
+    >
+      {{ props.errorMessage }}
+    </div>
+    <div
+      v-else-if="props.successMessage"
+      class="rounded-lg border border-success/40 bg-success/10 p-3 text-sm text-success"
+    >
+      {{ props.successMessage }}
+    </div>
 
     <template v-if="exerciseModel.value">
       <section class="md-stack md-stack-3">
@@ -165,6 +189,10 @@ import { useAuthoringSaveTracker } from '@/composables/useAuthoringSaveTracker';
 const props = defineProps<{
   exerciseModel: ShallowRef<LessonEditorModel | null>;
   tagsField: ComputedRef<string>;
+  errorMessage?: string | null;
+  successMessage?: string | null;
+  canRevert?: boolean;
+  onRevert?: () => void;
 }>();
 
 const tagsFieldProxy = computed({
@@ -177,6 +205,14 @@ const tagsFieldProxy = computed({
 const blocks = computed(() => props.exerciseModel.value?.blocks ?? []);
 const selectedBlockIndex = ref(0);
 const newBlockType = ref<string>(supportedBlockTypes[0] ?? 'contentBlock');
+
+const showRevertButton = computed(
+  () => Boolean(props.canRevert) && typeof props.onRevert === 'function'
+);
+
+function handleRevert() {
+  props.onRevert?.();
+}
 
 watch(blocks, (current) => {
   if (!current.length) {

--- a/src/components/lesson/LessonAuthoringPanel.vue
+++ b/src/components/lesson/LessonAuthoringPanel.vue
@@ -9,12 +9,36 @@
             Ajuste metadados, reordene blocos e visualize o conteúdo renderizado em tempo real.
           </p>
         </div>
-        <div class="flex items-center gap-2 text-sm" :class="statusTone">
-          <component :is="statusIcon" class="md-icon md-icon--sm" aria-hidden="true" />
-          <span>{{ statusLabel }}</span>
+        <div class="flex items-center gap-2">
+          <div class="flex items-center gap-2 text-sm" :class="statusTone">
+            <component :is="statusIcon" class="md-icon md-icon--sm" aria-hidden="true" />
+            <span>{{ statusLabel }}</span>
+          </div>
+          <Md3Button
+            v-if="showRevertButton"
+            type="button"
+            variant="text"
+            class="text-sm"
+            @click="handleRevert"
+          >
+            Reverter alterações
+          </Md3Button>
         </div>
       </div>
     </header>
+
+    <div
+      v-if="props.errorMessage"
+      class="rounded-lg border border-error/40 bg-error/10 p-3 text-sm text-error"
+    >
+      {{ props.errorMessage }}
+    </div>
+    <div
+      v-else-if="props.successMessage"
+      class="rounded-lg border border-success/40 bg-success/10 p-3 text-sm text-success"
+    >
+      {{ props.successMessage }}
+    </div>
 
     <template v-if="lessonModel.value">
       <section class="md-stack md-stack-3">
@@ -209,6 +233,10 @@ const props = defineProps<{
   lessonModel: ShallowRef<LessonEditorModel | null>;
   tagsField: ComputedRef<string>;
   createArrayField: (field: LessonArrayField) => ComputedRef<string>;
+  errorMessage?: string | null;
+  successMessage?: string | null;
+  canRevert?: boolean;
+  onRevert?: () => void;
 }>();
 
 const tagsFieldProxy = computed({
@@ -227,6 +255,14 @@ const prerequisitesField = props.createArrayField('prerequisites');
 const blocks = computed(() => props.lessonModel.value?.blocks ?? []);
 const selectedBlockIndex = ref(0);
 const newBlockType = ref<string>(supportedBlockTypes[0] ?? 'contentBlock');
+
+const showRevertButton = computed(
+  () => Boolean(props.canRevert) && typeof props.onRevert === 'function'
+);
+
+function handleRevert() {
+  props.onRevert?.();
+}
 
 watch(blocks, (current) => {
   if (!current.length) {

--- a/src/pages/LessonView.logic.ts
+++ b/src/pages/LessonView.logic.ts
@@ -120,6 +120,7 @@ export function useLessonViewController(
   const lessonOutcomes = ref<string[]>([]);
   const lessonPrerequisites = ref<string[]>([]);
   const lessonData = shallowRef<LessonContent | null>(null);
+  const lessonContentFile = ref('');
 
   async function loadLesson() {
     lessonData.value = null;
@@ -132,6 +133,7 @@ export function useLessonViewController(
     lessonSkills.value = [];
     lessonOutcomes.value = [];
     lessonPrerequisites.value = [];
+    lessonContentFile.value = '';
 
     try {
       const currentCourse = courseId.value;
@@ -152,6 +154,8 @@ export function useLessonViewController(
       const lessonPath = `../content/courses/${currentCourse}/lessons/${entry.file}`;
       const lessonImporter = lessonModules[lessonPath];
       if (!lessonImporter) throw new Error(`Lesson module not found for path: ${lessonPath}`);
+
+      lessonContentFile.value = entry.file ?? '';
 
       const mod: any = await lessonImporter();
       const data = (mod.default ?? mod) as LessonContent | null;
@@ -216,6 +220,7 @@ export function useLessonViewController(
       lessonSkills.value = [];
       lessonOutcomes.value = [];
       lessonPrerequisites.value = [];
+      lessonContentFile.value = '';
     }
   }
 
@@ -240,6 +245,7 @@ export function useLessonViewController(
     lessonOutcomes,
     lessonPrerequisites,
     lessonData,
+    lessonContentFile,
     loadLesson,
     route,
   };

--- a/src/pages/__tests__/ExerciseView.component.test.ts
+++ b/src/pages/__tests__/ExerciseView.component.test.ts
@@ -28,6 +28,22 @@ vi.mock('../ExerciseView.logic', () => ({
   useExerciseViewController: () => controllerMock,
 }));
 
+const contentSyncMock = {
+  loading: ref(false),
+  saving: ref(false),
+  loadError: ref<string | null>(null),
+  saveError: ref<string | null>(null),
+  successMessage: ref<string | null>(null),
+  hasPendingChanges: ref(false),
+  revertChanges: vi.fn(),
+  refresh: vi.fn(),
+  serviceAvailable: true,
+};
+
+vi.mock('@/services/useTeacherContentEditor', () => ({
+  useTeacherContentEditor: () => contentSyncMock,
+}));
+
 const ButtonStub = {
   template: '<button><slot /></button>',
 };
@@ -35,6 +51,11 @@ const ButtonStub = {
 describe('ExerciseView component', () => {
   beforeEach(() => {
     controllerMock = createController();
+    contentSyncMock.loadError.value = null;
+    contentSyncMock.saveError.value = null;
+    contentSyncMock.successMessage.value = null;
+    contentSyncMock.hasPendingChanges.value = false;
+    contentSyncMock.revertChanges.mockReset();
   });
 
   it('renderiza componente de exercício quando disponível', () => {

--- a/src/pages/__tests__/LessonView.component.test.ts
+++ b/src/pages/__tests__/LessonView.component.test.ts
@@ -42,6 +42,22 @@ vi.mock('../LessonView.logic', () => ({
   useLessonViewController: () => controllerMock,
 }));
 
+const contentSyncMock = {
+  loading: ref(false),
+  saving: ref(false),
+  loadError: ref<string | null>(null),
+  saveError: ref<string | null>(null),
+  successMessage: ref<string | null>(null),
+  hasPendingChanges: ref(false),
+  revertChanges: vi.fn(),
+  refresh: vi.fn(),
+  serviceAvailable: true,
+};
+
+vi.mock('@/services/useTeacherContentEditor', () => ({
+  useTeacherContentEditor: () => contentSyncMock,
+}));
+
 const ButtonStub = {
   props: ['to'],
   template: '<button><slot /></button>',
@@ -54,6 +70,11 @@ const StubComponent = {
 describe('LessonView component', () => {
   beforeEach(() => {
     controllerMock = createController();
+    contentSyncMock.loadError.value = null;
+    contentSyncMock.saveError.value = null;
+    contentSyncMock.successMessage.value = null;
+    contentSyncMock.hasPendingChanges.value = false;
+    contentSyncMock.revertChanges.mockReset();
   });
 
   it('renderiza dados da lição quando disponíveis', () => {

--- a/src/services/useTeacherContentEditor.ts
+++ b/src/services/useTeacherContentEditor.ts
@@ -1,0 +1,345 @@
+import { computed, nextTick, ref, shallowRef, watch, type ComputedRef, type ShallowRef } from 'vue';
+import { teacherAutomationBaseUrl, teacherAutomationToken } from '@/pages/faculty/utils/automation';
+
+class TeacherContentServiceError extends Error {
+  constructor(
+    message: string,
+    readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'TeacherContentServiceError';
+  }
+}
+
+function cloneJson<T>(value: T): T {
+  try {
+    return structuredClone(value);
+  } catch (_error) {
+    return JSON.parse(JSON.stringify(value)) as T;
+  }
+}
+
+function serialize(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+const explicitBaseUrl = teacherAutomationBaseUrl;
+const fallbackBaseUrl = import.meta.env.DEV ? '/teacher-api' : '';
+const teacherContentBaseUrl = (explicitBaseUrl || fallbackBaseUrl).replace(/\/$/, '');
+export const teacherContentServiceEnabled = teacherContentBaseUrl.length > 0;
+
+async function teacherContentRequest<T>(path: string, init?: RequestInit): Promise<T> {
+  if (!teacherContentServiceEnabled) {
+    throw new TeacherContentServiceError(
+      'Serviço de automação do professor indisponível. Execute "npm run dev:teacher" ou defina VITE_TEACHER_API_URL.'
+    );
+  }
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(teacherAutomationToken ? { 'X-Teacher-Token': teacherAutomationToken } : {}),
+  };
+
+  if (init?.headers instanceof Headers) {
+    for (const [key, value] of init.headers.entries()) {
+      headers[key] = value;
+    }
+  } else if (init?.headers) {
+    Object.assign(headers, init.headers as Record<string, string>);
+  }
+
+  const response = await fetch(`${teacherContentBaseUrl}${path}`, {
+    ...init,
+    headers,
+  });
+
+  if (!response.ok) {
+    let detail: unknown;
+    let message = '';
+    try {
+      detail = await response.json();
+    } catch (_error) {
+      try {
+        detail = await response.text();
+      } catch (_textError) {
+        detail = undefined;
+      }
+    }
+
+    if (typeof detail === 'string') {
+      message = detail;
+    } else if (detail && typeof detail === 'object' && 'error' in detail) {
+      const errorValue = (detail as { error?: unknown }).error;
+      message = typeof errorValue === 'string' ? errorValue : '';
+    }
+
+    const suffix = message ? ` ${message}` : '';
+    throw new TeacherContentServiceError(
+      `Falha ao acessar o serviço de automação (${response.status}).${suffix}`.trim(),
+      detail
+    );
+  }
+
+  try {
+    return (await response.json()) as T;
+  } catch (error) {
+    throw new TeacherContentServiceError(
+      'Resposta inválida recebida do serviço de automação.',
+      error
+    );
+  }
+}
+
+interface TeacherContentResponse<TRaw> {
+  path: string;
+  content: TRaw;
+  savedAt?: string;
+}
+
+export interface TeacherContentEditorOptions<TModel, TRaw> {
+  path: ComputedRef<string | null>;
+  model: ShallowRef<TModel | null>;
+  setModel: (value: TModel | null) => void;
+  fromRaw: (raw: TRaw) => TModel;
+  toRaw: (model: TModel, base: TRaw | null) => TRaw;
+  debounceMs?: number;
+}
+
+export interface TeacherContentEditorState {
+  loading: ReturnType<typeof ref<boolean>>;
+  saving: ReturnType<typeof ref<boolean>>;
+  loadError: ReturnType<typeof ref<string | null>>;
+  saveError: ReturnType<typeof ref<string | null>>;
+  successMessage: ReturnType<typeof ref<string | null>>;
+  hasPendingChanges: ReturnType<typeof computed<boolean>>;
+  revertChanges: () => void;
+  refresh: () => Promise<void>;
+  serviceAvailable: boolean;
+}
+
+export function useTeacherContentEditor<TModel, TRaw>(
+  options: TeacherContentEditorOptions<TModel, TRaw>
+): TeacherContentEditorState {
+  const loading = ref(false);
+  const saving = ref(false);
+  const loadError = ref<string | null>(null);
+  const saveError = ref<string | null>(null);
+  const successMessage = ref<string | null>(null);
+
+  const snapshotRaw = shallowRef<TRaw | null>(null);
+  const snapshotSerialized = ref('');
+
+  const pendingRaw = shallowRef<TRaw | null>(null);
+  const pendingSerialized = ref<string | null>(null);
+
+  const dirty = ref(false);
+  let currentPath: string | null = null;
+  let ignoreNextChange = false;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearTimer() {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+  }
+
+  function resetModel(model: TModel | null, raw: TRaw | null) {
+    ignoreNextChange = true;
+    options.setModel(model);
+    void nextTick(() => {
+      ignoreNextChange = false;
+    });
+    snapshotRaw.value = raw ? cloneJson(raw) : null;
+    snapshotSerialized.value = raw ? serialize(raw) : '';
+    dirty.value = false;
+  }
+
+  async function loadContent(path: string | null) {
+    clearTimer();
+    pendingRaw.value = null;
+    pendingSerialized.value = null;
+    currentPath = path;
+    saveError.value = null;
+    successMessage.value = null;
+
+    if (!path) {
+      loadError.value = null;
+      resetModel(null, null);
+      return;
+    }
+
+    if (!teacherContentServiceEnabled) {
+      loadError.value =
+        'Serviço de automação não configurado. Execute "npm run dev:teacher" ou defina VITE_TEACHER_API_URL.';
+      resetModel(null, null);
+      return;
+    }
+
+    loading.value = true;
+    try {
+      const response = await teacherContentRequest<TeacherContentResponse<TRaw>>(
+        `/api/teacher/content?path=${encodeURIComponent(path)}`,
+        { method: 'GET' }
+      );
+
+      const raw = response?.content;
+      if (!raw || typeof raw !== 'object') {
+        throw new TeacherContentServiceError('O serviço retornou um payload inválido.');
+      }
+
+      const rawSnapshot = cloneJson(raw);
+      const model = options.fromRaw(cloneJson(rawSnapshot));
+      loadError.value = null;
+      resetModel(model, rawSnapshot);
+    } catch (error) {
+      const message =
+        error instanceof TeacherContentServiceError
+          ? error.message
+          : 'Não foi possível carregar o arquivo solicitado.';
+      console.error('[useTeacherContentEditor] Falha ao carregar conteúdo:', error);
+      loadError.value = message;
+      resetModel(null, null);
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function persistPending() {
+    if (!currentPath || saving.value) {
+      return;
+    }
+    const rawToSave = pendingRaw.value;
+    const serializedToSave = pendingSerialized.value;
+    if (!rawToSave || !serializedToSave) {
+      return;
+    }
+
+    pendingRaw.value = null;
+    pendingSerialized.value = null;
+    saving.value = true;
+    try {
+      const response = await teacherContentRequest<TeacherContentResponse<TRaw>>(
+        '/api/teacher/content',
+        {
+          method: 'PUT',
+          body: JSON.stringify({ path: currentPath, content: rawToSave }),
+        }
+      );
+
+      const snapshot = cloneJson(rawToSave);
+      snapshotRaw.value = snapshot;
+      snapshotSerialized.value = serializedToSave;
+      dirty.value = false;
+
+      const savedAt = typeof response?.savedAt === 'string' ? response.savedAt : null;
+      if (savedAt) {
+        try {
+          const savedDate = new Date(savedAt);
+          successMessage.value = `Alterações salvas às ${savedDate.toLocaleTimeString()}.`;
+        } catch (_error) {
+          successMessage.value = 'Alterações salvas com sucesso.';
+        }
+      } else {
+        successMessage.value = 'Alterações salvas com sucesso.';
+      }
+      saveError.value = null;
+    } catch (error) {
+      const message =
+        error instanceof TeacherContentServiceError
+          ? error.message
+          : 'Não foi possível salvar o arquivo solicitado.';
+      console.error('[useTeacherContentEditor] Falha ao salvar conteúdo:', error);
+      saveError.value = message;
+      dirty.value = true;
+      pendingRaw.value = rawToSave;
+      pendingSerialized.value = serializedToSave;
+    } finally {
+      saving.value = false;
+    }
+
+    if (pendingRaw.value && pendingSerialized.value) {
+      clearTimer();
+      const delay = options.debounceMs ?? 800;
+      debounceTimer = setTimeout(() => {
+        void persistPending();
+      }, delay);
+    }
+  }
+
+  function scheduleSave(raw: TRaw, serialized: string) {
+    pendingRaw.value = raw;
+    pendingSerialized.value = serialized;
+    successMessage.value = null;
+    saveError.value = null;
+    clearTimer();
+    const delay = options.debounceMs ?? 800;
+    debounceTimer = setTimeout(() => {
+      void persistPending();
+    }, delay);
+  }
+
+  watch(
+    options.path,
+    (nextPath) => {
+      void loadContent(nextPath);
+    },
+    { immediate: true }
+  );
+
+  watch(
+    () => options.model.value,
+    (value) => {
+      if (ignoreNextChange) {
+        return;
+      }
+      if (!currentPath || !value || !snapshotRaw.value) {
+        clearTimer();
+        dirty.value = false;
+        return;
+      }
+
+      const base = cloneJson(snapshotRaw.value);
+      const raw = options.toRaw(cloneJson(value), base);
+      const serialized = serialize(raw);
+      const hasChanged = serialized !== snapshotSerialized.value;
+      dirty.value = hasChanged;
+      if (!hasChanged) {
+        clearTimer();
+        return;
+      }
+
+      scheduleSave(raw, serialized);
+    },
+    { deep: true }
+  );
+
+  function revertChanges() {
+    if (!snapshotRaw.value) {
+      return;
+    }
+    const rawClone = cloneJson(snapshotRaw.value);
+    const model = options.fromRaw(cloneJson(rawClone));
+    saveError.value = null;
+    successMessage.value = null;
+    resetModel(model, rawClone);
+  }
+
+  async function refresh() {
+    await loadContent(currentPath);
+  }
+
+  const hasPendingChanges = computed(() => dirty.value);
+
+  return {
+    loading,
+    saving,
+    loadError,
+    saveError,
+    successMessage,
+    hasPendingChanges,
+    revertChanges,
+    refresh,
+    serviceAvailable: teacherContentServiceEnabled,
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -233,6 +233,13 @@ export default defineConfig(({ command }) => {
     },
     server: {
       port: 5173,
+      proxy: {
+        '^/teacher-api': {
+          target: 'http://127.0.0.1:4178',
+          changeOrigin: true,
+          rewrite: (urlPath) => urlPath.replace(/^\/teacher-api/, ''),
+        },
+      },
     },
     preview: {
       base: '/edu/',


### PR DESCRIPTION
## Summary
- add a content read/write API to the teacher automation server with path validation inside src/content
- create a combined dev script and vite proxy so the frontend can talk to the teacher service via /teacher-api
- implement a teacher content editor service with debounced saves, success/error handling, and integrate it into lesson/exercise authoring panels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e166f2b6bc832c9bc770403421a557