### PR TITLE
feat: add teacher authoring workspace layout

### DIFF
--- a/src/components/teacher/TeacherAuthoringWorkspace.vue
+++ b/src/components/teacher/TeacherAuthoringWorkspace.vue
@@ -1,0 +1,218 @@
+<template>
+  <section class="teacher-authoring-workspace">
+    <header class="teacher-authoring-workspace__header">
+      <div class="teacher-authoring-workspace__headline">
+        <slot name="header">
+          <h2 class="teacher-authoring-workspace__title">Área de autoria</h2>
+        </slot>
+      </div>
+      <div
+        v-if="showViewSelector"
+        class="teacher-authoring-workspace__tabs"
+        role="tablist"
+        aria-label="Alternar entre editor e prévia"
+      >
+        <button
+          type="button"
+          class="teacher-authoring-workspace__tab"
+          :class="{ 'teacher-authoring-workspace__tab--active': currentView === 'editor' }"
+          :aria-pressed="currentView === 'editor'"
+          data-testid="teacher-workspace-tab-editor"
+          @click="setView('editor')"
+        >
+          <span class="teacher-authoring-workspace__tab-label">Editor</span>
+        </button>
+        <button
+          type="button"
+          class="teacher-authoring-workspace__tab"
+          :class="{ 'teacher-authoring-workspace__tab--active': currentView === 'preview' }"
+          :aria-pressed="currentView === 'preview'"
+          data-testid="teacher-workspace-tab-preview"
+          @click="setView('preview')"
+        >
+          <span class="teacher-authoring-workspace__tab-label">Prévia</span>
+        </button>
+      </div>
+    </header>
+
+    <div class="teacher-authoring-workspace__body">
+      <div
+        v-if="currentView === 'editor' && editorEnabled"
+        key="editor"
+        class="teacher-authoring-workspace__pane teacher-authoring-workspace__pane--editor"
+      >
+        <slot name="editor" />
+      </div>
+      <div
+        v-else-if="currentView === 'preview' && previewEnabled"
+        key="preview"
+        class="teacher-authoring-workspace__pane teacher-authoring-workspace__pane--preview"
+      >
+        <slot name="preview" />
+      </div>
+      <div v-else class="teacher-authoring-workspace__empty" role="status">
+        <slot name="empty">Nenhum conteúdo disponível para esta visão.</slot>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+
+type WorkspaceView = 'editor' | 'preview';
+
+interface TeacherAuthoringWorkspaceProps {
+  view?: WorkspaceView;
+  defaultView?: WorkspaceView;
+  editorEnabled?: boolean;
+  previewEnabled?: boolean;
+}
+
+const props = withDefaults(defineProps<TeacherAuthoringWorkspaceProps>(), {
+  defaultView: 'editor',
+  editorEnabled: true,
+  previewEnabled: true,
+});
+
+const emit = defineEmits<{
+  'update:view': [WorkspaceView];
+  change: [WorkspaceView];
+}>();
+
+const internalView = ref<WorkspaceView>(
+  props.view ?? (props.editorEnabled ? props.defaultView : 'preview')
+);
+
+const currentView = computed(() => props.view ?? internalView.value);
+
+const editorEnabled = computed(() => props.editorEnabled);
+const previewEnabled = computed(() => props.previewEnabled);
+
+const showViewSelector = computed(() => editorEnabled.value && previewEnabled.value);
+
+watch(
+  () => props.view,
+  (next) => {
+    if (!next) {
+      return;
+    }
+    internalView.value = next;
+  }
+);
+
+watch([editorEnabled, previewEnabled], ([editorAvailable, previewAvailable]) => {
+  if (!editorAvailable && currentView.value === 'editor' && previewAvailable) {
+    setView('preview');
+  }
+  if (!previewAvailable && currentView.value === 'preview' && editorAvailable) {
+    setView('editor');
+  }
+});
+
+function setView(view: WorkspaceView) {
+  if (view === currentView.value) {
+    return;
+  }
+
+  if (view === 'editor' && !editorEnabled.value) {
+    return;
+  }
+
+  if (view === 'preview' && !previewEnabled.value) {
+    return;
+  }
+
+  if (props.view === undefined) {
+    internalView.value = view;
+  }
+
+  emit('update:view', view);
+  emit('change', view);
+}
+</script>
+
+<style scoped>
+.teacher-authoring-workspace {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.teacher-authoring-workspace__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.teacher-authoring-workspace__headline {
+  flex: 1;
+  min-width: 12rem;
+}
+
+.teacher-authoring-workspace__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+}
+
+.teacher-authoring-workspace__tabs {
+  display: inline-flex;
+  background: var(--md-sys-color-surface-container-high, #f3edf7);
+  border-radius: 9999px;
+  padding: 0.25rem;
+  gap: 0.25rem;
+}
+
+.teacher-authoring-workspace__tab {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 1rem;
+  border-radius: 9999px;
+  border: none;
+  background: transparent;
+  color: var(--md-sys-color-on-surface-variant, #49454f);
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.teacher-authoring-workspace__tab:focus-visible {
+  outline: 2px solid var(--md-sys-color-primary, #6750a4);
+  outline-offset: 2px;
+}
+
+.teacher-authoring-workspace__tab--active {
+  background: var(--md-sys-color-primary, #6750a4);
+  color: var(--md-sys-color-on-primary, #ffffff);
+}
+
+.teacher-authoring-workspace__tab-label {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.teacher-authoring-workspace__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.teacher-authoring-workspace__pane {
+  width: 100%;
+}
+
+.teacher-authoring-workspace__empty {
+  padding: 2rem;
+  text-align: center;
+  color: var(--md-sys-color-on-surface-variant, #49454f);
+  background: var(--md-sys-color-surface-container, #ece6f0);
+  border-radius: 1rem;
+}
+</style>

--- a/src/pages/__tests__/ExerciseView.component.test.ts
+++ b/src/pages/__tests__/ExerciseView.component.test.ts
@@ -105,7 +105,7 @@ describe('ExerciseView component', () => {
     exerciseEditorModel.value = {};
   });
 
-  it('renderiza componente de exercício quando disponível', () => {
+  it('exibe painel de autoria como visão padrão', () => {
     const wrapper = mount(ExerciseView, {
       global: {
         stubs: {
@@ -118,10 +118,30 @@ describe('ExerciseView component', () => {
       },
     });
 
+    expect(wrapper.find('.exercise-authoring-panel').exists()).toBe(true);
+    expect(wrapper.find('.lesson-content').exists()).toBe(false);
+  });
+
+  it('permite alternar para visualizar a prévia do exercício', async () => {
+    const wrapper = mount(ExerciseView, {
+      global: {
+        stubs: {
+          Md3Button: ButtonStub,
+          RouterLink: { template: '<a><slot /></a>' },
+          ExerciseAuthoringPanel: ExerciseAuthoringPanelStub,
+          ChevronRight: { template: '<span />' },
+          ArrowLeft: { template: '<span />' },
+        },
+      },
+    });
+
+    await wrapper.get('[data-testid="teacher-workspace-tab-preview"]').trigger('click');
+
+    expect(wrapper.find('.exercise-authoring-panel').exists()).toBe(false);
     expect(wrapper.text()).toContain('Título');
   });
 
-  it('mostra fallback quando exercício não possui componente', () => {
+  it('mostra fallback quando exercício não possui componente', async () => {
     controllerMock.exerciseComponent.value = null;
     const wrapper = mount(ExerciseView, {
       global: {
@@ -134,6 +154,8 @@ describe('ExerciseView component', () => {
         },
       },
     });
+
+    await wrapper.get('[data-testid="teacher-workspace-tab-preview"]').trigger('click');
 
     expect(wrapper.text()).toContain('Conteúdo deste exercício ainda não está disponível');
   });
@@ -154,5 +176,6 @@ describe('ExerciseView component', () => {
     });
 
     expect(wrapper.find('.exercise-authoring-panel').exists()).toBe(false);
+    expect(wrapper.text()).toContain('Título');
   });
 });

--- a/src/utils/prismHighlight.ts
+++ b/src/utils/prismHighlight.ts
@@ -1,0 +1,52 @@
+let prismInstance: typeof import('prismjs') | null = null;
+let prismLoader: Promise<typeof import('prismjs')> | null = null;
+
+async function ensurePrism(): Promise<typeof import('prismjs')> {
+  if (prismInstance) {
+    return prismInstance;
+  }
+
+  if (!prismLoader) {
+    prismLoader = (async () => {
+      const core = await import('prismjs');
+      const Prism =
+        (core as { default?: typeof import('prismjs') }).default ??
+        (core as typeof import('prismjs'));
+      const globalWithPrism = globalThis as typeof globalThis & {
+        Prism?: typeof import('prismjs');
+      };
+      if (!globalWithPrism.Prism) {
+        globalWithPrism.Prism = Prism;
+      }
+
+      await Promise.all([
+        import('prismjs/components/prism-markup'),
+        import('prismjs/components/prism-javascript'),
+        import('prismjs/components/prism-typescript'),
+        import('prismjs/components/prism-python'),
+        import('prismjs/components/prism-json'),
+        import('prismjs/components/prism-java'),
+        import('prismjs/components/prism-c'),
+        import('prismjs/components/prism-cpp'),
+        import('prismjs/components/prism-csharp'),
+        import('prismjs/components/prism-kotlin'),
+      ]);
+
+      return Prism;
+    })();
+  }
+
+  prismInstance = await prismLoader;
+  return prismInstance;
+}
+
+export type PrismHighlightHandler = (context?: unknown) => Promise<void> | void;
+
+export function createPrismHighlightHandler(): PrismHighlightHandler {
+  return async () => {
+    const Prism = await ensurePrism();
+    requestAnimationFrame(() => {
+      Prism.highlightAll();
+    });
+  };
+}


### PR DESCRIPTION
## Summary
- add a TeacherAuthoringWorkspace component with editor/preview segmented controls for authoring flows
- refactor LessonView and ExerciseView to render through the new workspace and trigger Prism highlighting only in preview
- extract a reusable Prism highlight helper and expand component tests to cover workspace tab switching

## Testing
- npm run test -- LessonView.component.test.ts ExerciseView.component.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e1cfee8704832c84235e2845d5d093