### PR TITLE
test: fix module mock typings

### DIFF
--- a/src/components/exercise/__tests__/ExerciseAuthoringPanel.test.ts
+++ b/src/components/exercise/__tests__/ExerciseAuthoringPanel.test.ts
@@ -53,7 +53,7 @@ const AuthoringDraggableListStub = defineComponent({
 });
 
 vi.mock('@/components/authoring/blocks/UnsupportedBlockEditor.vue', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
+  const actual = (await importOriginal()) as Record<string, unknown>;
 
   const Stub = defineComponent({
     name: 'UnsupportedBlockEditorStub',
@@ -87,7 +87,7 @@ vi.mock('@/components/authoring/blocks/UnsupportedBlockEditor.vue', async (impor
 });
 
 vi.mock('@/composables/useLessonEditorModel', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/composables/useLessonEditorModel')>();
+  const actual = (await importOriginal()) as typeof import('@/composables/useLessonEditorModel');
   const { default: Stub } = await import(
     '@/components/authoring/blocks/UnsupportedBlockEditor.vue'
   );

--- a/src/components/lesson/__tests__/LessonAuthoringPanel.fallback.test.ts
+++ b/src/components/lesson/__tests__/LessonAuthoringPanel.fallback.test.ts
@@ -5,7 +5,7 @@ import type { LessonEditorModel } from '@/composables/useLessonEditorModel';
 import type { LessonBlock } from '@/components/lesson/blockRegistry';
 
 vi.mock('@/components/authoring/blocks/UnsupportedBlockEditor.vue', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
+  const actual = (await importOriginal()) as Record<string, unknown>;
 
   const Stub = defineComponent({
     name: 'UnsupportedBlockEditorStub',
@@ -39,7 +39,7 @@ vi.mock('@/components/authoring/blocks/UnsupportedBlockEditor.vue', async (impor
 });
 
 vi.mock('@/composables/useLessonEditorModel', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/composables/useLessonEditorModel')>();
+  const actual = (await importOriginal()) as typeof import('@/composables/useLessonEditorModel');
   const { default: Stub } = await import(
     '@/components/authoring/blocks/UnsupportedBlockEditor.vue'
   );

--- a/src/components/lesson/__tests__/LessonRenderer.test.ts
+++ b/src/components/lesson/__tests__/LessonRenderer.test.ts
@@ -5,9 +5,9 @@ import ddmLesson01 from '@/content/courses/ddm/lessons/lesson-01.json';
 import { computed, ref } from 'vue';
 
 vi.mock('@/pages/course/LessonRenderer.logic', async () => {
-  const actual = await vi.importActual<typeof import('@/pages/course/LessonRenderer.logic')>(
+  const actual = (await vi.importActual(
     '@/pages/course/LessonRenderer.logic'
-  );
+  )) as typeof import('@/pages/course/LessonRenderer.logic');
 
   return {
     ...actual,
@@ -18,9 +18,9 @@ vi.mock('@/pages/course/LessonRenderer.logic', async () => {
 import { useLessonRenderer } from '@/pages/course/LessonRenderer.logic';
 
 const useLessonRendererMock = vi.mocked(useLessonRenderer);
-const actualLogicModulePromise = vi.importActual<
+const actualLogicModulePromise = vi.importActual('@/pages/course/LessonRenderer.logic') as Promise<
   typeof import('@/pages/course/LessonRenderer.logic')
->('@/pages/course/LessonRenderer.logic');
+>;
 
 beforeEach(async () => {
   const actual = await actualLogicModulePromise;

--- a/src/pages/__tests__/ExerciseView.component.test.ts
+++ b/src/pages/__tests__/ExerciseView.component.test.ts
@@ -16,9 +16,9 @@ const MetadataListEditorStub = {
 };
 
 vi.mock('@/composables/useLessonEditorModel', async () => {
-  const actual = await vi.importActual<typeof import('@/composables/useLessonEditorModel')>(
+  const actual = (await vi.importActual(
     '@/composables/useLessonEditorModel'
-  );
+  )) as typeof import('@/composables/useLessonEditorModel');
 
   return {
     ...actual,

--- a/src/pages/__tests__/LessonView.component.test.ts
+++ b/src/pages/__tests__/LessonView.component.test.ts
@@ -16,9 +16,9 @@ const MetadataListEditorStub = {
 };
 
 vi.mock('@/composables/useLessonEditorModel', async () => {
-  const actual = await vi.importActual<typeof import('@/composables/useLessonEditorModel')>(
+  const actual = (await vi.importActual(
     '@/composables/useLessonEditorModel'
-  );
+  )) as typeof import('@/composables/useLessonEditorModel');
 
   return {
     ...actual,


### PR DESCRIPTION
## Summary
- cast module mock imports to explicit types before spreading in authoring panel tests
- update exercise and lesson view suites to cast `vi.importActual` results for type safety

## Testing
- `npx vitest run src/components/lesson/__tests__/LessonAuthoringPanel.fallback.test.ts src/components/exercise/__tests__/ExerciseAuthoringPanel.test.ts src/pages/__tests__/ExerciseView.component.test.ts src/pages/__tests__/LessonView.component.test.ts src/components/lesson/__tests__/LessonRenderer.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e27e8335ec832ca8ff3c040c323a5a