### PR TITLE
Refine authoring field proxies

### DIFF
--- a/src/components/exercise/ExerciseAuthoringPanel.vue
+++ b/src/components/exercise/ExerciseAuthoringPanel.vue
@@ -188,7 +188,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, useId, watch, type Ref, type WritableComputedRef } from 'vue';
+import {
+  computed,
+  nextTick,
+  ref,
+  toRef,
+  toValue,
+  useId,
+  watch,
+  type Ref,
+  type WritableComputedRef,
+} from 'vue';
 import {
   AlertCircle,
   ArrowDown,
@@ -230,12 +240,17 @@ const props = defineProps<{
   onRevert?: () => void;
 }>();
 
-const tagsFieldProxy = computed({
-  get: () => props.tagsField.value,
-  set: (value: string) => {
-    props.tagsField.value = value;
-  },
-});
+function useWritableFieldProxy(field: WritableComputedRef<string>) {
+  const target = toRef(field, 'value');
+  return computed({
+    get: () => toValue(target),
+    set: (value: string) => {
+      target.value = value;
+    },
+  });
+}
+
+const tagsFieldProxy = useWritableFieldProxy(props.tagsField);
 
 const blocks = computed<LessonAuthoringBlock[]>(
   () => (props.exerciseModel.value?.blocks ?? []) as LessonAuthoringBlock[]

--- a/src/components/exercise/ExerciseAuthoringSidebar.vue
+++ b/src/components/exercise/ExerciseAuthoringSidebar.vue
@@ -168,7 +168,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, type Component, type Ref, type WritableComputedRef } from 'vue';
+import { computed, toRef, toValue, type Component, type Ref, type WritableComputedRef } from 'vue';
 import { ArrowDown, ArrowUp, GripVertical, PenSquare, Plus, Trash2 } from 'lucide-vue-next';
 import Md3Button from '@/components/Md3Button.vue';
 import AuthoringDraggableList from '@/components/authoring/AuthoringDraggableList.vue';
@@ -205,12 +205,17 @@ const props = defineProps<{
 
 const exerciseModel = props.exerciseModel;
 
-const tagsFieldProxy = computed({
-  get: () => props.tagsField.value,
-  set: (value: string) => {
-    props.tagsField.value = value;
-  },
-});
+function useWritableFieldProxy(field: WritableComputedRef<string>) {
+  const target = toRef(field, 'value');
+  return computed({
+    get: () => toValue(target),
+    set: (value: string) => {
+      target.value = value;
+    },
+  });
+}
+
+const tagsFieldProxy = useWritableFieldProxy(props.tagsField);
 
 const showRevertButton = computed(
   () => Boolean(props.canRevert) && typeof props.onRevert === 'function'

--- a/src/components/lesson/LessonAuthoringPanel.vue
+++ b/src/components/lesson/LessonAuthoringPanel.vue
@@ -104,11 +104,11 @@
           ></textarea>
         </label>
         <div class="grid gap-3 md:grid-cols-2">
-          <MetadataListEditor label="Objetivos específicos" v-model="objectivesField" />
-          <MetadataListEditor label="Competências" v-model="competenciesField" />
-          <MetadataListEditor label="Habilidades" v-model="skillsField" />
-          <MetadataListEditor label="Resultados esperados" v-model="outcomesField" />
-          <MetadataListEditor label="Pré-requisitos" v-model="prerequisitesField" />
+          <MetadataListEditor label="Objetivos específicos" v-model="objectivesFieldProxy" />
+          <MetadataListEditor label="Competências" v-model="competenciesFieldProxy" />
+          <MetadataListEditor label="Habilidades" v-model="skillsFieldProxy" />
+          <MetadataListEditor label="Resultados esperados" v-model="outcomesFieldProxy" />
+          <MetadataListEditor label="Pré-requisitos" v-model="prerequisitesFieldProxy" />
         </div>
       </section>
 
@@ -230,7 +230,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, useId, watch, type Ref, type WritableComputedRef } from 'vue';
+import {
+  computed,
+  nextTick,
+  ref,
+  toRef,
+  toValue,
+  useId,
+  watch,
+  type Ref,
+  type WritableComputedRef,
+} from 'vue';
 import {
   AlertCircle,
   ArrowDown,
@@ -274,18 +284,22 @@ const props = defineProps<{
   onRevert?: () => void;
 }>();
 
-const tagsFieldProxy = computed({
-  get: () => props.tagsField.value,
-  set: (value: string) => {
-    props.tagsField.value = value;
-  },
-});
+function useWritableFieldProxy(field: WritableComputedRef<string>) {
+  const target = toRef(field, 'value');
+  return computed({
+    get: () => toValue(target),
+    set: (value: string) => {
+      target.value = value;
+    },
+  });
+}
 
-const objectivesField = props.createArrayField('objectives');
-const competenciesField = props.createArrayField('competencies');
-const skillsField = props.createArrayField('skills');
-const outcomesField = props.createArrayField('outcomes');
-const prerequisitesField = props.createArrayField('prerequisites');
+const tagsFieldProxy = useWritableFieldProxy(props.tagsField);
+const objectivesFieldProxy = useWritableFieldProxy(props.createArrayField('objectives'));
+const competenciesFieldProxy = useWritableFieldProxy(props.createArrayField('competencies'));
+const skillsFieldProxy = useWritableFieldProxy(props.createArrayField('skills'));
+const outcomesFieldProxy = useWritableFieldProxy(props.createArrayField('outcomes'));
+const prerequisitesFieldProxy = useWritableFieldProxy(props.createArrayField('prerequisites'));
 
 const blocks = computed<LessonAuthoringBlock[]>(
   () => (props.lessonModel.value?.blocks ?? []) as LessonAuthoringBlock[]

--- a/src/components/lesson/LessonAuthoringSidebar.vue
+++ b/src/components/lesson/LessonAuthoringSidebar.vue
@@ -99,11 +99,11 @@
           ></textarea>
         </label>
         <div class="grid gap-3 md:grid-cols-2">
-          <MetadataListEditor label="Objetivos específicos" v-model="objectivesField" />
-          <MetadataListEditor label="Competências" v-model="competenciesField" />
-          <MetadataListEditor label="Habilidades" v-model="skillsField" />
-          <MetadataListEditor label="Resultados esperados" v-model="outcomesField" />
-          <MetadataListEditor label="Pré-requisitos" v-model="prerequisitesField" />
+          <MetadataListEditor label="Objetivos específicos" v-model="objectivesFieldProxy" />
+          <MetadataListEditor label="Competências" v-model="competenciesFieldProxy" />
+          <MetadataListEditor label="Habilidades" v-model="skillsFieldProxy" />
+          <MetadataListEditor label="Resultados esperados" v-model="outcomesFieldProxy" />
+          <MetadataListEditor label="Pré-requisitos" v-model="prerequisitesFieldProxy" />
         </div>
       </section>
 
@@ -211,7 +211,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, type Component, type Ref, type WritableComputedRef } from 'vue';
+import { computed, toRef, toValue, type Component, type Ref, type WritableComputedRef } from 'vue';
 import { ArrowDown, ArrowUp, GripVertical, PenSquare, Plus, Trash2 } from 'lucide-vue-next';
 import Md3Button from '@/components/Md3Button.vue';
 import AuthoringDraggableList from '@/components/authoring/AuthoringDraggableList.vue';
@@ -251,18 +251,22 @@ const props = defineProps<{
   editorSectionId?: string;
 }>();
 
-const tagsFieldProxy = computed({
-  get: () => props.tagsField.value,
-  set: (value: string) => {
-    props.tagsField.value = value;
-  },
-});
+function useWritableFieldProxy(field: WritableComputedRef<string>) {
+  const target = toRef(field, 'value');
+  return computed({
+    get: () => toValue(target),
+    set: (value: string) => {
+      target.value = value;
+    },
+  });
+}
 
-const objectivesField = props.createArrayField('objectives');
-const competenciesField = props.createArrayField('competencies');
-const skillsField = props.createArrayField('skills');
-const outcomesField = props.createArrayField('outcomes');
-const prerequisitesField = props.createArrayField('prerequisites');
+const tagsFieldProxy = useWritableFieldProxy(props.tagsField);
+const objectivesFieldProxy = useWritableFieldProxy(props.createArrayField('objectives'));
+const competenciesFieldProxy = useWritableFieldProxy(props.createArrayField('competencies'));
+const skillsFieldProxy = useWritableFieldProxy(props.createArrayField('skills'));
+const outcomesFieldProxy = useWritableFieldProxy(props.createArrayField('outcomes'));
+const prerequisitesFieldProxy = useWritableFieldProxy(props.createArrayField('prerequisites'));
 
 const showRevertButton = computed(
   () => Boolean(props.canRevert) && typeof props.onRevert === 'function'


### PR DESCRIPTION
## Summary
- wrap lesson and exercise authoring panel bindings with local proxies built from toRef/toValue
- apply the same writable proxy pattern in the authoring sidebars to avoid mutating props directly
- confirm metadata editing flows still sync with the model via existing panel tests

## Testing
- npm test -- --run src/components/lesson/__tests__/LessonAuthoringPanel.metadata.test.ts src/components/exercise/__tests__/ExerciseAuthoringPanel.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e27b05a680832ca31cdbbc4f06394d