### PR TITLE
Improve authoring save tracking transitions

### DIFF
--- a/src/components/exercise/ExerciseAuthoringPanel.vue
+++ b/src/components/exercise/ExerciseAuthoringPanel.vue
@@ -11,7 +11,12 @@
           </p>
         </div>
         <div class="flex items-center gap-2">
-          <div class="flex items-center gap-2 text-sm" :class="statusTone">
+          <div
+            class="flex items-center gap-2 text-sm"
+            :class="statusTone"
+            data-test="authoring-status"
+            :data-status="status"
+          >
             <component :is="statusIcon" :class="statusIconClass" aria-hidden="true" />
             <span>{{ statusLabel }}</span>
           </div>

--- a/src/components/lesson/LessonAuthoringPanel.vue
+++ b/src/components/lesson/LessonAuthoringPanel.vue
@@ -10,7 +10,12 @@
           </p>
         </div>
         <div class="flex items-center gap-2">
-          <div class="flex items-center gap-2 text-sm" :class="statusTone">
+          <div
+            class="flex items-center gap-2 text-sm"
+            :class="statusTone"
+            data-test="authoring-status"
+            :data-status="status"
+          >
             <component :is="statusIcon" :class="statusIconClass" aria-hidden="true" />
             <span>{{ statusLabel }}</span>
           </div>


### PR DESCRIPTION
## Summary
- refactor `useAuthoringSaveTracker` to track previous states with an immediate watcher and reset timestamps consistently
- expose `hasPendingChanges` as a writable ref from `useTeacherContentEditor` and surface status metadata on authoring panels
- expand panel and composable tests to cover idle → pending → saving → saved/error transitions

## Testing
- npx vitest run src/composables/__tests__/useAuthoringSaveTracker.test.ts src/components/exercise/__tests__/ExerciseAuthoringPanel.test.ts src/components/lesson/__tests__/LessonAuthoringPanel.metadata.test.ts src/services/__tests__/useTeacherContentEditor.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e274abbe5c832c861d27d973fa4661