### PR TITLE
feat(teacher): split authoring layout into sidebar and canvas

### DIFF
--- a/src/components/exercise/ExerciseAuthoringSidebar.vue
+++ b/src/components/exercise/ExerciseAuthoringSidebar.vue
@@ -1,0 +1,295 @@
+<template>
+  <div class="exercise-authoring-sidebar card md3-surface-section md-stack md-stack-4">
+    <header class="flex flex-col gap-3">
+      <div class="flex items-center justify-between gap-3">
+        <div class="flex flex-col gap-1">
+          <span class="chip chip--outlined self-start text-primary">Modo professor</span>
+          <h2 class="md-typescale-title-large font-semibold text-on-surface">Editar exercício</h2>
+          <p class="text-sm text-on-surface-variant">
+            Ajuste rapidamente os metadados e organize o enunciado deste exercício.
+          </p>
+        </div>
+        <div class="flex items-center gap-2">
+          <div class="flex items-center gap-2 text-sm" :class="statusTone">
+            <component :is="statusIcon" :class="statusIconClass" aria-hidden="true" />
+            <span>{{ statusLabel }}</span>
+          </div>
+          <Md3Button
+            v-if="showRevertButton"
+            type="button"
+            variant="text"
+            class="text-sm"
+            @click="handleRevert"
+          >
+            Reverter alterações
+          </Md3Button>
+        </div>
+      </div>
+    </header>
+
+    <div
+      v-if="props.errorMessage"
+      class="rounded-lg border border-error/40 bg-error/10 p-3 text-sm text-error"
+    >
+      {{ props.errorMessage }}
+    </div>
+    <div
+      v-else-if="props.successMessage"
+      class="rounded-lg border border-success/40 bg-success/10 p-3 text-sm text-success"
+    >
+      {{ props.successMessage }}
+    </div>
+
+    <template v-if="exerciseModel.value">
+      <section class="md-stack md-stack-3">
+        <h3 class="md-typescale-title-medium font-semibold text-on-surface">
+          Metadados do exercício
+        </h3>
+        <label class="flex flex-col gap-1">
+          <span class="md-typescale-label-large text-on-surface">Título</span>
+          <input
+            v-model="exerciseModel.value.title"
+            type="text"
+            class="md-shape-extra-large border border-outline bg-surface p-3 text-sm text-on-surface focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          />
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="md-typescale-label-large text-on-surface">Resumo</span>
+          <textarea
+            v-model="exerciseModel.value.summary"
+            rows="3"
+            class="md-shape-extra-large border border-outline bg-surface p-3 text-sm text-on-surface focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          ></textarea>
+        </label>
+        <MetadataListEditor label="Tags" v-model="tagsFieldProxy" />
+      </section>
+
+      <section class="md-stack md-stack-3">
+        <div class="flex items-center justify-between">
+          <h3 class="md-typescale-title-medium font-semibold text-on-surface">
+            Blocos do enunciado
+          </h3>
+          <div class="flex items-center gap-2">
+            <select
+              :value="props.newBlockType"
+              class="md-shape-large border border-outline bg-surface p-2 text-sm"
+              @change="handleNewBlockTypeChange"
+            >
+              <option v-for="type in supportedBlockTypes" :key="type" :value="type">
+                {{ type }}
+              </option>
+            </select>
+            <Md3Button type="button" variant="tonal" @click="props.onInsertBlock()">
+              <template #leading>
+                <Plus class="md-icon md-icon--sm" aria-hidden="true" />
+              </template>
+              Inserir
+            </Md3Button>
+          </div>
+        </div>
+
+        <AuthoringDraggableList
+          v-if="blocks.length"
+          :model-value="props.draggableBlocks"
+          item-key="__uiKey"
+          class="md-stack md-stack-2"
+          @update:model-value="props.onUpdateDraggableBlocks"
+          @end="props.onDragEnd"
+        >
+          <template #item="{ element: block, index }">
+            <article
+              :key="block.__uiKey"
+              class="authoring-block-card md-shape-extra-large border border-outline-variant bg-surface-container-high p-3"
+              :class="{ 'is-selected': index === props.selectedBlockIndex }"
+              :aria-expanded="index === props.selectedBlockIndex"
+              :aria-controls="props.editorSectionId"
+            >
+              <header class="flex items-start justify-between gap-2">
+                <div class="grabbable flex items-center gap-2">
+                  <GripVertical
+                    class="md-icon md-icon--sm text-on-surface-variant"
+                    aria-hidden="true"
+                  />
+                  <div>
+                    <p class="md-typescale-label-large text-on-surface">
+                      {{ formatBlockTitle(block, index) }}
+                    </p>
+                    <p class="text-xs text-on-surface-variant">{{ block.type ?? 'bloco' }}</p>
+                  </div>
+                </div>
+                <div class="flex items-center gap-1">
+                  <button
+                    type="button"
+                    class="icon-button"
+                    :disabled="index === 0"
+                    @click="props.onMoveBlock(index, -1)"
+                  >
+                    <ArrowUp class="md-icon md-icon--sm" aria-hidden="true" />
+                    <span class="sr-only">Mover para cima</span>
+                  </button>
+                  <button
+                    type="button"
+                    class="icon-button"
+                    :disabled="index === blocks.length - 1"
+                    @click="props.onMoveBlock(index, 1)"
+                  >
+                    <ArrowDown class="md-icon md-icon--sm" aria-hidden="true" />
+                    <span class="sr-only">Mover para baixo</span>
+                  </button>
+                  <button type="button" class="icon-button" @click="props.onRemoveBlock(index)">
+                    <Trash2 class="md-icon md-icon--sm text-error" aria-hidden="true" />
+                    <span class="sr-only">Remover bloco</span>
+                  </button>
+                </div>
+              </header>
+              <footer class="mt-3 flex items-center justify-between gap-2">
+                <Md3Button type="button" variant="text" @click="props.onSelectBlock(index)">
+                  <template #leading>
+                    <PenSquare class="md-icon md-icon--sm" aria-hidden="true" />
+                  </template>
+                  Editar detalhes
+                </Md3Button>
+                <Md3Button type="button" variant="outlined" @click="props.onInsertBlock(index)">
+                  Inserir abaixo
+                </Md3Button>
+              </footer>
+            </article>
+          </template>
+        </AuthoringDraggableList>
+        <p v-else class="text-sm text-on-surface-variant">
+          Adicione blocos para descrever o passo a passo ou a rubrica deste exercício.
+        </p>
+      </section>
+    </template>
+    <p v-else class="text-sm text-on-surface-variant">
+      Carregue o JSON correspondente para habilitar o painel de edição.
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, type Component, type Ref, type WritableComputedRef } from 'vue';
+import { ArrowDown, ArrowUp, GripVertical, PenSquare, Plus, Trash2 } from 'lucide-vue-next';
+import Md3Button from '@/components/Md3Button.vue';
+import AuthoringDraggableList from '@/components/authoring/AuthoringDraggableList.vue';
+import { MetadataListEditor, type LessonEditorModel } from '@/composables/useLessonEditorModel';
+import type { LessonAuthoringBlock } from '@/composables/useAuthoringBlockKeys';
+
+type DragEndEvent = { oldIndex?: number | null; newIndex?: number | null };
+
+const props = defineProps<{
+  exerciseModel: Ref<LessonEditorModel | null>;
+  tagsField: WritableComputedRef<string>;
+  blocks: LessonAuthoringBlock[];
+  draggableBlocks: LessonAuthoringBlock[];
+  selectedBlockIndex: number;
+  supportedBlockTypes: readonly string[];
+  newBlockType: string;
+  statusLabel: string;
+  statusTone: string;
+  statusIcon: Component | string;
+  statusIconClass: string;
+  errorMessage?: string | null;
+  successMessage?: string | null;
+  canRevert?: boolean;
+  onRevert?: () => void;
+  onInsertBlock: (index?: number) => void;
+  onSelectBlock: (index: number) => void;
+  onMoveBlock: (index: number, direction: 1 | -1) => void;
+  onRemoveBlock: (index: number) => void;
+  onUpdateNewBlockType: (value: string) => void;
+  onUpdateDraggableBlocks: (value: LessonAuthoringBlock[]) => void;
+  onDragEnd: (event: DragEndEvent) => void;
+  editorSectionId?: string;
+}>();
+
+const exerciseModel = props.exerciseModel;
+
+const tagsFieldProxy = computed({
+  get: () => props.tagsField.value,
+  set: (value: string) => {
+    props.tagsField.value = value;
+  },
+});
+
+const showRevertButton = computed(
+  () => Boolean(props.canRevert) && typeof props.onRevert === 'function'
+);
+
+const blocks = computed(() => props.blocks ?? []);
+
+function handleRevert() {
+  props.onRevert?.();
+}
+
+function handleNewBlockTypeChange(event: Event) {
+  const target = event.target as HTMLSelectElement | null;
+  const value = target?.value ?? '';
+  props.onUpdateNewBlockType(value);
+}
+
+function formatBlockTitle(block: LessonAuthoringBlock, index: number) {
+  if (typeof block !== 'object' || !block) return `Bloco ${index + 1}`;
+  const maybeTitle = (block as Record<string, unknown>).title;
+  if (typeof maybeTitle === 'string' && maybeTitle.length) {
+    return maybeTitle;
+  }
+  const unit = (block as Record<string, unknown>).unit as Record<string, unknown> | undefined;
+  if (unit && typeof unit.title === 'string' && unit.title.length) {
+    return unit.title;
+  }
+  return `Bloco ${index + 1}`;
+}
+</script>
+
+<style scoped>
+.exercise-authoring-sidebar {
+  width: 100%;
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  border-radius: 9999px;
+  color: var(--md-sys-color-on-surface-variant);
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.grabbable {
+  cursor: grab;
+}
+
+.grabbable:active {
+  cursor: grabbing;
+}
+
+.icon-button:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.icon-button:not(:disabled):hover {
+  background-color: color-mix(in srgb, var(--md-sys-color-on-surface-variant) 12%, transparent);
+}
+
+.authoring-block-card {
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.authoring-block-card.is-selected {
+  border-color: var(--md-sys-color-primary);
+  background-color: color-mix(
+    in srgb,
+    var(--md-sys-color-primary) 12%,
+    var(--md-sys-color-surface-container-high)
+  );
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--md-sys-color-primary) 18%, transparent);
+}
+</style>

--- a/src/components/exercise/ExerciseBlockEditorPanel.vue
+++ b/src/components/exercise/ExerciseBlockEditorPanel.vue
@@ -1,0 +1,80 @@
+<template>
+  <section
+    v-if="selectedBlock"
+    ref="panelEl"
+    :id="editorSectionId"
+    class="exercise-block-editor card md3-surface-section md-stack md-stack-3"
+  >
+    <h3 class="md-typescale-title-medium font-semibold text-on-surface">
+      Editor do bloco selecionado
+    </h3>
+    <component
+      v-if="blockEditorComponent"
+      :is="blockEditorComponent"
+      :block="selectedBlock"
+      @update:block="handleUpdateBlock"
+    />
+    <p v-else class="text-body-medium text-on-surface-variant">
+      Nenhum editor disponível para o bloco selecionado.
+    </p>
+  </section>
+  <section
+    v-else
+    class="exercise-block-editor exercise-block-editor--empty card md3-surface-section"
+  >
+    <p class="text-body-medium text-on-surface-variant">
+      Selecione um bloco na barra lateral para editar os detalhes.
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { nextTick, ref, watch, type Component } from 'vue';
+import type { LessonAuthoringBlock } from '@/composables/useAuthoringBlockKeys';
+import type { LessonBlock } from '@/components/lesson/blockRegistry';
+
+const props = defineProps<{
+  selectedBlock: LessonAuthoringBlock | null;
+  blockEditorComponent: Component | null;
+  editorSectionId?: string;
+  onUpdateBlock: (block: LessonBlock) => void;
+}>();
+
+const panelEl = ref<HTMLElement | null>(null);
+
+watch(
+  () => props.selectedBlock?.__uiKey,
+  () => {
+    nextTick(() => {
+      const container = panelEl.value;
+      if (!container) return;
+      if (typeof container.scrollIntoView === 'function') {
+        container.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+      const focusTarget =
+        container.querySelector<HTMLElement>('[autofocus]') ??
+        container.querySelector<HTMLElement>(
+          'input, textarea, select, [contenteditable="true"], [tabindex]:not([tabindex="-1"])'
+        );
+      focusTarget?.focus();
+    });
+  }
+);
+
+function handleUpdateBlock(block: LessonBlock) {
+  props.onUpdateBlock(block);
+}
+</script>
+
+<style scoped>
+.exercise-block-editor {
+  width: 100%;
+}
+
+.exercise-block-editor--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 12rem;
+}
+</style>

--- a/src/components/lesson/LessonAuthoringSidebar.vue
+++ b/src/components/lesson/LessonAuthoringSidebar.vue
@@ -1,0 +1,347 @@
+<template>
+  <div class="lesson-authoring-sidebar card md3-surface-section md-stack md-stack-4">
+    <header class="flex flex-col gap-3">
+      <div class="flex items-center justify-between gap-3">
+        <div class="flex flex-col gap-1">
+          <span class="chip chip--outlined self-start text-primary">Modo professor</span>
+          <h2 class="md-typescale-title-large font-semibold text-on-surface">Editar aula</h2>
+          <p class="text-sm text-on-surface-variant">
+            Ajuste metadados, reordene blocos e visualize o conteúdo renderizado em tempo real.
+          </p>
+        </div>
+        <div class="flex items-center gap-2">
+          <div class="flex items-center gap-2 text-sm" :class="statusTone">
+            <component :is="statusIcon" :class="statusIconClass" aria-hidden="true" />
+            <span>{{ statusLabel }}</span>
+          </div>
+          <Md3Button
+            v-if="showRevertButton"
+            type="button"
+            variant="text"
+            class="text-sm"
+            @click="handleRevert"
+          >
+            Reverter alterações
+          </Md3Button>
+        </div>
+      </div>
+    </header>
+
+    <div
+      v-if="props.errorMessage"
+      class="rounded-lg border border-error/40 bg-error/10 p-3 text-sm text-error"
+    >
+      {{ props.errorMessage }}
+    </div>
+    <div
+      v-else-if="props.successMessage"
+      class="rounded-lg border border-success/40 bg-success/10 p-3 text-sm text-success"
+    >
+      {{ props.successMessage }}
+    </div>
+
+    <template v-if="lessonModel.value">
+      <section class="md-stack md-stack-3">
+        <h3 class="md-typescale-title-medium font-semibold text-on-surface">
+          Metadados principais
+        </h3>
+        <label class="flex flex-col gap-1">
+          <span class="md-typescale-label-large text-on-surface">Título</span>
+          <input
+            v-model="lessonModel.value.title"
+            type="text"
+            class="md-shape-extra-large border border-outline bg-surface p-3 text-sm text-on-surface focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          />
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="md-typescale-label-large text-on-surface">Resumo</span>
+          <textarea
+            v-model="lessonModel.value.summary"
+            rows="3"
+            class="md-shape-extra-large border border-outline bg-surface p-3 text-sm text-on-surface focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          ></textarea>
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="md-typescale-label-large text-on-surface">Objetivo geral</span>
+          <textarea
+            v-model="lessonModel.value.objective"
+            rows="3"
+            class="md-shape-extra-large border border-outline bg-surface p-3 text-sm text-on-surface focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          ></textarea>
+        </label>
+        <div class="grid gap-3 md:grid-cols-2">
+          <label class="flex flex-col gap-1">
+            <span class="md-typescale-label-large text-on-surface">Modalidade</span>
+            <input
+              v-model="lessonModel.value.modality"
+              type="text"
+              class="md-shape-extra-large border border-outline bg-surface p-3 text-sm text-on-surface focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              placeholder="in-person, remoto, híbrido..."
+            />
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="md-typescale-label-large text-on-surface">Duração (min)</span>
+            <input
+              v-model.number="lessonModel.value.duration"
+              type="number"
+              min="0"
+              class="md-shape-extra-large border border-outline bg-surface p-3 text-sm text-on-surface focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            />
+          </label>
+        </div>
+        <label class="flex flex-col gap-1">
+          <span class="md-typescale-label-large text-on-surface">Tags</span>
+          <textarea
+            v-model="tagsFieldProxy"
+            rows="2"
+            class="md-shape-extra-large border border-outline bg-surface p-3 text-sm text-on-surface focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            placeholder="Uma tag por linha"
+          ></textarea>
+        </label>
+        <div class="grid gap-3 md:grid-cols-2">
+          <MetadataListEditor label="Objetivos específicos" v-model="objectivesField" />
+          <MetadataListEditor label="Competências" v-model="competenciesField" />
+          <MetadataListEditor label="Habilidades" v-model="skillsField" />
+          <MetadataListEditor label="Resultados esperados" v-model="outcomesField" />
+          <MetadataListEditor label="Pré-requisitos" v-model="prerequisitesField" />
+        </div>
+      </section>
+
+      <section class="md-stack md-stack-3">
+        <div class="flex items-center justify-between">
+          <h3 class="md-typescale-title-medium font-semibold text-on-surface">
+            Blocos de conteúdo
+          </h3>
+          <div class="flex items-center gap-2">
+            <select
+              :value="props.newBlockType"
+              class="md-shape-large border border-outline bg-surface p-2 text-sm"
+              @change="handleNewBlockTypeChange"
+            >
+              <option v-for="type in supportedBlockTypes" :key="type" :value="type">
+                {{ type }}
+              </option>
+            </select>
+            <Md3Button type="button" variant="tonal" @click="props.onInsertBlock()">
+              <template #leading>
+                <Plus class="md-icon md-icon--sm" aria-hidden="true" />
+              </template>
+              Inserir
+            </Md3Button>
+          </div>
+        </div>
+
+        <AuthoringDraggableList
+          v-if="blocks.length"
+          :model-value="props.draggableBlocks"
+          item-key="__uiKey"
+          class="md-stack md-stack-2"
+          @update:model-value="props.onUpdateDraggableBlocks"
+          @end="props.onDragEnd"
+        >
+          <template #item="{ element: block, index }">
+            <article
+              :key="block.__uiKey"
+              class="authoring-block-card md-shape-extra-large border border-outline-variant bg-surface-container-high p-3"
+              :class="{ 'is-selected': index === props.selectedBlockIndex }"
+              :aria-expanded="index === props.selectedBlockIndex"
+              :aria-controls="props.editorSectionId"
+            >
+              <header class="flex items-start justify-between gap-2">
+                <div class="grabbable flex items-center gap-2">
+                  <GripVertical
+                    class="md-icon md-icon--sm text-on-surface-variant"
+                    aria-hidden="true"
+                  />
+                  <div>
+                    <p class="md-typescale-label-large text-on-surface">
+                      {{ formatBlockTitle(block, index) }}
+                    </p>
+                    <p class="text-xs text-on-surface-variant">{{ block.type ?? 'bloco' }}</p>
+                  </div>
+                </div>
+                <div class="flex items-center gap-1">
+                  <button
+                    type="button"
+                    class="icon-button"
+                    :disabled="index === 0"
+                    @click="props.onMoveBlock(index, -1)"
+                  >
+                    <ArrowUp class="md-icon md-icon--sm" aria-hidden="true" />
+                    <span class="sr-only">Mover para cima</span>
+                  </button>
+                  <button
+                    type="button"
+                    class="icon-button"
+                    :disabled="index === blocks.length - 1"
+                    @click="props.onMoveBlock(index, 1)"
+                  >
+                    <ArrowDown class="md-icon md-icon--sm" aria-hidden="true" />
+                    <span class="sr-only">Mover para baixo</span>
+                  </button>
+                  <button type="button" class="icon-button" @click="props.onRemoveBlock(index)">
+                    <Trash2 class="md-icon md-icon--sm text-error" aria-hidden="true" />
+                    <span class="sr-only">Remover bloco</span>
+                  </button>
+                </div>
+              </header>
+              <footer class="mt-3 flex items-center justify-between gap-2">
+                <Md3Button type="button" variant="text" @click="props.onSelectBlock(index)">
+                  <template #leading>
+                    <PenSquare class="md-icon md-icon--sm" aria-hidden="true" />
+                  </template>
+                  Editar detalhes
+                </Md3Button>
+                <Md3Button type="button" variant="outlined" @click="props.onInsertBlock(index)">
+                  Inserir abaixo
+                </Md3Button>
+              </footer>
+            </article>
+          </template>
+        </AuthoringDraggableList>
+        <p v-else class="text-sm text-on-surface-variant">
+          Esta aula ainda não possui blocos. Adicione um tipo acima para começar a montar o roteiro.
+        </p>
+      </section>
+    </template>
+    <p v-else class="text-sm text-on-surface-variant">
+      Carregando os dados da aula. Abra uma aula válida para habilitar o painel de edição.
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, type Component, type Ref, type WritableComputedRef } from 'vue';
+import { ArrowDown, ArrowUp, GripVertical, PenSquare, Plus, Trash2 } from 'lucide-vue-next';
+import Md3Button from '@/components/Md3Button.vue';
+import AuthoringDraggableList from '@/components/authoring/AuthoringDraggableList.vue';
+import {
+  MetadataListEditor,
+  type LessonArrayField,
+  type LessonEditorModel,
+} from '@/composables/useLessonEditorModel';
+import type { LessonAuthoringBlock } from '@/composables/useAuthoringBlockKeys';
+
+type DragEndEvent = { oldIndex?: number | null; newIndex?: number | null };
+
+const props = defineProps<{
+  lessonModel: Ref<LessonEditorModel | null>;
+  tagsField: WritableComputedRef<string>;
+  createArrayField: (field: LessonArrayField) => WritableComputedRef<string>;
+  blocks: LessonAuthoringBlock[];
+  draggableBlocks: LessonAuthoringBlock[];
+  selectedBlockIndex: number;
+  supportedBlockTypes: readonly string[];
+  newBlockType: string;
+  statusLabel: string;
+  statusTone: string;
+  statusIcon: Component | string;
+  statusIconClass: string;
+  errorMessage?: string | null;
+  successMessage?: string | null;
+  canRevert?: boolean;
+  onRevert?: () => void;
+  onInsertBlock: (index?: number) => void;
+  onSelectBlock: (index: number) => void;
+  onMoveBlock: (index: number, direction: 1 | -1) => void;
+  onRemoveBlock: (index: number) => void;
+  onUpdateNewBlockType: (value: string) => void;
+  onUpdateDraggableBlocks: (value: LessonAuthoringBlock[]) => void;
+  onDragEnd: (event: DragEndEvent) => void;
+  editorSectionId?: string;
+}>();
+
+const tagsFieldProxy = computed({
+  get: () => props.tagsField.value,
+  set: (value: string) => {
+    props.tagsField.value = value;
+  },
+});
+
+const objectivesField = props.createArrayField('objectives');
+const competenciesField = props.createArrayField('competencies');
+const skillsField = props.createArrayField('skills');
+const outcomesField = props.createArrayField('outcomes');
+const prerequisitesField = props.createArrayField('prerequisites');
+
+const showRevertButton = computed(
+  () => Boolean(props.canRevert) && typeof props.onRevert === 'function'
+);
+
+const blocks = computed(() => props.blocks ?? []);
+
+function handleRevert() {
+  props.onRevert?.();
+}
+
+function handleNewBlockTypeChange(event: Event) {
+  const target = event.target as HTMLSelectElement | null;
+  const value = target?.value ?? '';
+  props.onUpdateNewBlockType(value);
+}
+
+function formatBlockTitle(block: LessonAuthoringBlock, index: number) {
+  if (typeof block !== 'object' || !block) return `Bloco ${index + 1}`;
+  const maybeTitle = (block as Record<string, unknown>).title;
+  if (typeof maybeTitle === 'string' && maybeTitle.length) {
+    return maybeTitle;
+  }
+  const unit = (block as Record<string, unknown>).unit as Record<string, unknown> | undefined;
+  if (unit && typeof unit.title === 'string' && unit.title.length) {
+    return unit.title;
+  }
+  return `Bloco ${index + 1}`;
+}
+</script>
+
+<style scoped>
+.lesson-authoring-sidebar {
+  width: 100%;
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  border-radius: 9999px;
+  color: var(--md-sys-color-on-surface-variant);
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.grabbable {
+  cursor: grab;
+}
+
+.grabbable:active {
+  cursor: grabbing;
+}
+
+.icon-button:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.icon-button:not(:disabled):hover {
+  background-color: color-mix(in srgb, var(--md-sys-color-on-surface-variant) 12%, transparent);
+}
+
+.authoring-block-card {
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.authoring-block-card.is-selected {
+  border-color: var(--md-sys-color-primary);
+  background-color: color-mix(
+    in srgb,
+    var(--md-sys-color-primary) 12%,
+    var(--md-sys-color-surface-container-high)
+  );
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--md-sys-color-primary) 18%, transparent);
+}
+</style>

--- a/src/components/lesson/LessonBlockEditorPanel.vue
+++ b/src/components/lesson/LessonBlockEditorPanel.vue
@@ -1,0 +1,77 @@
+<template>
+  <section
+    v-if="selectedBlock"
+    ref="panelEl"
+    :id="editorSectionId"
+    class="lesson-block-editor card md3-surface-section md-stack md-stack-3"
+  >
+    <h3 class="md-typescale-title-medium font-semibold text-on-surface">
+      Editor do bloco selecionado
+    </h3>
+    <component
+      v-if="blockEditorComponent"
+      :is="blockEditorComponent"
+      :block="selectedBlock"
+      @update:block="handleUpdateBlock"
+    />
+    <p v-else class="text-body-medium text-on-surface-variant">
+      Nenhum editor disponível para o bloco selecionado.
+    </p>
+  </section>
+  <section v-else class="lesson-block-editor lesson-block-editor--empty card md3-surface-section">
+    <p class="text-body-medium text-on-surface-variant">
+      Selecione um bloco na barra lateral para editar os detalhes.
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { nextTick, ref, watch, type Component } from 'vue';
+import type { LessonAuthoringBlock } from '@/composables/useAuthoringBlockKeys';
+import type { LessonBlock } from '@/components/lesson/blockRegistry';
+
+const props = defineProps<{
+  selectedBlock: LessonAuthoringBlock | null;
+  blockEditorComponent: Component | null;
+  editorSectionId?: string;
+  onUpdateBlock: (block: LessonBlock) => void;
+}>();
+
+const panelEl = ref<HTMLElement | null>(null);
+
+watch(
+  () => props.selectedBlock?.__uiKey,
+  () => {
+    nextTick(() => {
+      const container = panelEl.value;
+      if (!container) return;
+      if (typeof container.scrollIntoView === 'function') {
+        container.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+      const focusTarget =
+        container.querySelector<HTMLElement>('[autofocus]') ??
+        container.querySelector<HTMLElement>(
+          'input, textarea, select, [contenteditable="true"], [tabindex]:not([tabindex="-1"])'
+        );
+      focusTarget?.focus();
+    });
+  }
+);
+
+function handleUpdateBlock(block: LessonBlock) {
+  props.onUpdateBlock(block);
+}
+</script>
+
+<style scoped>
+.lesson-block-editor {
+  width: 100%;
+}
+
+.lesson-block-editor--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 12rem;
+}
+</style>

--- a/src/components/teacher/TeacherAuthoringWorkspace.vue
+++ b/src/components/teacher/TeacherAuthoringWorkspace.vue
@@ -6,59 +6,71 @@
           <h2 class="teacher-authoring-workspace__title">Área de autoria</h2>
         </slot>
       </div>
-      <div
-        v-if="showViewSelector"
-        class="teacher-authoring-workspace__tabs"
-        role="tablist"
-        aria-label="Alternar entre editor e prévia"
-      >
-        <button
-          type="button"
-          class="teacher-authoring-workspace__tab"
-          :class="{ 'teacher-authoring-workspace__tab--active': currentView === 'editor' }"
-          :aria-pressed="currentView === 'editor'"
-          data-testid="teacher-workspace-tab-editor"
-          @click="setView('editor')"
-        >
-          <span class="teacher-authoring-workspace__tab-label">Editor</span>
-        </button>
-        <button
-          type="button"
-          class="teacher-authoring-workspace__tab"
-          :class="{ 'teacher-authoring-workspace__tab--active': currentView === 'preview' }"
-          :aria-pressed="currentView === 'preview'"
-          data-testid="teacher-workspace-tab-preview"
-          @click="setView('preview')"
-        >
-          <span class="teacher-authoring-workspace__tab-label">Prévia</span>
-        </button>
-      </div>
     </header>
 
-    <div class="teacher-authoring-workspace__body">
-      <div
-        v-if="currentView === 'editor' && editorEnabled"
-        key="editor"
-        class="teacher-authoring-workspace__pane teacher-authoring-workspace__pane--editor"
-      >
-        <slot name="editor" />
-      </div>
-      <div
-        v-else-if="currentView === 'preview' && previewEnabled"
-        key="preview"
-        class="teacher-authoring-workspace__pane teacher-authoring-workspace__pane--preview"
-      >
-        <slot name="preview" />
-      </div>
-      <div v-else class="teacher-authoring-workspace__empty" role="status">
-        <slot name="empty">Nenhum conteúdo disponível para esta visão.</slot>
+    <div
+      class="teacher-authoring-workspace__layout"
+      :class="{ 'teacher-authoring-workspace__layout--with-sidebar': hasSidebar }"
+    >
+      <aside v-if="hasSidebar" class="teacher-authoring-workspace__sidebar">
+        <slot name="sidebar" />
+      </aside>
+
+      <div class="teacher-authoring-workspace__canvas">
+        <div
+          v-if="showViewSelector"
+          class="teacher-authoring-workspace__tabs"
+          role="tablist"
+          aria-label="Alternar entre editor e prévia"
+        >
+          <button
+            type="button"
+            class="teacher-authoring-workspace__tab"
+            :class="{ 'teacher-authoring-workspace__tab--active': currentView === 'editor' }"
+            :aria-pressed="currentView === 'editor'"
+            data-testid="teacher-workspace-tab-editor"
+            @click="setView('editor')"
+          >
+            <span class="teacher-authoring-workspace__tab-label">Editor</span>
+          </button>
+          <button
+            type="button"
+            class="teacher-authoring-workspace__tab"
+            :class="{ 'teacher-authoring-workspace__tab--active': currentView === 'preview' }"
+            :aria-pressed="currentView === 'preview'"
+            data-testid="teacher-workspace-tab-preview"
+            @click="setView('preview')"
+          >
+            <span class="teacher-authoring-workspace__tab-label">Prévia</span>
+          </button>
+        </div>
+
+        <div class="teacher-authoring-workspace__body">
+          <div
+            v-if="currentView === 'editor' && editorEnabled"
+            key="editor"
+            class="teacher-authoring-workspace__pane teacher-authoring-workspace__pane--editor"
+          >
+            <slot name="editor" />
+          </div>
+          <div
+            v-else-if="currentView === 'preview' && previewEnabled"
+            key="preview"
+            class="teacher-authoring-workspace__pane teacher-authoring-workspace__pane--preview"
+          >
+            <slot name="preview" />
+          </div>
+          <div v-else class="teacher-authoring-workspace__empty" role="status">
+            <slot name="empty">Nenhum conteúdo disponível para esta visão.</slot>
+          </div>
+        </div>
       </div>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, ref, watch, useSlots } from 'vue';
 
 type WorkspaceView = 'editor' | 'preview';
 
@@ -90,6 +102,8 @@ const editorEnabled = computed(() => props.editorEnabled);
 const previewEnabled = computed(() => props.previewEnabled);
 
 const showViewSelector = computed(() => editorEnabled.value && previewEnabled.value);
+const slots = useSlots();
+const hasSidebar = computed(() => Boolean(slots.sidebar));
 
 watch(
   () => props.view,
@@ -158,6 +172,33 @@ function setView(view: WorkspaceView) {
   color: var(--md-sys-color-on-surface, #1d1b20);
 }
 
+.teacher-authoring-workspace__layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.teacher-authoring-workspace__layout--with-sidebar {
+  gap: 2rem;
+}
+
+.teacher-authoring-workspace__sidebar {
+  position: relative;
+}
+
+.teacher-authoring-workspace__canvas {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-width: 0;
+}
+
+.teacher-authoring-workspace__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
 .teacher-authoring-workspace__tabs {
   display: inline-flex;
   background: var(--md-sys-color-surface-container-high, #f3edf7);
@@ -198,12 +239,6 @@ function setView(view: WorkspaceView) {
   line-height: 1.25rem;
 }
 
-.teacher-authoring-workspace__body {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
 .teacher-authoring-workspace__pane {
   width: 100%;
 }
@@ -214,5 +249,28 @@ function setView(view: WorkspaceView) {
   color: var(--md-sys-color-on-surface-variant, #49454f);
   background: var(--md-sys-color-surface-container, #ece6f0);
   border-radius: 1rem;
+}
+
+@media (min-width: 1024px) {
+  .teacher-authoring-workspace__layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .teacher-authoring-workspace__layout--with-sidebar {
+    grid-template-columns: 20rem minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .teacher-authoring-workspace__sidebar {
+    position: sticky;
+    top: 5.5rem;
+    max-height: calc(100vh - 6rem);
+    overflow: auto;
+  }
+
+  .teacher-authoring-workspace__canvas {
+    min-height: 0;
+  }
 }
 </style>

--- a/src/pages/ExerciseView.vue
+++ b/src/pages/ExerciseView.vue
@@ -22,19 +22,42 @@
       :editor-enabled="showAuthoringPanel"
       :default-view="showAuthoringPanel ? 'editor' : 'preview'"
     >
-      <template #editor>
-        <ExerciseAuthoringPanel
+      <template #sidebar>
+        <ExerciseAuthoringSidebar
           v-if="showAuthoringPanel"
-          class="exercise-view__authoring-panel"
           :exercise-model="exerciseEditor.lessonModel"
           :tags-field="exerciseEditor.tagsField"
-          :saving="exerciseContentSync.saving"
-          :has-pending-changes="exerciseContentSync.hasPendingChanges"
-          :save-error="exerciseContentSync.saveError"
+          :blocks="exerciseBlocks"
+          :draggable-blocks="displayedBlocks"
+          :selected-block-index="selectedBlockIndex"
+          :supported-block-types="supportedBlockTypes"
+          :new-block-type="newBlockType"
+          :status-label="statusLabel"
+          :status-tone="statusTone"
+          :status-icon="statusIcon"
+          :status-icon-class="statusIconClass"
           :error-message="exerciseAuthoringError"
           :success-message="exerciseAuthoringSuccess"
           :can-revert="exerciseCanRevert"
           :on-revert="exerciseContentSync.revertChanges"
+          :on-insert-block="insertBlock"
+          :on-select-block="selectBlock"
+          :on-move-block="moveBlock"
+          :on-remove-block="removeBlock"
+          :on-update-new-block-type="updateNewBlockType"
+          :on-update-draggable-blocks="updateDraggableBlocks"
+          :on-drag-end="handleBlockDragEnd"
+          :editor-section-id="editorSectionId"
+        />
+      </template>
+
+      <template #editor>
+        <ExerciseBlockEditorPanel
+          v-if="showAuthoringPanel"
+          :selected-block="selectedBlock"
+          :block-editor-component="blockEditorComponent"
+          :editor-section-id="editorSectionId"
+          :on-update-block="replaceSelectedBlock"
         />
       </template>
 
@@ -72,21 +95,39 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, ref, watch, useId } from 'vue';
 import { RouterLink } from 'vue-router';
-import { ArrowLeft, ChevronRight } from 'lucide-vue-next';
+import {
+  AlertCircle,
+  ArrowLeft,
+  CheckCircle2,
+  ChevronRight,
+  CircleDashed,
+  Clock3,
+  LoaderCircle,
+} from 'lucide-vue-next';
 import Md3Button from '@/components/Md3Button.vue';
-import ExerciseAuthoringPanel from '@/components/exercise/ExerciseAuthoringPanel.vue';
+import ExerciseAuthoringSidebar from '@/components/exercise/ExerciseAuthoringSidebar.vue';
+import ExerciseBlockEditorPanel from '@/components/exercise/ExerciseBlockEditorPanel.vue';
 import TeacherAuthoringWorkspace from '@/components/teacher/TeacherAuthoringWorkspace.vue';
-import { useLessonEditorModel, type LessonEditorModel } from '@/composables/useLessonEditorModel';
+import {
+  useLessonEditorModel,
+  resolveLessonBlockEditor,
+  type LessonEditorModel,
+} from '@/composables/useLessonEditorModel';
 import { useTeacherMode } from '@/composables/useTeacherMode';
 import { useExerciseViewController } from './ExerciseView.logic';
 import { useTeacherContentEditor } from '@/services/useTeacherContentEditor';
-import type { LessonBlock } from '@/components/lesson/blockRegistry';
+import { supportedBlockTypes, type LessonBlock } from '@/components/lesson/blockRegistry';
 import {
   applyAuthoringBlockKeys,
   stripAuthoringBlockKeys,
+  ensureAuthoringBlockKey,
+  inheritAuthoringBlockKey,
+  type LessonAuthoringBlock,
 } from '@/composables/useAuthoringBlockKeys';
+import { defaultBlockTemplates } from '@/components/authoring/defaultBlockTemplates';
+import { useAuthoringSaveTracker } from '@/composables/useAuthoringSaveTracker';
 
 function cloneDeep<T>(value: T): T {
   try {
@@ -131,6 +172,173 @@ const controller = useExerciseViewController();
 const exerciseEditor = useLessonEditorModel();
 const { teacherMode } = useTeacherMode();
 
+const exerciseBlocks = computed<LessonAuthoringBlock[]>(
+  () => (exerciseEditor.lessonModel.value?.blocks ?? []) as LessonAuthoringBlock[]
+);
+const selectedBlockIndex = ref(0);
+const editorSectionId = `exercise-authoring-selected-block-${useId()}`;
+const newBlockType = ref<string>(supportedBlockTypes[0] ?? 'contentBlock');
+const pendingReorder = ref<LessonAuthoringBlock[] | null>(null);
+const displayedBlocks = computed<LessonAuthoringBlock[]>(
+  () => pendingReorder.value ?? exerciseBlocks.value
+);
+
+const selectedBlock = computed<LessonAuthoringBlock | null>(
+  () => exerciseBlocks.value[selectedBlockIndex.value] ?? null
+);
+
+const blockEditorComponent = computed(() =>
+  resolveLessonBlockEditor(selectedBlock.value as LessonBlock | null)
+);
+
+type DragEndEvent = { oldIndex?: number | null; newIndex?: number | null };
+
+function updateNewBlockType(value: string) {
+  if (!value) {
+    return;
+  }
+  newBlockType.value = value;
+}
+
+function updateDraggableBlocks(value: LessonAuthoringBlock[]) {
+  pendingReorder.value = [...value];
+}
+
+function createBlockPayload(type: string): LessonAuthoringBlock {
+  const template = defaultBlockTemplates[type];
+  const baseBlock = template ? structuredClone(template) : ({ type } as LessonBlock);
+  return ensureAuthoringBlockKey(baseBlock);
+}
+
+function updateBlocks(next: LessonAuthoringBlock[]) {
+  if (!exerciseEditor.lessonModel.value) return;
+  exerciseEditor.lessonModel.value.blocks = next;
+}
+
+function insertBlock(index?: number) {
+  if (!exerciseEditor.lessonModel.value) return;
+  const targetIndex = typeof index === 'number' ? index + 1 : exerciseBlocks.value.length;
+  const nextBlocks = [...exerciseBlocks.value];
+  nextBlocks.splice(targetIndex, 0, createBlockPayload(newBlockType.value));
+  updateBlocks(nextBlocks);
+  selectBlock(targetIndex);
+}
+
+function moveBlock(index: number, direction: 1 | -1) {
+  const nextIndex = index + direction;
+  if (nextIndex < 0 || nextIndex >= exerciseBlocks.value.length) return;
+  const nextBlocks = [...exerciseBlocks.value];
+  const [item] = nextBlocks.splice(index, 1);
+  if (!item) return;
+  nextBlocks.splice(nextIndex, 0, item);
+  pendingReorder.value = nextBlocks;
+  commitPendingBlockOrder({ oldIndex: index, newIndex: nextIndex });
+}
+
+function commitPendingBlockOrder(event?: DragEndEvent) {
+  if (!exerciseEditor.lessonModel.value) return;
+  const current = (exerciseEditor.lessonModel.value.blocks ?? []) as LessonAuthoringBlock[];
+  let proposed = pendingReorder.value;
+
+  if (
+    !proposed &&
+    event &&
+    typeof event.oldIndex === 'number' &&
+    typeof event.newIndex === 'number'
+  ) {
+    const copy = [...current];
+    const [moved] = copy.splice(event.oldIndex, 1);
+    if (moved) {
+      copy.splice(event.newIndex, 0, moved);
+      proposed = copy;
+    }
+  }
+
+  if (!proposed) {
+    return;
+  }
+
+  pendingReorder.value = null;
+
+  const currentByKey = new Map(current.map((block) => [block.__uiKey, block]));
+  const normalized = proposed.map((block, index) => {
+    const key = typeof block?.__uiKey === 'string' ? block.__uiKey : undefined;
+    const source = (key ? currentByKey.get(key) : undefined) ?? current[index];
+    return inheritAuthoringBlockKey(source, block);
+  }) as LessonAuthoringBlock[];
+
+  updateBlocks(normalized);
+
+  if (!event) {
+    return;
+  }
+
+  const movedKey =
+    typeof event.oldIndex === 'number' ? current[event.oldIndex]?.__uiKey : undefined;
+  let targetIndex =
+    typeof movedKey === 'string' ? normalized.findIndex((block) => block.__uiKey === movedKey) : -1;
+
+  if (targetIndex < 0) {
+    if (typeof event.newIndex === 'number') {
+      targetIndex = event.newIndex;
+    } else if (typeof event.oldIndex === 'number') {
+      targetIndex = event.oldIndex;
+    }
+  }
+
+  if (targetIndex >= 0) {
+    selectBlock(targetIndex);
+  }
+}
+
+function handleBlockDragEnd(event: DragEndEvent) {
+  commitPendingBlockOrder(event);
+}
+
+function replaceSelectedBlock(nextBlock: LessonBlock) {
+  if (!exerciseEditor.lessonModel.value) return;
+  if (!Array.isArray(exerciseEditor.lessonModel.value.blocks)) return;
+  const index = selectedBlockIndex.value;
+  if (index < 0 || index >= exerciseEditor.lessonModel.value.blocks.length) return;
+
+  const nextBlocks = [...(exerciseEditor.lessonModel.value.blocks as LessonAuthoringBlock[])];
+  const current = nextBlocks[index];
+  nextBlocks.splice(index, 1, inheritAuthoringBlockKey(current, nextBlock));
+  updateBlocks(nextBlocks);
+}
+
+function removeBlock(index: number) {
+  const previousSelection = selectedBlockIndex.value;
+  const nextBlocks = exerciseBlocks.value.filter((_, blockIndex) => blockIndex !== index);
+  updateBlocks(nextBlocks);
+  if (!nextBlocks.length) {
+    selectedBlockIndex.value = 0;
+    return;
+  }
+
+  if (previousSelection > index) {
+    selectBlock(previousSelection - 1);
+    return;
+  }
+
+  if (previousSelection === index) {
+    selectBlock(Math.min(index, nextBlocks.length - 1));
+    return;
+  }
+
+  if (previousSelection >= nextBlocks.length) {
+    selectBlock(nextBlocks.length - 1);
+  }
+}
+
+function selectBlock(index: number) {
+  if (index < 0) {
+    selectedBlockIndex.value = 0;
+    return;
+  }
+  selectedBlockIndex.value = Math.min(index, Math.max(exerciseBlocks.value.length - 1, 0));
+}
+
 const exerciseContentPath = computed(() => {
   const file = controller.exerciseFile.value;
   if (!file) {
@@ -154,6 +362,31 @@ const exerciseAuthoringError = computed(
 const exerciseAuthoringSuccess = computed(() => exerciseContentSync.successMessage.value);
 const exerciseCanRevert = computed(() => exerciseContentSync.hasPendingChanges.value);
 
+const { status, statusLabel, statusTone } = useAuthoringSaveTracker(exerciseEditor.lessonModel, {
+  saving: exerciseContentSync.saving,
+  hasPendingChanges: exerciseContentSync.hasPendingChanges,
+  saveError: exerciseContentSync.saveError,
+});
+
+const statusIcon = computed(() => {
+  switch (status.value) {
+    case 'saving':
+      return LoaderCircle;
+    case 'error':
+      return AlertCircle;
+    case 'pending':
+      return Clock3;
+    case 'saved':
+      return CheckCircle2;
+    default:
+      return CircleDashed;
+  }
+});
+
+const statusIconClass = computed(() =>
+  status.value === 'saving' ? 'md-icon md-icon--sm animate-spin' : 'md-icon md-icon--sm'
+);
+
 const authoringExercise = computed(() => exerciseEditor.lessonModel.value);
 const showAuthoringPanel = computed(
   () =>
@@ -162,6 +395,16 @@ const showAuthoringPanel = computed(
     exerciseContentSync.serviceAvailable &&
     Boolean(authoringExercise.value)
 );
+
+watch(exerciseBlocks, (current) => {
+  if (!current.length) {
+    selectedBlockIndex.value = 0;
+    return;
+  }
+  if (selectedBlockIndex.value > current.length - 1) {
+    selectBlock(current.length - 1);
+  }
+});
 
 watch(
   showAuthoringPanel,


### PR DESCRIPTION
## Summary
- add a sidebar slot to `TeacherAuthoringWorkspace` and apply responsive grid layout for editor/preview
- extract lesson and exercise authoring panels into dedicated sidebar and block editor components used in their views
- update lesson and exercise view component tests to cover the split workspace and view switching

## Testing
- npx vitest run src/pages/__tests__/LessonView.component.test.ts src/pages/__tests__/ExerciseView.component.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68e263ffd40c832cbc076bd7ba04ed76