### PR TITLE
Adjust Prism highlight target handling for null contexts

### DIFF
--- a/src/utils/prismHighlight.ts
+++ b/src/utils/prismHighlight.ts
@@ -102,7 +102,7 @@ export function createPrismHighlightHandler(): PrismHighlightHandler {
     }
 
     const highlightRoot = root ?? lastRoot;
-    const highlightTargets = toElementList(targets);
+    const highlightTargets = targets ? toElementList(targets) : [];
 
     requestAnimationFrame(() => {
       if (highlightTargets.length > 0) {

--- a/tests/utils/prismHighlight.spec.ts
+++ b/tests/utils/prismHighlight.spec.ts
@@ -78,4 +78,23 @@ describe('createPrismHighlightHandler', () => {
     expect(highlightElementMock).toHaveBeenNthCalledWith(2, second);
     expect(highlightAllMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      name: 'null targets',
+      context: { targets: null },
+    },
+    {
+      name: 'single element',
+      context: { targets: document.createElement('code') },
+    },
+    {
+      name: 'iterable targets',
+      context: { targets: new Set([document.createElement('code')]) },
+    },
+  ])('does not throw when called with $name', async ({ context }) => {
+    const handler = createPrismHighlightHandler();
+
+    await expect(handler(context)).resolves.toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- ensure the Prism highlight handler only materializes target elements when provided
- extend the unit tests to cover null, single element, and iterable target scenarios

## Testing
- npm run test -- tests/utils/prismHighlight.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e284acd2bc832c86b0411399f318e5