### PR TITLE
chore: tighten authoring panel test mocks

### DIFF
--- a/src/components/exercise/__tests__/ExerciseAuthoringPanel.test.ts
+++ b/src/components/exercise/__tests__/ExerciseAuthoringPanel.test.ts
@@ -53,7 +53,7 @@ const AuthoringDraggableListStub = defineComponent({
 });
 
 vi.mock('@/components/authoring/blocks/UnsupportedBlockEditor.vue', async (importOriginal) => {
-  const actual = await importOriginal();
+  const actual = await importOriginal<Record<string, unknown>>();
 
   const Stub = defineComponent({
     name: 'UnsupportedBlockEditorStub',
@@ -95,7 +95,7 @@ vi.mock('@/composables/useLessonEditorModel', async (importOriginal) => {
   return {
     __esModule: true,
     ...actual,
-    resolveLessonBlockEditor(block) {
+    resolveLessonBlockEditor(block: LessonBlock | null) {
       if (
         block &&
         typeof block === 'object' &&


### PR DESCRIPTION
## Summary
- cast the UnsupportedBlockEditor mocks to a generic record before spreading the real module exports
- type the resolveLessonBlockEditor mock parameter as LessonBlock | null and provide a deterministic AuthoringDraggableList stub for the focus tests

## Testing
- npm run test -- --run LessonAuthoringPanel
- npm run test -- --run ExerciseAuthoringPanel

------
https://chatgpt.com/codex/tasks/task_e_68e2712361f8832cbeddc7426f01d575