### PR TITLE
Guard teacher mode when manual authoring backend is absent

### DIFF
--- a/src/composables/__tests__/useTeacherMode.test.ts
+++ b/src/composables/__tests__/useTeacherMode.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+async function importComposable() {
+  const module = await import('../useTeacherMode');
+  return module.useTeacherMode;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  window.localStorage.clear();
+  window.history.replaceState({}, '', '/');
+});
+
+describe('useTeacherMode', () => {
+  it('mantém desativado e limpa storage quando o backend está indisponível', async () => {
+    window.localStorage.setItem('teacherMode', 'true');
+    vi.stubEnv('DEV', '');
+    vi.stubEnv('VITE_TEACHER_API_URL', '');
+
+    const useTeacherMode = await importComposable();
+    const composable = useTeacherMode();
+
+    expect(composable.teacherMode.value).toBe(false);
+    expect(composable.isTeacherModeReady.value).toBe(true);
+    expect(window.localStorage.getItem('teacherMode')).toBeNull();
+
+    composable.enableTeacherMode();
+
+    expect(composable.teacherMode.value).toBe(false);
+    expect(window.localStorage.getItem('teacherMode')).toBeNull();
+  });
+
+  it('restaura e persiste o estado manual quando o backend está disponível', async () => {
+    window.localStorage.setItem('teacherMode', 'true');
+    vi.stubEnv('DEV', '');
+    vi.stubEnv('VITE_TEACHER_API_URL', 'https://teacher.local');
+
+    const useTeacherMode = await importComposable();
+    const composable = useTeacherMode();
+
+    expect(composable.teacherMode.value).toBe(true);
+    expect(composable.isTeacherModeReady.value).toBe(true);
+
+    composable.disableTeacherMode();
+    expect(composable.teacherMode.value).toBe(false);
+    expect(window.localStorage.getItem('teacherMode')).toBe('false');
+
+    composable.enableTeacherMode();
+    expect(composable.teacherMode.value).toBe(true);
+    expect(window.localStorage.getItem('teacherMode')).toBe('true');
+  });
+
+  it('ativa pelo query string quando manual authoring está habilitado', async () => {
+    vi.stubEnv('DEV', '');
+    vi.stubEnv('VITE_TEACHER_API_URL', 'https://teacher.local');
+    window.history.replaceState({}, '', '/lesson?teacher=1#detalhes');
+
+    const useTeacherMode = await importComposable();
+    const composable = useTeacherMode();
+
+    expect(composable.teacherMode.value).toBe(true);
+    expect(window.location.search).toBe('');
+  });
+
+  it('ignora o query string quando manual authoring está desabilitado', async () => {
+    vi.stubEnv('DEV', '');
+    vi.stubEnv('VITE_TEACHER_API_URL', '');
+    window.history.replaceState({}, '', '/lesson?teacher=1');
+
+    const useTeacherMode = await importComposable();
+    const composable = useTeacherMode();
+
+    expect(composable.teacherMode.value).toBe(false);
+    expect(window.location.search).toBe('?teacher=1');
+  });
+});


### PR DESCRIPTION
## Summary
- introduce a manual authoring availability flag so teacher mode skips query string and localStorage persistence when the backend is missing
- clear any persisted teacher mode value during initialization when manual authoring is disabled and prevent toggles from activating it
- add unit tests for scenarios with and without the backend, including query string handling

## Testing
- npm run test -- --run src/composables/__tests__/useTeacherMode.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e17b6e5230832ca631c143951291fd