### PR TITLE
docs: document local teacher mode workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ npm run build
 npm run preview
 ```
 
+## Modo Professor local
+
+O fluxo de edição inline do modo professor precisa do Vite e do serviço auxiliar `teacher:service` rodando juntos.
+
+1. Execute `npm run dev:teacher` em um terminal. O script sobe o Vite e o serviço de automação na porta `4178`, já com o proxy configurado para `VITE_TEACHER_API_URL=/teacher-api`.
+2. Acesse `http://localhost:5173/?teacher=1` (ou ative o modo pelo botão **Professor** no rodapé) para revelar o painel lateral "Editar aula"/"Editar exercício".
+3. Abra uma aula ou exercício. O painel exibe metadados, a lista de blocos e o editor contextual do bloco selecionado. As alterações são salvas automaticamente após alguns segundos de inatividade; mensagens como "Salvando alterações…" e "Alterações salvas" confirmam o status.
+
+> ⚠️ O `teacher:service` foi projetado para desenvolvimento local. Não exponha o serviço publicamente sem autenticação via `TEACHER_SERVICE_TOKEN` e VPN/reverse proxy controlados.
+
 ## Formatting & Git Hooks
 
 - `npm run format` – applies Prettier to the entire project.
@@ -99,3 +109,4 @@ Before opening a pull request:
 - [ ] Use canonical tokens for `callout.variant` (`info`, `good-practice`, `academic`, `warning`, `task`, `error`) and lesson plan icons (`target`, `bullseye`, `graduation-cap`, `calendar-days`, `users`, etc.).
 - [ ] Confirm that lessons/exercises reference the correct JSON wrapper and appear in `lessons.json` / `exercises.json` indexes.
 - [ ] Update documentation when the architecture or authoring workflow changes.
+- [ ] Ao tocar no modo professor, execute `npm run dev:teacher`, confirme o autosave do painel (status "Alterações salvas") e mantenha o `teacher:service` restrito ao ambiente local.


### PR DESCRIPTION
## Summary
- add a "Modo Professor local" section to the README with instructions to run `npm run dev:teacher`, open the inline editor, and keep the automation service local
- extend the content authoring guide with directions for the block panel, autosave behaviour, and canonical block types
- expand the teacher automation backend guide with the content endpoints used by autosave and reiterate the local-only scope of the service

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e16ec5c9e4832c97e74f364314fd29