### PR TITLE
Preserve authoring block identity in lesson authoring panels

### DIFF
--- a/src/components/exercise/__tests__/ExerciseAuthoringPanel.ordering.test.ts
+++ b/src/components/exercise/__tests__/ExerciseAuthoringPanel.ordering.test.ts
@@ -1,0 +1,119 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { computed, ref } from 'vue';
+import { describe, expect, it } from 'vitest';
+import type { LessonEditorModel } from '@/composables/useLessonEditorModel';
+import type { LessonAuthoringBlock } from '@/composables/useAuthoringBlockKeys';
+
+const iconStubs = {
+  AlertCircle: true,
+  ArrowDown: true,
+  ArrowUp: true,
+  CheckCircle2: true,
+  CircleDashed: true,
+  Clock3: true,
+  GripVertical: true,
+  LoaderCircle: true,
+  PenSquare: true,
+  Plus: true,
+  Trash2: true,
+};
+
+function createTextField(initialValue = '') {
+  const state = ref(initialValue);
+  return computed({
+    get: () => state.value,
+    set: (value: string) => {
+      state.value = value;
+    },
+  });
+}
+
+describe('ExerciseAuthoringPanel - reordenação e inserção', () => {
+  async function mountPanel(initialBlocks: LessonAuthoringBlock[]) {
+    const exerciseModel = ref<LessonEditorModel | null>({
+      blocks: initialBlocks,
+    });
+
+    const { default: ExerciseAuthoringPanel } = await import('../ExerciseAuthoringPanel.vue');
+
+    const wrapper = mount(ExerciseAuthoringPanel, {
+      props: {
+        exerciseModel,
+        tagsField: createTextField(),
+        saving: ref(false),
+        hasPendingChanges: ref(false),
+        saveError: ref<string | null>(null),
+      },
+      global: {
+        stubs: {
+          Md3Button: { template: '<button><slot /></button>' },
+          MetadataListEditor: { template: '<div />' },
+          ...iconStubs,
+        },
+      },
+    });
+
+    await flushPromises();
+
+    return { wrapper, exerciseModel };
+  }
+
+  function readCardTitles(wrapper: ReturnType<typeof mount>) {
+    return wrapper
+      .findAll('article')
+      .map((card) => card.find('p.md-typescale-label-large').text().trim());
+  }
+
+  it('mantém o cartão correspondente após mover um bloco', async () => {
+    const initialBlocks: LessonAuthoringBlock[] = [
+      { type: 'contentBlock', title: 'Primeiro', __uiKey: 'exercise-block-1' },
+      { type: 'contentBlock', title: 'Segundo', __uiKey: 'exercise-block-2' },
+    ];
+
+    const { wrapper, exerciseModel } = await mountPanel(initialBlocks);
+
+    expect(readCardTitles(wrapper)).toEqual(['Primeiro', 'Segundo']);
+
+    const firstCard = wrapper.findAll('article')[0];
+    const moveDownButton = firstCard
+      .findAll('button')
+      .find((button) => button.text().includes('Mover para baixo'));
+    expect(moveDownButton).toBeTruthy();
+
+    await moveDownButton!.trigger('click');
+    await flushPromises();
+
+    expect(readCardTitles(wrapper)).toEqual(['Segundo', 'Primeiro']);
+    const blocks = exerciseModel.value?.blocks as LessonAuthoringBlock[];
+    expect(blocks[0].__uiKey).toBe('exercise-block-2');
+    expect(blocks[1].__uiKey).toBe('exercise-block-1');
+  });
+
+  it('mantém os cartões corretos após inserir um novo bloco', async () => {
+    const initialBlocks: LessonAuthoringBlock[] = [
+      { type: 'contentBlock', title: 'Primeiro', __uiKey: 'exercise-block-1' },
+      { type: 'contentBlock', title: 'Segundo', __uiKey: 'exercise-block-2' },
+    ];
+
+    const { wrapper, exerciseModel } = await mountPanel(initialBlocks);
+
+    const firstCard = wrapper.findAll('article')[0];
+    const insertBelowButton = firstCard
+      .findAll('button')
+      .find((button) => button.text().includes('Inserir abaixo'));
+    expect(insertBelowButton).toBeTruthy();
+
+    await insertBelowButton!.trigger('click');
+    await flushPromises();
+
+    expect(readCardTitles(wrapper)).toEqual(['Primeiro', 'Bloco 2', 'Segundo']);
+
+    const blocks = (exerciseModel.value?.blocks ?? []) as LessonAuthoringBlock[];
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0].__uiKey).toBe('exercise-block-1');
+    expect(blocks[2].__uiKey).toBe('exercise-block-2');
+    expect(typeof blocks[1].__uiKey).toBe('string');
+    expect(blocks[1].__uiKey).not.toBe(blocks[0].__uiKey);
+    expect(blocks[1].__uiKey).not.toBe(blocks[2].__uiKey);
+  });
+});

--- a/src/components/lesson/__tests__/LessonAuthoringPanel.ordering.test.ts
+++ b/src/components/lesson/__tests__/LessonAuthoringPanel.ordering.test.ts
@@ -1,0 +1,120 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { computed, ref } from 'vue';
+import { describe, expect, it } from 'vitest';
+import type { LessonEditorModel } from '@/composables/useLessonEditorModel';
+import type { LessonAuthoringBlock } from '@/composables/useAuthoringBlockKeys';
+
+const iconStubs = {
+  AlertCircle: true,
+  ArrowDown: true,
+  ArrowUp: true,
+  CheckCircle2: true,
+  CircleDashed: true,
+  Clock3: true,
+  GripVertical: true,
+  LoaderCircle: true,
+  PenSquare: true,
+  Plus: true,
+  Trash2: true,
+};
+
+function createTextField(initialValue = '') {
+  const state = ref(initialValue);
+  return computed({
+    get: () => state.value,
+    set: (value: string) => {
+      state.value = value;
+    },
+  });
+}
+
+describe('LessonAuthoringPanel - reordenação e inserção', () => {
+  async function mountPanel(initialBlocks: LessonAuthoringBlock[]) {
+    const lessonModel = ref<LessonEditorModel | null>({
+      blocks: initialBlocks,
+    });
+
+    const { default: LessonAuthoringPanel } = await import('../LessonAuthoringPanel.vue');
+
+    const wrapper = mount(LessonAuthoringPanel, {
+      props: {
+        lessonModel,
+        tagsField: createTextField(),
+        createArrayField: () => createTextField(),
+        saving: ref(false),
+        hasPendingChanges: ref(false),
+        saveError: ref<string | null>(null),
+      },
+      global: {
+        stubs: {
+          Md3Button: { template: '<button><slot /></button>' },
+          MetadataListEditor: { template: '<div />' },
+          ...iconStubs,
+        },
+      },
+    });
+
+    await flushPromises();
+
+    return { wrapper, lessonModel };
+  }
+
+  function readCardTitles(wrapper: ReturnType<typeof mount>) {
+    return wrapper
+      .findAll('article')
+      .map((card) => card.find('p.md-typescale-label-large').text().trim());
+  }
+
+  it('mantém a correspondência entre cartões e blocos após mover um item', async () => {
+    const initialBlocks: LessonAuthoringBlock[] = [
+      { type: 'contentBlock', title: 'Primeiro', __uiKey: 'lesson-block-1' },
+      { type: 'contentBlock', title: 'Segundo', __uiKey: 'lesson-block-2' },
+    ];
+
+    const { wrapper, lessonModel } = await mountPanel(initialBlocks);
+
+    expect(readCardTitles(wrapper)).toEqual(['Primeiro', 'Segundo']);
+
+    const firstCard = wrapper.findAll('article')[0];
+    const moveDownButton = firstCard
+      .findAll('button')
+      .find((button) => button.text().includes('Mover para baixo'));
+    expect(moveDownButton).toBeTruthy();
+
+    await moveDownButton!.trigger('click');
+    await flushPromises();
+
+    expect(readCardTitles(wrapper)).toEqual(['Segundo', 'Primeiro']);
+    const blocks = lessonModel.value?.blocks as LessonAuthoringBlock[];
+    expect(blocks[0].__uiKey).toBe('lesson-block-2');
+    expect(blocks[1].__uiKey).toBe('lesson-block-1');
+  });
+
+  it('mantém o cartão correto para cada bloco ao inserir um item', async () => {
+    const initialBlocks: LessonAuthoringBlock[] = [
+      { type: 'contentBlock', title: 'Primeiro', __uiKey: 'lesson-block-1' },
+      { type: 'contentBlock', title: 'Segundo', __uiKey: 'lesson-block-2' },
+    ];
+
+    const { wrapper, lessonModel } = await mountPanel(initialBlocks);
+
+    const firstCard = wrapper.findAll('article')[0];
+    const insertBelowButton = firstCard
+      .findAll('button')
+      .find((button) => button.text().includes('Inserir abaixo'));
+    expect(insertBelowButton).toBeTruthy();
+
+    await insertBelowButton!.trigger('click');
+    await flushPromises();
+
+    expect(readCardTitles(wrapper)).toEqual(['Primeiro', 'Bloco 2', 'Segundo']);
+
+    const blocks = (lessonModel.value?.blocks ?? []) as LessonAuthoringBlock[];
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0].__uiKey).toBe('lesson-block-1');
+    expect(blocks[2].__uiKey).toBe('lesson-block-2');
+    expect(typeof blocks[1].__uiKey).toBe('string');
+    expect(blocks[1].__uiKey).not.toBe(blocks[0].__uiKey);
+    expect(blocks[1].__uiKey).not.toBe(blocks[2].__uiKey);
+  });
+});

--- a/src/composables/useAuthoringBlockKeys.ts
+++ b/src/composables/useAuthoringBlockKeys.ts
@@ -1,0 +1,75 @@
+import type { LessonBlock } from '@/components/lesson/blockRegistry';
+
+export const AUTHORING_BLOCK_UI_KEY = '__uiKey' as const;
+
+export type AuthoringBlockUiKey = { __uiKey: string };
+export type LessonAuthoringBlock = LessonBlock & AuthoringBlockUiKey;
+
+type BlockWithOptionalKey<T extends Record<string, unknown>> = T & {
+  __uiKey?: string;
+};
+
+function inheritKey<T extends Record<string, unknown>>(
+  block: T,
+  key?: string
+): T & AuthoringBlockUiKey {
+  const current = (block as BlockWithOptionalKey<T>).__uiKey;
+  if (typeof current === 'string') {
+    if (!key || current === key) {
+      return block as T & AuthoringBlockUiKey;
+    }
+    return {
+      ...(block as object),
+      __uiKey: key,
+    } as T & AuthoringBlockUiKey;
+  }
+
+  const nextKey = key ?? crypto.randomUUID();
+  return {
+    ...(block as object),
+    __uiKey: nextKey,
+  } as T & AuthoringBlockUiKey;
+}
+
+export function ensureAuthoringBlockKey<T extends Record<string, unknown>>(
+  block: T,
+  inheritedKey?: string
+): T & AuthoringBlockUiKey {
+  return inheritKey(block, inheritedKey);
+}
+
+export function applyAuthoringBlockKeys<T extends Record<string, unknown>>(
+  blocks: readonly T[]
+): (T & AuthoringBlockUiKey)[] {
+  return blocks.map((block) => ensureAuthoringBlockKey(block));
+}
+
+export function stripAuthoringBlockKey<T extends Record<string, unknown>>(
+  block: T & { __uiKey?: string }
+): T {
+  if (!('__uiKey' in block)) {
+    return block;
+  }
+  const { __uiKey: _removed, ...rest } = block;
+  return rest as T;
+}
+
+export function stripAuthoringBlockKeys<T extends Record<string, unknown>>(
+  blocks: readonly (T & { __uiKey?: string })[]
+): T[] {
+  return blocks.map((block) => stripAuthoringBlockKey(block));
+}
+
+export function cloneWithAuthoringBlockKey<T extends Record<string, unknown>>(
+  block: T & { __uiKey?: string }
+): T & AuthoringBlockUiKey {
+  return inheritKey(block, (block as BlockWithOptionalKey<T>).__uiKey);
+}
+
+export function inheritAuthoringBlockKey<T extends Record<string, unknown>>(
+  source: { __uiKey?: string } | undefined,
+  target: T
+): T & AuthoringBlockUiKey {
+  const key = typeof source?.__uiKey === 'string' ? source.__uiKey : undefined;
+  return ensureAuthoringBlockKey(target, key);
+}

--- a/src/pages/ExerciseView.vue
+++ b/src/pages/ExerciseView.vue
@@ -81,6 +81,10 @@ import { useTeacherMode } from '@/composables/useTeacherMode';
 import { useExerciseViewController } from './ExerciseView.logic';
 import { useTeacherContentEditor } from '@/services/useTeacherContentEditor';
 import type { LessonBlock } from '@/components/lesson/blockRegistry';
+import {
+  applyAuthoringBlockKeys,
+  stripAuthoringBlockKeys,
+} from '@/composables/useAuthoringBlockKeys';
 
 function cloneDeep<T>(value: T): T {
   try {
@@ -96,7 +100,7 @@ function toExerciseEditorModel(raw: ExerciseFilePayload): LessonEditorModel {
   const { content, ...rest } = raw;
   return {
     ...(rest as LessonEditorModel),
-    blocks: Array.isArray(content) ? cloneDeep(content) : [],
+    blocks: Array.isArray(content) ? applyAuthoringBlockKeys(cloneDeep(content)) : [],
   };
 }
 
@@ -108,7 +112,7 @@ function toExerciseFilePayload(
   const { blocks, ...rest } = model;
   Object.assign(target, rest);
   if (Array.isArray(blocks)) {
-    target.content = cloneDeep(blocks);
+    target.content = cloneDeep(stripAuthoringBlockKeys(blocks));
   } else {
     target.content = [];
   }

--- a/src/pages/LessonView.vue
+++ b/src/pages/LessonView.vue
@@ -99,6 +99,10 @@ import { useTeacherMode } from '@/composables/useTeacherMode';
 import { useLessonViewController } from './LessonView.logic';
 import { useTeacherContentEditor } from '@/services/useTeacherContentEditor';
 import type { LessonBlock } from '@/components/lesson/blockRegistry';
+import {
+  applyAuthoringBlockKeys,
+  stripAuthoringBlockKeys,
+} from '@/composables/useAuthoringBlockKeys';
 import { createPrismHighlightHandler } from '@/utils/prismHighlight';
 
 function cloneDeep<T>(value: T): T {
@@ -115,7 +119,7 @@ function toLessonEditorModel(raw: LessonFilePayload): LessonEditorModel {
   const { content, ...rest } = raw;
   return {
     ...(rest as LessonEditorModel),
-    blocks: Array.isArray(content) ? cloneDeep(content) : [],
+    blocks: Array.isArray(content) ? applyAuthoringBlockKeys(cloneDeep(content)) : [],
   };
 }
 
@@ -127,7 +131,7 @@ function toLessonFilePayload(
   const { blocks, ...rest } = model;
   Object.assign(target, rest);
   if (Array.isArray(blocks)) {
-    target.content = cloneDeep(blocks);
+    target.content = cloneDeep(stripAuthoringBlockKeys(blocks));
   } else {
     target.content = [];
   }


### PR DESCRIPTION
## Summary
- add a helper to assign stable UI identifiers to authoring blocks and strip them when saving
- update lesson and exercise authoring panels to propagate the identifiers during insertion, reorder, and replacement
- cover insertion and reorder flows with component tests to ensure the correct cards stay aligned with their blocks

## Testing
- npm run test -- LessonAuthoringPanel.ordering ExerciseAuthoringPanel.ordering

------
https://chatgpt.com/codex/tasks/task_e_68e248150818832cac8b273baf6d611a