### PR TITLE
Normalize teacher mode environment handling

### DIFF
--- a/src/composables/__tests__/useTeacherMode.test.ts
+++ b/src/composables/__tests__/useTeacherMode.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 describe('useTeacherMode', () => {
   it('mantém desativado e limpa storage quando o backend está indisponível', async () => {
     window.localStorage.setItem('teacherMode', 'true');
-    vi.stubEnv('DEV', '');
+    vi.stubEnv('DEV', false);
     vi.stubEnv('VITE_TEACHER_API_URL', '');
 
     const useTeacherMode = await importComposable();
@@ -35,7 +35,7 @@ describe('useTeacherMode', () => {
 
   it('restaura e persiste o estado manual quando o backend está disponível', async () => {
     window.localStorage.setItem('teacherMode', 'true');
-    vi.stubEnv('DEV', '');
+    vi.stubEnv('DEV', false);
     vi.stubEnv('VITE_TEACHER_API_URL', 'https://teacher.local');
 
     const useTeacherMode = await importComposable();
@@ -54,7 +54,7 @@ describe('useTeacherMode', () => {
   });
 
   it('ativa pelo query string quando manual authoring está habilitado', async () => {
-    vi.stubEnv('DEV', '');
+    vi.stubEnv('DEV', false);
     vi.stubEnv('VITE_TEACHER_API_URL', 'https://teacher.local');
     window.history.replaceState({}, '', '/lesson?teacher=1#detalhes');
 
@@ -66,7 +66,7 @@ describe('useTeacherMode', () => {
   });
 
   it('ignora o query string quando manual authoring está desabilitado', async () => {
-    vi.stubEnv('DEV', '');
+    vi.stubEnv('DEV', false);
     vi.stubEnv('VITE_TEACHER_API_URL', '');
     window.history.replaceState({}, '', '/lesson?teacher=1');
 

--- a/src/composables/useTeacherMode.ts
+++ b/src/composables/useTeacherMode.ts
@@ -1,7 +1,20 @@
 import { computed, readonly, ref } from 'vue';
 
-const manualAuthoringEnabled = Boolean(import.meta.env.VITE_TEACHER_API_URL);
-const authoringForced = Boolean(import.meta.env.DEV) && manualAuthoringEnabled;
+function resolveEnvFlag(value: unknown): boolean {
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === '' || normalized === 'false' || normalized === '0' || normalized === 'off') {
+      return false;
+    }
+    if (normalized === 'true') {
+      return true;
+    }
+  }
+  return Boolean(value);
+}
+
+const manualAuthoringEnabled = resolveEnvFlag(import.meta.env.VITE_TEACHER_API_URL);
+const authoringForced = resolveEnvFlag(import.meta.env.DEV) && manualAuthoringEnabled;
 
 const teacherMode = ref(authoringForced);
 const ready = ref(authoringForced);


### PR DESCRIPTION
## Summary
- normalize environment flags in `useTeacherMode` so "false"-like values don’t force teacher mode
- update `useTeacherMode` tests to stub the DEV flag using the new boolean format

## Testing
- npx vitest run useTeacherMode

------
https://chatgpt.com/codex/tasks/task_e_68e2810d0f54832c890e6873e542164f