### PR TITLE
Update lesson editor refs and add autosave coverage

### DIFF
--- a/src/components/exercise/ExerciseAuthoringPanel.vue
+++ b/src/components/exercise/ExerciseAuthoringPanel.vue
@@ -165,7 +165,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch, type ComputedRef, type ShallowRef } from 'vue';
+import { computed, ref, watch, type ComputedRef, type Ref } from 'vue';
 import {
   ArrowDown,
   ArrowUp,
@@ -187,7 +187,7 @@ import {
 import { useAuthoringSaveTracker } from '@/composables/useAuthoringSaveTracker';
 
 const props = defineProps<{
-  exerciseModel: ShallowRef<LessonEditorModel | null>;
+  exerciseModel: Ref<LessonEditorModel | null>;
   tagsField: ComputedRef<string>;
   errorMessage?: string | null;
   successMessage?: string | null;

--- a/src/components/lesson/LessonAuthoringPanel.vue
+++ b/src/components/lesson/LessonAuthoringPanel.vue
@@ -207,7 +207,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch, type ComputedRef, type ShallowRef } from 'vue';
+import { computed, ref, watch, type ComputedRef, type Ref } from 'vue';
 import {
   ArrowDown,
   ArrowUp,
@@ -230,7 +230,7 @@ import {
 import { useAuthoringSaveTracker } from '@/composables/useAuthoringSaveTracker';
 
 const props = defineProps<{
-  lessonModel: ShallowRef<LessonEditorModel | null>;
+  lessonModel: Ref<LessonEditorModel | null>;
   tagsField: ComputedRef<string>;
   createArrayField: (field: LessonArrayField) => ComputedRef<string>;
   errorMessage?: string | null;

--- a/src/composables/useAuthoringSaveTracker.ts
+++ b/src/composables/useAuthoringSaveTracker.ts
@@ -1,8 +1,8 @@
-import { computed, onBeforeUnmount, ref, watch, type ShallowRef } from 'vue';
+import { computed, onBeforeUnmount, ref, watch, type Ref } from 'vue';
 
 type SaveStatus = 'idle' | 'pending' | 'saved';
 
-export function useAuthoringSaveTracker(target: ShallowRef<unknown>) {
+export function useAuthoringSaveTracker(target: Ref<unknown>) {
   const status = ref<SaveStatus>('idle');
   const lastSavedAt = ref<string>('');
   let skipNextChange = true;

--- a/src/composables/useLessonEditorModel.ts
+++ b/src/composables/useLessonEditorModel.ts
@@ -1,10 +1,10 @@
 import {
   computed,
   defineAsyncComponent,
-  shallowRef,
+  ref,
   type Component,
   type ComputedRef,
-  type ShallowRef,
+  type Ref,
 } from 'vue';
 import type { LessonBlock } from '@/components/lesson/blockRegistry';
 
@@ -66,7 +66,7 @@ function cloneModel(model: LessonEditorModel): LessonEditorModel {
 }
 
 export interface LessonEditorContext {
-  lessonModel: ShallowRef<LessonEditorModel | null>;
+  lessonModel: Ref<LessonEditorModel | null>;
   setLessonModel: (value: LessonEditorModel | null) => void;
   tagsField: ComputedRef<string>;
   useArrayField: (field: LessonArrayField) => ComputedRef<string>;
@@ -75,9 +75,7 @@ export interface LessonEditorContext {
 export function useLessonEditorModel(
   initialValue: LessonEditorModel | null = null
 ): LessonEditorContext {
-  const lessonModel = shallowRef<LessonEditorModel | null>(
-    initialValue ? cloneModel(initialValue) : null
-  );
+  const lessonModel = ref<LessonEditorModel | null>(initialValue ? cloneModel(initialValue) : null);
 
   function setLessonModel(value: LessonEditorModel | null) {
     lessonModel.value = value ? cloneModel(value) : null;

--- a/src/pages/__tests__/ExerciseView.component.test.ts
+++ b/src/pages/__tests__/ExerciseView.component.test.ts
@@ -36,7 +36,7 @@ vi.mock('@/composables/useTeacherMode', () => ({
   }),
 }));
 
-const exerciseEditorModel = shallowRef<Record<string, unknown> | null>({});
+const exerciseEditorModel = ref<Record<string, unknown> | null>({});
 
 vi.mock('@/composables/useLessonEditorModel', () => ({
   useLessonEditorModel: () => ({

--- a/src/services/__tests__/useTeacherContentEditor.test.ts
+++ b/src/services/__tests__/useTeacherContentEditor.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, nextTick, ref } from 'vue';
+
+type LessonEditorModel = {
+  title?: string;
+  blocks?: unknown[];
+};
+
+async function importEditorModule() {
+  return await import('../useTeacherContentEditor');
+}
+
+describe('useTeacherContentEditor', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetModules();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('detects pending changes and triggers autosave on model edits', async () => {
+    vi.stubEnv('VITE_TEACHER_API_URL', 'https://automation.local');
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          path: 'courses/demo/lessons/example.json',
+          content: { title: 'Original title', blocks: [] },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          path: 'courses/demo/lessons/example.json',
+          content: {
+            title: 'New title',
+            blocks: [{ type: 'contentBlock', id: 1 }],
+          },
+          savedAt: new Date().toISOString(),
+        }),
+      });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { useTeacherContentEditor } = await importEditorModule();
+
+    const path = ref('courses/demo/lessons/example.json');
+    const lessonModel = ref<LessonEditorModel | null>(null);
+    const setLessonModel = vi.fn((value: LessonEditorModel | null) => {
+      lessonModel.value = value ? JSON.parse(JSON.stringify(value)) : null;
+    });
+
+    const editor = useTeacherContentEditor<LessonEditorModel, LessonEditorModel>({
+      path: computed(() => path.value),
+      model: lessonModel,
+      setModel: setLessonModel,
+      fromRaw: (raw) => JSON.parse(JSON.stringify(raw)) as LessonEditorModel,
+      toRaw: (model) => JSON.parse(JSON.stringify(model)) as LessonEditorModel,
+      debounceMs: 10,
+    });
+
+    await nextTick();
+    await Promise.resolve();
+    await nextTick();
+    expect(lessonModel.value).toEqual({ title: 'Original title', blocks: [] });
+
+    await nextTick();
+    lessonModel.value!.title = 'New title';
+    lessonModel.value!.blocks = [{ type: 'contentBlock', id: 1 }];
+
+    await nextTick();
+    await nextTick();
+    expect(editor.hasPendingChanges.value).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(10);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'https://automation.local/api/teacher/content',
+      expect.objectContaining({
+        method: 'PUT',
+      })
+    );
+
+    await nextTick();
+    expect(editor.hasPendingChanges.value).toBe(false);
+  });
+});

--- a/src/services/useTeacherContentEditor.ts
+++ b/src/services/useTeacherContentEditor.ts
@@ -1,4 +1,4 @@
-import { computed, nextTick, ref, shallowRef, watch, type ComputedRef, type ShallowRef } from 'vue';
+import { computed, nextTick, ref, shallowRef, watch, type ComputedRef, type Ref } from 'vue';
 import { teacherAutomationBaseUrl, teacherAutomationToken } from './teacherAutomation';
 
 class TeacherContentServiceError extends Error {
@@ -96,7 +96,7 @@ interface TeacherContentResponse<TRaw> {
 
 export interface TeacherContentEditorOptions<TModel, TRaw> {
   path: ComputedRef<string | null>;
-  model: ShallowRef<TModel | null>;
+  model: Ref<TModel | null>;
   setModel: (value: TModel | null) => void;
   fromRaw: (raw: TRaw) => TModel;
   toRaw: (model: TModel, base: TRaw | null) => TRaw;


### PR DESCRIPTION
## Summary
- replace lesson editor shallow refs with refs to ensure cloned models remain reactive
- update authoring panels and content editor options to accept Ref-based models
- add a unit test that edits the lesson model and verifies autosave is triggered

## Testing
- npx vitest run src/services/__tests__/useTeacherContentEditor.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e1c613605c832c8b13773e3084ec6f