### PR TITLE
Align controller interfaces and update component test doubles

### DIFF
--- a/src/pages/LessonView.logic.ts
+++ b/src/pages/LessonView.logic.ts
@@ -25,7 +25,7 @@ type LessonModuleLoaderMap = Record<string, () => Promise<unknown>>;
 
 type HighlightHandler = (lesson: LessonContent) => Promise<void> | void;
 
-interface LessonViewControllerOptions {
+export interface LessonViewControllerOptions {
   lessonIndexModules?: ManifestLoaderMap;
   lessonContentModules?: LessonModuleLoaderMap;
   highlight?: HighlightHandler;
@@ -44,6 +44,7 @@ export interface LessonViewController {
   lessonOutcomes: ReturnType<typeof ref<string[]>>;
   lessonPrerequisites: ReturnType<typeof ref<string[]>>;
   lessonData: ReturnType<typeof shallowRef<LessonContent | null>>;
+  lessonContentFile: ReturnType<typeof ref<string>>;
   loadLesson: () => Promise<void>;
   route: RouteLocationNormalizedLoaded;
 }

--- a/src/pages/__tests__/CourseHome.component.test.ts
+++ b/src/pages/__tests__/CourseHome.component.test.ts
@@ -10,9 +10,9 @@ const createController = () => {
   const contentFilter = ref<'all' | 'lesson' | 'exercise'>('all');
   const viewMode = ref<'grid' | 'list'>('grid');
   const isLoading = ref(false);
-  const displayItems = ref<CourseHomeItem[]>([]);
+  const displayItemsState = ref<CourseHomeItem[]>([]);
 
-  return {
+  const controller = {
     lessons,
     exercises,
     contentFilter,
@@ -20,17 +20,24 @@ const createController = () => {
     isLoading,
     rawSearchQuery: computed(() => ''),
     searchTerm: computed(() => ''),
-    combinedItems: computed(() => displayItems.value),
-    displayItems,
+    combinedItems: computed(() => displayItemsState.value),
+    displayItems: computed(() => displayItemsState.value),
     refreshCourseContent: vi.fn(),
     resetFilters: vi.fn(),
     updateSection: vi.fn(),
     courseId: computed(() => 'demo'),
     route: { params: {}, query: {} } as any,
   } satisfies CourseHomeController;
+
+  const setDisplayItems = (items: CourseHomeItem[]) => {
+    displayItemsState.value = items;
+  };
+
+  return { controller, setDisplayItems };
 };
 
 let controllerMock: CourseHomeController;
+let setDisplayItems: (items: CourseHomeItem[]) => void;
 
 vi.mock('../CourseHome.logic', () => ({
   useCourseHomeController: () => controllerMock,
@@ -45,7 +52,9 @@ const ButtonStub = {
 
 describe('CourseHome component', () => {
   beforeEach(() => {
-    controllerMock = createController();
+    const controllerSetup = createController();
+    controllerMock = controllerSetup.controller;
+    setDisplayItems = controllerSetup.setDisplayItems;
   });
 
   it('exibe estado de carregamento', () => {
@@ -67,7 +76,7 @@ describe('CourseHome component', () => {
 
   it('renderiza itens disponíveis com classes corretas', () => {
     controllerMock.isLoading.value = false;
-    controllerMock.displayItems.value = [
+    setDisplayItems([
       {
         key: 'lesson-01',
         type: 'lesson',
@@ -84,7 +93,7 @@ describe('CourseHome component', () => {
         wrapper: 'div',
         attrs: {},
       },
-    ];
+    ]);
 
     const wrapper = mount(CourseHome, {
       global: {
@@ -106,7 +115,7 @@ describe('CourseHome component', () => {
 
   it('aciona reset ao clicar em "Limpar filtros"', async () => {
     controllerMock.isLoading.value = false;
-    controllerMock.displayItems.value = [];
+    setDisplayItems([]);
     controllerMock.resetFilters.mockClear();
 
     const wrapper = mount(CourseHome, {

--- a/src/pages/__tests__/ExerciseView.component.test.ts
+++ b/src/pages/__tests__/ExerciseView.component.test.ts
@@ -34,6 +34,7 @@ const createController = () => {
   const exerciseTitle = ref('Título');
   const exerciseSummary = ref('Resumo');
   const exerciseComponent = shallowRef<any | null>({ render: () => null });
+  const exerciseFile = ref('exercise.vue');
 
   return {
     courseId: computed(() => 'demo'),
@@ -41,6 +42,7 @@ const createController = () => {
     exerciseTitle,
     exerciseSummary,
     exerciseComponent,
+    exerciseFile,
     loadExercise: vi.fn(),
     route: { params: { courseId: 'demo', exerciseId: 'exercise-01' }, query: {} } as any,
   } satisfies Controller;

--- a/src/pages/__tests__/LessonView.component.test.ts
+++ b/src/pages/__tests__/LessonView.component.test.ts
@@ -41,6 +41,7 @@ const createController = () => {
   const lessonOutcomes = ref(['outcome']);
   const lessonPrerequisites = ref(['pre']);
   const lessonData = shallowRef({ content: [] } as any);
+  const lessonContentFile = ref('lesson.json');
 
   return {
     courseId: computed(() => 'demo'),
@@ -55,6 +56,7 @@ const createController = () => {
     lessonOutcomes,
     lessonPrerequisites,
     lessonData,
+    lessonContentFile,
     loadLesson: vi.fn(),
     route: { params: { courseId: 'demo', lessonId: 'lesson-01' }, query: {} } as any,
   } satisfies Controller;


### PR DESCRIPTION
## Summary
- expose the lesson view controller options and add the missing lessonContentFile contract
- refresh CourseHome, LessonView, and ExerciseView component tests to satisfy the updated controller interfaces

## Testing
- npm run test -- CourseHome
- npm run test -- ExerciseView

------
https://chatgpt.com/codex/tasks/task_e_68e2732e7bb0832c94ec0d0876cd8c62