### PR TITLE
Fix TypeScript authoring panels and provide draggable typings

### DIFF
--- a/src/components/exercise/ExerciseAuthoringPanel.vue
+++ b/src/components/exercise/ExerciseAuthoringPanel.vue
@@ -188,17 +188,7 @@
 </template>
 
 <script setup lang="ts">
-import {
-  computed,
-  nextTick,
-  ref,
-  toRef,
-  toValue,
-  useId,
-  watch,
-  type Ref,
-  type WritableComputedRef,
-} from 'vue';
+import { computed, nextTick, ref, useId, watch, type Ref, type WritableComputedRef } from 'vue';
 import {
   AlertCircle,
   ArrowDown,
@@ -241,11 +231,10 @@ const props = defineProps<{
 }>();
 
 function useWritableFieldProxy(field: WritableComputedRef<string>) {
-  const target = toRef(field, 'value');
   return computed({
-    get: () => toValue(target),
+    get: () => field.value,
     set: (value: string) => {
-      target.value = value;
+      field.value = value;
     },
   });
 }
@@ -414,10 +403,14 @@ function commitPendingBlockOrder(event?: DragEndEvent) {
 
   pendingReorder.value = null;
 
-  const currentByKey = new Map(current.map((block) => [block.__uiKey, block]));
+  const currentByKey = new Map<string, LessonAuthoringBlock>();
+  for (const block of current) {
+    currentByKey.set(block.__uiKey, block);
+  }
   const normalized = proposed.map((block, index) => {
     const key = typeof block?.__uiKey === 'string' ? block.__uiKey : undefined;
-    const source = (key ? currentByKey.get(key) : undefined) ?? current[index];
+    const source: LessonAuthoringBlock | undefined =
+      (key ? currentByKey.get(key) : undefined) ?? current[index];
     return inheritAuthoringBlockKey(source, block);
   }) as LessonAuthoringBlock[];
 

--- a/src/components/exercise/ExerciseAuthoringSidebar.vue
+++ b/src/components/exercise/ExerciseAuthoringSidebar.vue
@@ -40,7 +40,7 @@
       {{ props.successMessage }}
     </div>
 
-    <template v-if="exerciseModel.value">
+    <template v-if="hasExerciseModel">
       <section class="md-stack md-stack-3">
         <h3 class="md-typescale-title-medium font-semibold text-on-surface">
           Metadados do exercício
@@ -168,7 +168,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, toRef, toValue, type Component, type Ref, type WritableComputedRef } from 'vue';
+import { computed, type Component, type Ref, type WritableComputedRef } from 'vue';
 import { ArrowDown, ArrowUp, GripVertical, PenSquare, Plus, Trash2 } from 'lucide-vue-next';
 import Md3Button from '@/components/Md3Button.vue';
 import AuthoringDraggableList from '@/components/authoring/AuthoringDraggableList.vue';
@@ -204,6 +204,7 @@ const props = defineProps<{
 }>();
 
 const exerciseModel = props.exerciseModel;
+const hasExerciseModel = computed(() => exerciseModel.value !== null);
 
 type NormalizedLessonEditorModel = LessonEditorModel & {
   title: string;
@@ -241,11 +242,10 @@ const currentExercise = computed<NormalizedLessonEditorModel>(() => {
 });
 
 function useWritableFieldProxy(field: WritableComputedRef<string>) {
-  const target = toRef(field, 'value');
   return computed({
-    get: () => toValue(target),
+    get: () => field.value,
     set: (value: string) => {
-      target.value = value;
+      field.value = value;
     },
   });
 }

--- a/src/components/lesson/LessonAuthoringPanel.vue
+++ b/src/components/lesson/LessonAuthoringPanel.vue
@@ -230,17 +230,7 @@
 </template>
 
 <script setup lang="ts">
-import {
-  computed,
-  nextTick,
-  ref,
-  toRef,
-  toValue,
-  useId,
-  watch,
-  type Ref,
-  type WritableComputedRef,
-} from 'vue';
+import { computed, nextTick, ref, useId, watch, type Ref, type WritableComputedRef } from 'vue';
 import {
   AlertCircle,
   ArrowDown,
@@ -285,11 +275,10 @@ const props = defineProps<{
 }>();
 
 function useWritableFieldProxy(field: WritableComputedRef<string>) {
-  const target = toRef(field, 'value');
   return computed({
-    get: () => toValue(target),
+    get: () => field.value,
     set: (value: string) => {
-      target.value = value;
+      field.value = value;
     },
   });
 }
@@ -423,7 +412,10 @@ function commitPendingBlockOrder(event?: DragEndEvent) {
 
   pendingReorder.value = null;
 
-  const currentByKey = new Map(current.map((block) => [block.__uiKey, block]));
+  const currentByKey = new Map<string, LessonAuthoringBlock>();
+  for (const block of current) {
+    currentByKey.set(block.__uiKey, block);
+  }
   const normalized = proposed.map((block, index) => {
     const key = typeof block?.__uiKey === 'string' ? block.__uiKey : undefined;
     const source = (key ? currentByKey.get(key) : undefined) ?? current[index];

--- a/src/composables/useAuthoringSaveTracker.ts
+++ b/src/composables/useAuthoringSaveTracker.ts
@@ -3,9 +3,9 @@ import { computed, ref, watch, type Ref } from 'vue';
 type SaveStatus = 'idle' | 'pending' | 'saving' | 'saved' | 'error';
 
 type SaveSignals = {
-  saving: Ref<boolean>;
-  hasPendingChanges: Ref<boolean>;
-  saveError: Ref<string | null>;
+  saving: Ref<boolean | undefined>;
+  hasPendingChanges: Ref<boolean | undefined>;
+  saveError: Ref<string | null | undefined>;
 };
 
 export function useAuthoringSaveTracker(target: Ref<unknown>, signals: SaveSignals) {
@@ -22,9 +22,9 @@ export function useAuthoringSaveTracker(target: Ref<unknown>, signals: SaveSigna
 
   watch(
     () => ({
-      saving: signals.saving.value,
-      pending: signals.hasPendingChanges.value,
-      error: signals.saveError.value,
+      saving: Boolean(signals.saving.value),
+      pending: Boolean(signals.hasPendingChanges.value),
+      error: signals.saveError.value ?? null,
     }),
     ({ saving, pending, error }) => {
       if (pending && !previous.pending) {

--- a/src/pages/__tests__/ExerciseView.component.test.ts
+++ b/src/pages/__tests__/ExerciseView.component.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { computed, shallowRef, ref } from 'vue';
 import type { ExerciseViewController } from '../ExerciseView.logic';

--- a/src/types/vuedraggable.d.ts
+++ b/src/types/vuedraggable.d.ts
@@ -1,0 +1,6 @@
+declare module 'vuedraggable' {
+  import type { DefineComponent } from 'vue';
+
+  const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, any>;
+  export default component;
+}


### PR DESCRIPTION
## Summary
- ensure authoring panels and sidebars use writable proxies and normalized data to satisfy strict TypeScript checks
- relax save tracker signal types and add the missing afterEach import used by the ExerciseView component tests
- add a local vuedraggable type declaration so vue-tsc can resolve the dependency during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2869bf67c832ca2fb86de30639304