### PR TITLE
Ensure teacher mode only forces when teacher backend configured

### DIFF
--- a/src/composables/useTeacherMode.ts
+++ b/src/composables/useTeacherMode.ts
@@ -1,6 +1,6 @@
 import { computed, readonly, ref } from 'vue';
 
-const authoringForced = import.meta.env.DEV;
+const authoringForced = import.meta.env.DEV && Boolean(import.meta.env.VITE_TEACHER_API_URL);
 
 const teacherMode = ref(authoringForced);
 const ready = ref(authoringForced);


### PR DESCRIPTION
## Summary
- force teacher authoring mode in development only when a teacher API URL is configured

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1763b5a78832cb484387626d5a5d6