### PR TITLE
feat: allow editing unsupported lesson blocks via JSON

### DIFF
--- a/src/components/authoring/blocks/UnsupportedBlockEditor.vue
+++ b/src/components/authoring/blocks/UnsupportedBlockEditor.vue
@@ -1,26 +1,72 @@
 <template>
   <section class="flex flex-col gap-3">
     <header>
-      <h3 class="md-typescale-title-medium font-semibold text-on-surface">Bloco não suportado</h3>
+      <h3 class="md-typescale-title-medium font-semibold text-on-surface">Editor JSON do bloco</h3>
       <p class="text-sm text-on-surface-variant">
-        Este tipo de bloco ainda não possui edição visual. Ajuste o JSON bruto abaixo conforme
-        necessário.
+        Este bloco não possui editor visual dedicado. Ajuste o JSON bruto abaixo; alterações válidas
+        são aplicadas imediatamente.
       </p>
     </header>
-    <textarea
-      :value="formatted"
-      rows="12"
-      class="rounded-3xl border border-outline bg-surface-container-high p-4 font-mono text-sm text-on-surface"
-      readonly
-    ></textarea>
+    <label class="flex flex-col gap-2">
+      <span class="md-typescale-label-large text-on-surface">Conteúdo bruto</span>
+      <textarea
+        v-model="draft"
+        rows="12"
+        class="rounded-3xl border border-outline bg-surface-container-high p-4 font-mono text-sm text-on-surface"
+        :aria-invalid="Boolean(errorMessage)"
+        spellcheck="false"
+      ></textarea>
+    </label>
+    <p v-if="errorMessage" class="text-xs text-error">{{ errorMessage }}</p>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed, toRef } from 'vue';
+import { ref, toRef, watch } from 'vue';
 
-const props = defineProps<{ block: unknown }>();
-const block = toRef(props, 'block');
+const props = defineProps<{ block: Record<string, unknown> | null | undefined }>();
+const emit = defineEmits<{
+  (event: 'update:block', value: Record<string, unknown>): void;
+}>();
 
-const formatted = computed(() => JSON.stringify(block.value, null, 2));
+const blockRef = toRef(props, 'block');
+
+const draft = ref('');
+const errorMessage = ref('');
+let syncingFromBlock = false;
+
+function formatBlock(value: unknown) {
+  try {
+    return JSON.stringify(value ?? null, null, 2);
+  } catch (error) {
+    return '';
+  }
+}
+
+watch(
+  blockRef,
+  (value) => {
+    syncingFromBlock = true;
+    draft.value = formatBlock(value);
+    errorMessage.value = '';
+    syncingFromBlock = false;
+  },
+  { immediate: true, deep: true }
+);
+
+watch(draft, (value) => {
+  if (syncingFromBlock) return;
+
+  try {
+    const parsed = JSON.parse(value);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('O bloco precisa ser um objeto JSON.');
+    }
+
+    emit('update:block', parsed as Record<string, unknown>);
+    errorMessage.value = '';
+  } catch (error) {
+    errorMessage.value = 'JSON inválido. Ajuste a estrutura e tente novamente.';
+  }
+});
 </script>

--- a/src/components/authoring/blocks/__tests__/UnsupportedBlockEditor.test.ts
+++ b/src/components/authoring/blocks/__tests__/UnsupportedBlockEditor.test.ts
@@ -1,0 +1,37 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import UnsupportedBlockEditor from '../UnsupportedBlockEditor.vue';
+
+describe('UnsupportedBlockEditor', () => {
+  it('emits update:block when JSON is válido', async () => {
+    const wrapper = mount(UnsupportedBlockEditor, {
+      props: {
+        block: { type: 'customBlock', foo: 'bar' },
+      },
+    });
+
+    const textarea = wrapper.find('textarea');
+    const payload = JSON.stringify({ type: 'customBlock', foo: 'baz' }, null, 2);
+
+    await textarea.setValue(payload);
+
+    const events = wrapper.emitted('update:block');
+    expect(events).toBeTruthy();
+    expect(events?.[0]?.[0]).toMatchObject({ foo: 'baz' });
+    expect(wrapper.find('.text-error').exists()).toBe(false);
+  });
+
+  it('exibe mensagem de erro quando o JSON é inválido', async () => {
+    const wrapper = mount(UnsupportedBlockEditor, {
+      props: {
+        block: { type: 'customBlock', foo: 'bar' },
+      },
+    });
+
+    const textarea = wrapper.find('textarea');
+    await textarea.setValue('{ "type": "customBlock"');
+
+    expect(wrapper.emitted('update:block')).toBeUndefined();
+    expect(wrapper.find('.text-error').text()).toContain('JSON inválido');
+  });
+});

--- a/src/components/lesson/LessonAuthoringPanel.vue
+++ b/src/components/lesson/LessonAuthoringPanel.vue
@@ -197,7 +197,11 @@
         <h3 class="md-typescale-title-medium font-semibold text-on-surface">
           Editor do bloco selecionado
         </h3>
-        <component :is="blockEditorComponent" :block="selectedBlock" />
+        <component
+          :is="blockEditorComponent"
+          :block="selectedBlock"
+          @update:block="replaceSelectedBlock"
+        />
       </section>
     </template>
     <p v-else class="text-sm text-on-surface-variant">
@@ -318,6 +322,17 @@ function moveBlock(index: number, direction: 1 | -1) {
   nextBlocks.splice(nextIndex, 0, item);
   updateBlocks(nextBlocks);
   selectedBlockIndex.value = nextIndex;
+}
+
+function replaceSelectedBlock(nextBlock: LessonBlock) {
+  if (!props.lessonModel.value) return;
+  if (!Array.isArray(props.lessonModel.value.blocks)) return;
+  const index = selectedBlockIndex.value;
+  if (index < 0 || index >= props.lessonModel.value.blocks.length) return;
+
+  const nextBlocks = [...props.lessonModel.value.blocks];
+  nextBlocks.splice(index, 1, nextBlock);
+  updateBlocks(nextBlocks);
 }
 
 function removeBlock(index: number) {

--- a/src/components/lesson/__tests__/LessonAuthoringPanel.fallback.test.ts
+++ b/src/components/lesson/__tests__/LessonAuthoringPanel.fallback.test.ts
@@ -1,0 +1,119 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { computed, defineComponent, ref } from 'vue';
+import { describe, expect, it, vi } from 'vitest';
+import type { LessonEditorModel } from '@/composables/useLessonEditorModel';
+
+vi.mock('@/components/authoring/blocks/UnsupportedBlockEditor.vue', async (importOriginal) => {
+  const actual = await importOriginal();
+
+  const Stub = defineComponent({
+    name: 'UnsupportedBlockEditorStub',
+    props: {
+      block: {
+        type: Object,
+        required: true,
+      },
+    },
+    emits: ['update:block'],
+    setup(_, { emit }) {
+      function handleInput(event: Event) {
+        try {
+          const value = JSON.parse((event.target as HTMLTextAreaElement).value);
+          emit('update:block', value);
+        } catch {
+          // Ignora entradas inválidas no stub.
+        }
+      }
+
+      return { handleInput };
+    },
+    template: '<textarea data-test="raw-json" @input="handleInput"></textarea>',
+  });
+
+  return {
+    __esModule: true,
+    ...actual,
+    default: Stub,
+  };
+});
+
+vi.mock('@/composables/useLessonEditorModel', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/composables/useLessonEditorModel')>();
+  const { default: Stub } = await import(
+    '@/components/authoring/blocks/UnsupportedBlockEditor.vue'
+  );
+
+  return {
+    __esModule: true,
+    ...actual,
+    resolveLessonBlockEditor(block) {
+      if (
+        block &&
+        typeof block === 'object' &&
+        (block as { type?: string }).type === 'customBlock'
+      ) {
+        return Stub;
+      }
+      return actual.resolveLessonBlockEditor(block);
+    },
+  };
+});
+
+const iconStubs = {
+  ArrowDown: true,
+  ArrowUp: true,
+  CheckCircle2: true,
+  CircleDashed: true,
+  Clock3: true,
+  GripVertical: true,
+  PenSquare: true,
+  Plus: true,
+  Trash2: true,
+};
+
+function createTextField(initialValue = '') {
+  const state = ref(initialValue);
+  return computed({
+    get: () => state.value,
+    set: (value: string) => {
+      state.value = value;
+    },
+  });
+}
+
+describe('LessonAuthoringPanel - generic block editor integration', () => {
+  it('atualiza lessonModel quando o editor genérico emite update:block', async () => {
+    const lessonModel = ref<LessonEditorModel>({
+      blocks: [{ type: 'customBlock', foo: 'bar' }],
+    });
+
+    const { default: LessonAuthoringPanel } = await import('../LessonAuthoringPanel.vue');
+
+    const wrapper = mount(LessonAuthoringPanel, {
+      props: {
+        lessonModel,
+        tagsField: createTextField(),
+        createArrayField: () => createTextField(),
+      },
+      global: {
+        stubs: {
+          Md3Button: {
+            template: '<button><slot /></button>',
+          },
+          ...iconStubs,
+        },
+      },
+    });
+
+    await flushPromises();
+    await flushPromises();
+
+    const textarea = wrapper.find('[data-test="raw-json"]');
+    expect(textarea.exists()).toBe(true);
+
+    const nextValue = JSON.stringify({ type: 'customBlock', foo: 'baz' });
+    await textarea.setValue(nextValue);
+
+    expect(lessonModel.value?.blocks?.[0]?.foo).toBe('baz');
+  });
+});

--- a/src/composables/useLessonEditorModel.ts
+++ b/src/composables/useLessonEditorModel.ts
@@ -45,7 +45,7 @@ const CardGridEditor = defineAsyncComponent(
 const ContentBlockEditor = defineAsyncComponent(
   () => import('@/components/authoring/blocks/ContentBlockEditor.vue')
 );
-const UnsupportedBlockEditor = defineAsyncComponent(
+const GenericJsonBlockEditor = defineAsyncComponent(
   () => import('@/components/authoring/blocks/UnsupportedBlockEditor.vue')
 );
 
@@ -124,7 +124,7 @@ export function useLessonEditorModel(
 
 export function resolveLessonBlockEditor(block: LessonBlock | null | undefined): Component {
   if (!block || typeof block !== 'object') {
-    return UnsupportedBlockEditor;
+    return GenericJsonBlockEditor;
   }
 
   const type = block.type;
@@ -132,7 +132,7 @@ export function resolveLessonBlockEditor(block: LessonBlock | null | undefined):
     return blockEditorRegistry[type as keyof BlockEditorRegistry];
   }
 
-  return UnsupportedBlockEditor;
+  return GenericJsonBlockEditor;
 }
 
 export {
@@ -141,6 +141,6 @@ export {
   CalloutEditor,
   CardGridEditor,
   ContentBlockEditor,
-  UnsupportedBlockEditor,
+  GenericJsonBlockEditor as UnsupportedBlockEditor,
 };
 export type { LessonBlock };


### PR DESCRIPTION
## Summary
- replace the unsupported block placeholder with a two-way JSON editor that validates and emits updates
- update the lesson authoring panel to accept raw JSON updates for unknown block types and route them through the model
- adjust the block editor resolver to reuse the generic JSON editor and add regression tests for editor and panel integration

## Testing
- npx vitest run src/components/authoring/blocks/__tests__/UnsupportedBlockEditor.test.ts src/components/lesson/__tests__/LessonAuthoringPanel.fallback.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e1c7869bd0832caf5f9d9b4aede01f