### PR TITLE
Document teacher mode auto activation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm run preview
 O fluxo de edição inline do modo professor precisa do Vite e do serviço auxiliar `teacher:service` rodando juntos.
 
 1. Execute `npm run dev:teacher` em um terminal. O script sobe o Vite e o serviço de automação na porta `4178`, já com o proxy configurado para `VITE_TEACHER_API_URL=/teacher-api`.
-2. Acesse `http://localhost:5173/?teacher=1` (ou ative o modo pelo botão **Professor** no rodapé) para revelar o painel lateral "Editar aula"/"Editar exercício".
+2. Acesse `http://localhost:5173/`. O painel lateral "Editar aula"/"Editar exercício" aparece automaticamente quando o serviço do modo professor estiver ativo.
 3. Abra uma aula ou exercício. O painel exibe metadados, a lista de blocos e o editor contextual do bloco selecionado. As alterações são salvas automaticamente após alguns segundos de inatividade; mensagens como "Salvando alterações…" e "Alterações salvas" confirmam o status.
 
 > ⚠️ O `teacher:service` foi projetado para desenvolvimento local. Não exponha o serviço publicamente sem autenticação via `TEACHER_SERVICE_TOKEN` e VPN/reverse proxy controlados.
@@ -109,4 +109,4 @@ Before opening a pull request:
 - [ ] Use canonical tokens for `callout.variant` (`info`, `good-practice`, `academic`, `warning`, `task`, `error`) and lesson plan icons (`target`, `bullseye`, `graduation-cap`, `calendar-days`, `users`, etc.).
 - [ ] Confirm that lessons/exercises reference the correct JSON wrapper and appear in `lessons.json` / `exercises.json` indexes.
 - [ ] Update documentation when the architecture or authoring workflow changes.
-- [ ] Ao tocar no modo professor, execute `npm run dev:teacher`, confirme o autosave do painel (status "Alterações salvas") e mantenha o `teacher:service` restrito ao ambiente local.
+- [ ] Para validar o modo professor, execute `npm run dev:teacher`, confirme o autosave do painel (status "Alterações salvas") e mantenha o `teacher:service` restrito ao ambiente local.

--- a/docs/CONTENT_AUTHORING_GUIDE.md
+++ b/docs/CONTENT_AUTHORING_GUIDE.md
@@ -8,7 +8,7 @@ This document explains how to produce new lessons and exercises that integrate s
 
 - Run `npm run dev:teacher` to launch Vite and the automation service (`teacher:service`) with the proxy already pointing to `/teacher-api`.
 - Keep the service bound to `127.0.0.1` unless you configure `TEACHER_SERVICE_TOKEN`, VPN/reverse proxy and the allowlists described in [`automation-backend.md`](professor-module/automation-backend.md). The API is designed for local authoring sessions.
-- Access `http://localhost:5173/?teacher=1` or toggle the **Professor** button in the footer to unlock the restricted pages.
+- Open `http://localhost:5173/`. The **Professor** panel appears automatically when the automation service is reachable (locally or via `VITE_TEACHER_API_URL`).
 
 ### Use the block panel
 

--- a/src/components/TeacherModeGate.vue
+++ b/src/components/TeacherModeGate.vue
@@ -13,17 +13,10 @@
             </p>
           </header>
           <template v-if="showCallToAction">
-            <Md3Button
-              class="w-full md:w-auto"
-              variant="filled"
-              type="button"
-              @click="enableTeacherMode"
-            >
-              {{ ctaLabel }}
-            </Md3Button>
-            <p class="md-typescale-body-small text-on-surface-variant">
-              Também é possível ativar adicionando <code>?teacher=1</code> à URL ou pelo atalho
-              <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>P</kbd>.
+            <p class="md-typescale-body-medium text-on-surface-variant">
+              Execute <code>npm run dev:teacher</code> para iniciar o serviço de autoria local e
+              habilitar o painel do modo professor. Caso utilize um backend remoto, configure a
+              variável <code>VITE_TEACHER_API_URL</code> com a URL do serviço disponível.
             </p>
           </template>
         </section>
@@ -35,24 +28,20 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useTeacherMode } from '../composables/useTeacherMode';
-import Md3Button from './Md3Button.vue';
 
 withDefaults(
   defineProps<{
     title?: string;
     description?: string;
-    ctaLabel?: string;
   }>(),
   {
     title: 'Ative o modo professor para continuar',
     description:
       'Utilize o modo professor para acessar ferramentas restritas e conteúdos de governança.',
-    ctaLabel: 'Ativar modo professor',
   }
 );
 
-const { isTeacherModeReady, enableTeacherMode, isAuthoringEnabled, isAuthoringForced } =
-  useTeacherMode();
+const { isTeacherModeReady, isAuthoringEnabled, isAuthoringForced } = useTeacherMode();
 
 const isGateOpen = computed(() => isTeacherModeReady.value && isAuthoringEnabled.value);
 const showCallToAction = computed(() => !isAuthoringForced.value);

--- a/src/pages/TeacherGuide.vue
+++ b/src/pages/TeacherGuide.vue
@@ -16,16 +16,20 @@
 
     <section class="md-stack md-stack-3">
       <h2 class="md-typescale-title-large font-semibold text-on-surface">
-        1. Ative o modo professor
+        1. Inicie o serviço do modo professor
       </h2>
       <ul class="md-stack md-stack-2 list-disc pl-6 text-on-surface-variant">
-        <li>Use o botão “Professor” no rodapé para habilitar o modo docente.</li>
         <li>
-          Em ambientes locais você também pode abrir a URL com
-          <code class="chip chip--filled">?teacher=1</code> para acionar o modo automaticamente.
+          Execute <code class="chip chip--filled">npm run dev:teacher</code> em um terminal para
+          iniciar o serviço que habilita o painel de autoria.
         </li>
         <li>
-          Após ativar, acesse qualquer aula ou exercício para visualizar o painel lateral de edição.
+          Caso utilize uma API hospedada em outro ambiente, defina
+          <code class="chip chip--filled">VITE_TEACHER_API_URL</code> antes de iniciar o front-end.
+        </li>
+        <li>
+          O painel “Professor” aparece automaticamente nas páginas suportadas somente enquanto o
+          serviço estiver ativo.
         </li>
       </ul>
     </section>
@@ -52,16 +56,10 @@
         3. Sincronize com arquivos locais
       </h2>
       <ol class="md-stack md-stack-2 list-decimal pl-6 text-on-surface-variant">
-        <li>
-          Execute <code class="chip chip--filled">npm run dev:teacher</code> em outro terminal.
-        </li>
-        <li>
-          Informe a variável <code class="chip chip--filled">VITE_TEACHER_API_URL</code> caso a API
-          rode em um endereço diferente do padrão.
-        </li>
+        <li>Organize os arquivos na pasta esperada pelo serviço iniciado no passo anterior.</li>
         <li>
           A cada alteração o painel indicará o status de salvamento e enviará o JSON atualizado para
-          o serviço local.
+          o serviço ativo.
         </li>
       </ol>
       <p class="text-sm text-on-surface-variant">


### PR DESCRIPTION
## Summary
- update the teacher gate copy to direct developers to start the combined `npm run dev:teacher` stack or set `VITE_TEACHER_API_URL`
- align the teacher guide and project docs with the automatic activation flow that depends on the backend service

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1bb7a1980832c856749bc5c31b5a2