### PR TITLE
Improve authoring panel block selection accessibility

### DIFF
--- a/src/components/exercise/ExerciseAuthoringPanel.vue
+++ b/src/components/exercise/ExerciseAuthoringPanel.vue
@@ -92,8 +92,10 @@
           <article
             v-for="(block, index) in blocks"
             :key="block.__uiKey"
-            class="md-shape-extra-large border border-outline-variant bg-surface-container-high p-3"
-            :class="{ 'border-primary': index === selectedBlockIndex }"
+            class="authoring-block-card md-shape-extra-large border border-outline-variant bg-surface-container-high p-3"
+            :class="{ 'is-selected': index === selectedBlockIndex }"
+            :aria-expanded="index === selectedBlockIndex"
+            :aria-controls="editorSectionId"
           >
             <header class="flex items-start justify-between gap-2">
               <div class="flex items-center gap-2">
@@ -134,7 +136,7 @@
               </div>
             </header>
             <footer class="mt-3 flex items-center justify-between gap-2">
-              <Md3Button type="button" variant="text" @click="selectedBlockIndex = index">
+              <Md3Button type="button" variant="text" @click="selectBlock(index)">
                 <template #leading>
                   <PenSquare class="md-icon md-icon--sm" aria-hidden="true" />
                 </template>
@@ -151,7 +153,12 @@
         </p>
       </section>
 
-      <section v-if="selectedBlock" class="md-stack md-stack-3">
+      <section
+        v-if="selectedBlock"
+        ref="selectedEditorEl"
+        :id="editorSectionId"
+        class="md-stack md-stack-3"
+      >
         <h3 class="md-typescale-title-medium font-semibold text-on-surface">
           Editor do bloco selecionado
         </h3>
@@ -169,7 +176,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch, type ComputedRef, type Ref } from 'vue';
+import { computed, nextTick, ref, useId, watch, type ComputedRef, type Ref } from 'vue';
 import {
   AlertCircle,
   ArrowDown,
@@ -221,6 +228,8 @@ const blocks = computed<LessonAuthoringBlock[]>(
   () => (props.exerciseModel.value?.blocks ?? []) as LessonAuthoringBlock[]
 );
 const selectedBlockIndex = ref(0);
+const selectedEditorEl = ref<HTMLElement | null>(null);
+const editorSectionId = `exercise-authoring-selected-block-${useId()}`;
 const newBlockType = ref<string>(supportedBlockTypes[0] ?? 'contentBlock');
 
 const showRevertButton = computed(
@@ -237,7 +246,7 @@ watch(blocks, (current) => {
     return;
   }
   if (selectedBlockIndex.value > current.length - 1) {
-    selectedBlockIndex.value = current.length - 1;
+    selectBlock(current.length - 1);
   }
 });
 
@@ -290,7 +299,7 @@ function insertBlock(index?: number) {
   const nextBlocks = [...blocks.value];
   nextBlocks.splice(targetIndex, 0, createBlockPayload(newBlockType.value));
   updateBlocks(nextBlocks);
-  selectedBlockIndex.value = targetIndex;
+  selectBlock(targetIndex);
 }
 
 function moveBlock(index: number, direction: 1 | -1) {
@@ -300,7 +309,7 @@ function moveBlock(index: number, direction: 1 | -1) {
   const [item] = nextBlocks.splice(index, 1);
   nextBlocks.splice(nextIndex, 0, item);
   updateBlocks(nextBlocks);
-  selectedBlockIndex.value = nextIndex;
+  selectBlock(nextIndex);
 }
 
 function replaceSelectedBlock(nextBlock: LessonBlock) {
@@ -316,12 +325,26 @@ function replaceSelectedBlock(nextBlock: LessonBlock) {
 }
 
 function removeBlock(index: number) {
+  const previousSelection = selectedBlockIndex.value;
   const nextBlocks = blocks.value.filter((_, blockIndex) => blockIndex !== index);
   updateBlocks(nextBlocks);
   if (!nextBlocks.length) {
     selectedBlockIndex.value = 0;
-  } else if (selectedBlockIndex.value >= nextBlocks.length) {
-    selectedBlockIndex.value = nextBlocks.length - 1;
+    return;
+  }
+
+  if (previousSelection > index) {
+    selectBlock(previousSelection - 1);
+    return;
+  }
+
+  if (previousSelection === index) {
+    selectBlock(Math.min(index, nextBlocks.length - 1));
+    return;
+  }
+
+  if (previousSelection >= nextBlocks.length) {
+    selectBlock(nextBlocks.length - 1);
   }
 }
 
@@ -336,6 +359,21 @@ function formatBlockTitle(block: LessonAuthoringBlock, index: number) {
     return unit.title;
   }
   return `Bloco ${index + 1}`;
+}
+
+function selectBlock(index: number) {
+  selectedBlockIndex.value = index;
+  nextTick(() => {
+    const sectionEl = selectedEditorEl.value;
+    if (!sectionEl) return;
+    sectionEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    const focusTarget =
+      sectionEl.querySelector<HTMLElement>('[autofocus]') ??
+      sectionEl.querySelector<HTMLElement>(
+        'input, textarea, select, [contenteditable="true"], [tabindex]:not([tabindex="-1"])'
+      );
+    focusTarget?.focus();
+  });
 }
 </script>
 
@@ -366,5 +404,22 @@ function formatBlockTitle(block: LessonAuthoringBlock, index: number) {
 
 .icon-button:not(:disabled):hover {
   background-color: color-mix(in srgb, var(--md-sys-color-on-surface-variant) 12%, transparent);
+}
+
+.authoring-block-card {
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.authoring-block-card.is-selected {
+  border-color: var(--md-sys-color-primary);
+  background-color: color-mix(
+    in srgb,
+    var(--md-sys-color-primary) 12%,
+    var(--md-sys-color-surface-container-high)
+  );
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--md-sys-color-primary) 18%, transparent);
 }
 </style>

--- a/src/components/exercise/__tests__/ExerciseAuthoringPanel.test.ts
+++ b/src/components/exercise/__tests__/ExerciseAuthoringPanel.test.ts
@@ -1,6 +1,6 @@
 import { flushPromises, mount } from '@vue/test-utils';
-import { computed, defineComponent, ref } from 'vue';
-import { describe, expect, it, vi } from 'vitest';
+import { computed, defineComponent, nextTick, ref } from 'vue';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LessonEditorModel } from '@/composables/useLessonEditorModel';
 import type { LessonAuthoringBlock } from '@/composables/useAuthoringBlockKeys';
 import { defaultBlockTemplates } from '@/components/authoring/defaultBlockTemplates';
@@ -30,7 +30,7 @@ vi.mock('@/components/authoring/blocks/UnsupportedBlockEditor.vue', async (impor
 
       return { handleInput };
     },
-    template: '<textarea data-test="raw-json" @input="handleInput"></textarea>',
+    template: '<textarea data-test="raw-json" autofocus @input="handleInput"></textarea>',
   });
 
   return {
@@ -75,6 +75,18 @@ const iconStubs = {
   Plus: true,
   Trash2: true,
 };
+
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+const scrollIntoViewSpy = vi.fn();
+
+beforeAll(() => {
+  HTMLElement.prototype.scrollIntoView =
+    scrollIntoViewSpy as typeof HTMLElement.prototype.scrollIntoView;
+});
+
+afterAll(() => {
+  HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+});
 
 function createTextField(initialValue = '') {
   const state = ref(initialValue);
@@ -198,5 +210,70 @@ describe('ExerciseAuthoringPanel - templates padrão', () => {
     const resolution = resolveBlock(block);
     expect(resolution.error).toBeUndefined();
     expect(resolution.component).not.toBeNull();
+  });
+});
+
+describe('ExerciseAuthoringPanel - gerenciamento de foco', () => {
+  let lastFocused: Element | null = null;
+  const originalFocus = HTMLElement.prototype.focus;
+
+  beforeAll(() => {
+    HTMLElement.prototype.focus = function focusOverride(this: HTMLElement) {
+      lastFocused = this;
+      return originalFocus?.call(this);
+    } as typeof HTMLElement.prototype.focus;
+  });
+
+  afterAll(() => {
+    HTMLElement.prototype.focus = originalFocus;
+  });
+
+  beforeEach(() => {
+    scrollIntoViewSpy.mockClear();
+    lastFocused = null;
+  });
+
+  it('move o foco para o editor do bloco selecionado', async () => {
+    const exerciseModel = ref<LessonEditorModel>({
+      blocks: [{ type: 'customBlock', foo: 'bar' }],
+    });
+
+    const { default: ExerciseAuthoringPanel } = await import('../ExerciseAuthoringPanel.vue');
+
+    const wrapper = mount(ExerciseAuthoringPanel, {
+      props: {
+        exerciseModel,
+        tagsField: createTextField(),
+        saving: ref(false),
+        hasPendingChanges: ref(false),
+        saveError: ref<string | null>(null),
+      },
+      global: {
+        stubs: {
+          Md3Button: { template: '<button type="button"><slot /></button>' },
+          MetadataListEditor: { template: '<div />' },
+          ...iconStubs,
+        },
+      },
+    });
+
+    await flushPromises();
+
+    const editorField = wrapper.find('[data-test="raw-json"]');
+    expect(editorField.exists()).toBe(true);
+
+    document.body.focus();
+
+    const editButton = wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Editar detalhes'));
+    expect(editButton).toBeTruthy();
+
+    await editButton!.trigger('click');
+    await flushPromises();
+    await nextTick();
+
+    expect(lastFocused).toBe(editorField.element);
+    expect(scrollIntoViewSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add smooth scrolling and focus management to lesson and exercise authoring panels when selecting blocks
- enhance block card accessibility with aria metadata and a clearer selected state style
- cover the focus workflow with new interaction tests for both authoring panels

## Testing
- npx vitest run src/components/lesson/__tests__/LessonAuthoringPanel.fallback.test.ts src/components/exercise/__tests__/ExerciseAuthoringPanel.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e24fad217c832caf3b2f4ad77b8132