### PR TITLE
feat: support writable lesson metadata editing

### DIFF
--- a/src/components/exercise/ExerciseAuthoringPanel.vue
+++ b/src/components/exercise/ExerciseAuthoringPanel.vue
@@ -183,7 +183,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, useId, watch, type ComputedRef, type Ref } from 'vue';
+import { computed, nextTick, ref, useId, watch, type Ref, type WritableComputedRef } from 'vue';
 import {
   AlertCircle,
   ArrowDown,
@@ -215,7 +215,7 @@ import { defaultBlockTemplates } from '@/components/authoring/defaultBlockTempla
 
 const props = defineProps<{
   exerciseModel: Ref<LessonEditorModel | null>;
-  tagsField: ComputedRef<string>;
+  tagsField: WritableComputedRef<string>;
   saving: Ref<boolean>;
   hasPendingChanges: Ref<boolean>;
   saveError: Ref<string | null>;

--- a/src/components/lesson/LessonAuthoringPanel.vue
+++ b/src/components/lesson/LessonAuthoringPanel.vue
@@ -225,7 +225,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, useId, watch, type ComputedRef, type Ref } from 'vue';
+import { computed, nextTick, ref, useId, watch, type Ref, type WritableComputedRef } from 'vue';
 import {
   AlertCircle,
   ArrowDown,
@@ -258,8 +258,8 @@ import { defaultBlockTemplates } from '@/components/authoring/defaultBlockTempla
 
 const props = defineProps<{
   lessonModel: Ref<LessonEditorModel | null>;
-  tagsField: ComputedRef<string>;
-  createArrayField: (field: LessonArrayField) => ComputedRef<string>;
+  tagsField: WritableComputedRef<string>;
+  createArrayField: (field: LessonArrayField) => WritableComputedRef<string>;
   saving: Ref<boolean>;
   hasPendingChanges: Ref<boolean>;
   saveError: Ref<string | null>;

--- a/src/components/lesson/__tests__/LessonAuthoringPanel.metadata.test.ts
+++ b/src/components/lesson/__tests__/LessonAuthoringPanel.metadata.test.ts
@@ -1,0 +1,98 @@
+import { mount } from '@vue/test-utils';
+import { computed, ref } from 'vue';
+import { describe, expect, it } from 'vitest';
+import type { LessonEditorModel } from '@/composables/useLessonEditorModel';
+
+const iconStubs = {
+  AlertCircle: true,
+  ArrowDown: true,
+  ArrowUp: true,
+  CheckCircle2: true,
+  CircleDashed: true,
+  Clock3: true,
+  GripVertical: true,
+  LoaderCircle: true,
+  PenSquare: true,
+  Plus: true,
+  Trash2: true,
+};
+
+function createArrayField() {
+  return computed({
+    get: () => '',
+    set: () => {
+      /* no-op for tests */
+    },
+  });
+}
+
+function findField(wrapper: ReturnType<typeof mount>, label: string, selector: string) {
+  const targetLabel = wrapper.findAll('label').find((node) => node.text().includes(label));
+
+  if (!targetLabel) {
+    throw new Error(`Could not find label containing: ${label}`);
+  }
+
+  const field = targetLabel.find(selector);
+  if (!field.exists()) {
+    throw new Error(`Could not find ${selector} inside label ${label}`);
+  }
+
+  return field;
+}
+
+describe('LessonAuthoringPanel - edição de metadados', () => {
+  it('sincroniza título, resumo e tags com o modelo reativo', async () => {
+    const lessonModel = ref<LessonEditorModel>({
+      title: 'Introdução',
+      summary: 'Resumo original',
+      tags: ['frontend'],
+      blocks: [],
+    });
+
+    const tagsField = computed({
+      get: () => (lessonModel.value?.tags ?? []).join('\n'),
+      set: (value: string) => {
+        if (!lessonModel.value) return;
+        lessonModel.value.tags = value
+          .split('\n')
+          .map((entry) => entry.trim())
+          .filter(Boolean);
+      },
+    });
+
+    const { default: LessonAuthoringPanel } = await import('../LessonAuthoringPanel.vue');
+
+    const wrapper = mount(LessonAuthoringPanel, {
+      props: {
+        lessonModel,
+        tagsField,
+        createArrayField,
+        saving: ref(false),
+        hasPendingChanges: ref(false),
+        saveError: ref<string | null>(null),
+      },
+      global: {
+        stubs: {
+          Md3Button: { template: '<button><slot /></button>' },
+          MetadataListEditor: { template: '<div />' },
+          AuthoringDraggableList: { template: '<div><slot /></div>' },
+          ...iconStubs,
+        },
+      },
+    });
+
+    const titleInput = findField(wrapper, 'Título', 'input');
+    await titleInput.setValue('Nova aula');
+
+    const summaryField = findField(wrapper, 'Resumo', 'textarea');
+    await summaryField.setValue('Resumo atualizado');
+
+    const tagsFieldElement = findField(wrapper, 'Tags', 'textarea');
+    await tagsFieldElement.setValue('tag-1\ntag-2');
+
+    expect(lessonModel.value?.title).toBe('Nova aula');
+    expect(lessonModel.value?.summary).toBe('Resumo atualizado');
+    expect(lessonModel.value?.tags).toEqual(['tag-1', 'tag-2']);
+  });
+});

--- a/src/composables/useLessonEditorModel.ts
+++ b/src/composables/useLessonEditorModel.ts
@@ -3,8 +3,8 @@ import {
   defineAsyncComponent,
   ref,
   type Component,
-  type ComputedRef,
   type Ref,
+  type WritableComputedRef,
 } from 'vue';
 import type { LessonBlock } from '@/components/lesson/blockRegistry';
 
@@ -68,8 +68,8 @@ function cloneModel(model: LessonEditorModel): LessonEditorModel {
 export interface LessonEditorContext {
   lessonModel: Ref<LessonEditorModel | null>;
   setLessonModel: (value: LessonEditorModel | null) => void;
-  tagsField: ComputedRef<string>;
-  useArrayField: (field: LessonArrayField) => ComputedRef<string>;
+  tagsField: WritableComputedRef<string>;
+  useArrayField: (field: LessonArrayField) => WritableComputedRef<string>;
 }
 
 export function useLessonEditorModel(


### PR DESCRIPTION
## Summary
- expose tags and list helpers from the lesson editor as writable computed refs
- update lesson/exercise authoring panels and lesson view to use the writable helpers and sanitize renderer data
- add component coverage for editing lesson and exercise metadata fields

## Testing
- npm run test -- --run LessonAuthoringPanel.metadata
- npm run test -- --run ExerciseAuthoringPanel.test
- npm run test -- --run LessonView.component

------
https://chatgpt.com/codex/tasks/task_e_68e26cae1e18832cb08867a61ce5e054