### PR TITLE
Add dedicated editors for frequently used lesson blocks

### DIFF
--- a/src/components/authoring/blocks/KnowledgeCheckEditor.vue
+++ b/src/components/authoring/blocks/KnowledgeCheckEditor.vue
@@ -1,0 +1,215 @@
+<template>
+  <section class="md-stack md-stack-4">
+    <header class="md-stack md-stack-1">
+      <h3 class="md-typescale-title-medium font-semibold text-on-surface">Checagem rápida</h3>
+      <p class="text-sm text-on-surface-variant">
+        Elabore perguntas objetivas para garantir que os participantes compreenderam o tópico
+        apresentado.
+      </p>
+    </header>
+
+    <div class="grid gap-4 md:grid-cols-2">
+      <label class="flex flex-col gap-2">
+        <span class="md-typescale-label-large text-on-surface">Título</span>
+        <input
+          v-model="state.title"
+          type="text"
+          class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          placeholder="Opcional"
+          autofocus
+        />
+      </label>
+      <label class="md:col-span-2 flex flex-col gap-2">
+        <span class="md-typescale-label-large text-on-surface">Pergunta</span>
+        <textarea
+          v-model="state.prompt"
+          rows="3"
+          class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          placeholder="Qual conceito deseja reforçar?"
+        ></textarea>
+      </label>
+    </div>
+
+    <fieldset
+      class="rounded-3xl border border-outline bg-surface-container-high p-4 md-stack md-stack-3"
+    >
+      <legend class="md-typescale-title-small font-semibold text-on-surface">
+        Alternativas exibidas
+      </legend>
+      <p class="text-sm text-on-surface-variant">
+        Cadastre opções claras e concisas. A explicação será mostrada após a seleção de qualquer
+        alternativa.
+      </p>
+
+      <div class="flex flex-col gap-4">
+        <article
+          v-for="(option, index) in state.options"
+          :key="option.id"
+          class="rounded-3xl border border-outline bg-surface p-4 md-stack md-stack-3"
+        >
+          <header class="flex items-center justify-between gap-3">
+            <h4 class="text-title-small font-semibold text-on-surface">Opção {{ index + 1 }}</h4>
+            <Md3Button
+              v-if="state.options.length > 2"
+              type="button"
+              variant="text"
+              class="text-error"
+              @click="removeOption(index)"
+            >
+              <template #leading>
+                <Trash2 class="md-icon md-icon--sm" aria-hidden="true" />
+              </template>
+              Remover
+            </Md3Button>
+          </header>
+
+          <label class="flex flex-col gap-2">
+            <span class="md-typescale-label-large text-on-surface">Texto da opção</span>
+            <input
+              v-model="option.text"
+              type="text"
+              class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            />
+          </label>
+        </article>
+      </div>
+
+      <Md3Button type="button" variant="tonal" class="self-start" @click="addOption">
+        <template #leading>
+          <Plus class="md-icon md-icon--sm" aria-hidden="true" />
+        </template>
+        Adicionar opção
+      </Md3Button>
+    </fieldset>
+
+    <section
+      class="rounded-3xl border border-outline bg-surface-container-high p-4 md-stack md-stack-3"
+    >
+      <h4 class="text-title-small font-semibold text-on-surface">Feedback</h4>
+      <label class="flex items-center gap-3 text-on-surface">
+        <input v-model="state.allowMultiple" type="checkbox" class="h-4 w-4" />
+        <span>Permitir selecionar mais de uma opção</span>
+      </label>
+      <label class="flex flex-col gap-2">
+        <span class="md-typescale-label-large text-on-surface"
+          >Explicação exibida após a resposta</span
+        >
+        <textarea
+          v-model="state.explanation"
+          rows="3"
+          class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          placeholder="Resumo ou reforço sobre a resposta"
+        ></textarea>
+      </label>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { reactive, watch } from 'vue';
+import { Plus, Trash2 } from 'lucide-vue-next';
+import Md3Button from '@/components/Md3Button.vue';
+
+interface KnowledgeCheckOptionState {
+  id: string;
+  text: string;
+}
+
+interface KnowledgeCheckInput {
+  type?: string;
+  title?: string;
+  prompt?: string;
+  explanation?: string;
+  allowMultiple?: boolean;
+  options?: Array<{ id?: string; text?: string }>;
+}
+
+const props = defineProps<{ block: KnowledgeCheckInput }>();
+const emit = defineEmits<{ (event: 'update:block', value: KnowledgeCheckInput): void }>();
+
+function createKey(prefix = 'option'): string {
+  const globalCrypto =
+    typeof globalThis !== 'undefined' ? (globalThis.crypto as Crypto | undefined) : undefined;
+  if (globalCrypto && typeof globalCrypto.randomUUID === 'function') {
+    return `${prefix}-${globalCrypto.randomUUID()}`;
+  }
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function createOption(): KnowledgeCheckOptionState {
+  return {
+    id: createKey(),
+    text: '',
+  };
+}
+
+function normalizeOptions(block: KnowledgeCheckInput): KnowledgeCheckOptionState[] {
+  const raw = Array.isArray(block?.options) ? block.options : [];
+  if (raw.length >= 2) {
+    return raw.map((option, index) => ({
+      id: option?.id ? String(option.id) : createKey(`option-${index + 1}`),
+      text: typeof option?.text === 'string' ? option.text : '',
+    }));
+  }
+  return [createOption(), createOption()];
+}
+
+function normalizeState(block: KnowledgeCheckInput) {
+  return {
+    type: typeof block?.type === 'string' ? block.type : 'knowledgeCheck',
+    title: typeof block?.title === 'string' ? block.title : '',
+    prompt: typeof block?.prompt === 'string' ? block.prompt : '',
+    explanation: typeof block?.explanation === 'string' ? block.explanation : '',
+    allowMultiple: Boolean(block?.allowMultiple),
+    options: normalizeOptions(block),
+  };
+}
+
+const state = reactive(normalizeState(props.block));
+
+let syncing = false;
+
+watch(
+  () => props.block,
+  (value) => {
+    syncing = true;
+    const next = normalizeState(value ?? {});
+    state.type = next.type;
+    state.title = next.title;
+    state.prompt = next.prompt;
+    state.explanation = next.explanation;
+    state.allowMultiple = next.allowMultiple;
+    state.options = next.options;
+    syncing = false;
+  },
+  { deep: true }
+);
+
+watch(
+  state,
+  () => {
+    if (syncing) return;
+    emit('update:block', {
+      type: state.type || 'knowledgeCheck',
+      title: state.title || undefined,
+      prompt: state.prompt,
+      explanation: state.explanation || undefined,
+      allowMultiple: state.allowMultiple || undefined,
+      options: state.options.map((option) => ({
+        id: option.id,
+        text: option.text,
+      })),
+    });
+  },
+  { deep: true }
+);
+
+function addOption() {
+  state.options = [...state.options, createOption()];
+}
+
+function removeOption(index: number) {
+  if (state.options.length <= 2) return;
+  state.options = state.options.filter((_, i) => i !== index);
+}
+</script>

--- a/src/components/authoring/blocks/QuizBlockEditor.vue
+++ b/src/components/authoring/blocks/QuizBlockEditor.vue
@@ -1,0 +1,317 @@
+<template>
+  <section class="md-stack md-stack-4">
+    <header class="md-stack md-stack-1">
+      <h3 class="md-typescale-title-medium font-semibold text-on-surface">Quiz avaliativo</h3>
+      <p class="text-sm text-on-surface-variant">
+        Configure perguntas objetivas com alternativas corretas para validar o entendimento dos
+        estudantes.
+      </p>
+    </header>
+
+    <div class="grid gap-4 md:grid-cols-2">
+      <label class="flex flex-col gap-2 md:col-span-2">
+        <span class="md-typescale-label-large text-on-surface">Título</span>
+        <input
+          v-model="state.title"
+          type="text"
+          class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          autofocus
+        />
+      </label>
+      <label class="flex flex-col gap-2 md:col-span-2">
+        <span class="md-typescale-label-large text-on-surface">Enunciado</span>
+        <textarea
+          v-model="state.question"
+          rows="4"
+          class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          placeholder="Descreva a pergunta do quiz"
+        ></textarea>
+      </label>
+    </div>
+
+    <fieldset
+      class="rounded-3xl border border-outline bg-surface-container-high p-4 md-stack md-stack-3"
+    >
+      <legend class="md-typescale-title-small font-semibold text-on-surface">Alternativas</legend>
+      <p class="text-sm text-on-surface-variant">
+        Marque quais respostas devem ser consideradas corretas. Em modo de resposta única, apenas
+        uma alternativa pode ficar selecionada.
+      </p>
+
+      <div class="flex flex-col gap-4">
+        <article
+          v-for="(option, index) in state.options"
+          :key="option.id"
+          class="rounded-3xl border border-outline bg-surface p-3 md-stack md-stack-3"
+        >
+          <header class="flex items-center justify-between gap-3">
+            <h4 class="text-title-small font-semibold text-on-surface">
+              Alternativa {{ index + 1 }}
+            </h4>
+            <Md3Button
+              v-if="state.options.length > 2"
+              type="button"
+              variant="text"
+              class="text-error"
+              @click="removeOption(index)"
+            >
+              <template #leading>
+                <Trash2 class="md-icon md-icon--sm" aria-hidden="true" />
+              </template>
+              Remover
+            </Md3Button>
+          </header>
+
+          <label class="flex flex-col gap-2">
+            <span class="md-typescale-label-large text-on-surface">Texto da alternativa</span>
+            <textarea
+              v-model="option.text"
+              rows="3"
+              class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            ></textarea>
+          </label>
+
+          <label class="flex flex-col gap-2">
+            <span class="md-typescale-label-large text-on-surface">Explicação (opcional)</span>
+            <textarea
+              v-model="option.explanation"
+              rows="2"
+              class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              placeholder="Texto exibido após o envio para justificar a resposta"
+            ></textarea>
+          </label>
+
+          <label class="flex items-center gap-3 text-on-surface">
+            <input v-if="state.multiple" v-model="option.correct" type="checkbox" class="h-4 w-4" />
+            <input
+              v-else
+              type="radio"
+              class="h-4 w-4"
+              name="quiz-correct-option"
+              :value="option.id"
+              :checked="option.correct"
+              @change="setSingleCorrect(index)"
+            />
+            <span>Esta alternativa está correta</span>
+          </label>
+        </article>
+      </div>
+
+      <Md3Button type="button" variant="tonal" class="self-start" @click="addOption">
+        <template #leading>
+          <Plus class="md-icon md-icon--sm" aria-hidden="true" />
+        </template>
+        Adicionar alternativa
+      </Md3Button>
+    </fieldset>
+
+    <section
+      class="rounded-3xl border border-outline bg-surface-container-high p-4 md-stack md-stack-3"
+    >
+      <h4 class="text-title-small font-semibold text-on-surface">Configurações</h4>
+      <label class="flex items-center gap-3 text-on-surface">
+        <input
+          v-model="state.multiple"
+          type="checkbox"
+          class="h-4 w-4"
+          @change="handleMultipleChange"
+        />
+        <span>Permitir múltiplas respostas corretas</span>
+      </label>
+      <label class="flex items-center gap-3 text-on-surface">
+        <input v-model="state.shuffle" type="checkbox" class="h-4 w-4" />
+        <span>Embaralhar alternativas ao exibir</span>
+      </label>
+      <label class="flex items-center gap-3 text-on-surface">
+        <input v-model="state.allowRetry" type="checkbox" class="h-4 w-4" />
+        <span>Permitir nova tentativa após o envio</span>
+      </label>
+
+      <div class="grid gap-3 md:grid-cols-2">
+        <label class="flex flex-col gap-2">
+          <span class="md-typescale-label-large text-on-surface">Feedback para acerto</span>
+          <textarea
+            v-model="state.feedback.correct"
+            rows="2"
+            class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            placeholder="Mensagem exibida quando o estudante acerta"
+          ></textarea>
+        </label>
+        <label class="flex flex-col gap-2">
+          <span class="md-typescale-label-large text-on-surface">Feedback para erro</span>
+          <textarea
+            v-model="state.feedback.incorrect"
+            rows="2"
+            class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            placeholder="Mensagem exibida quando o estudante erra"
+          ></textarea>
+        </label>
+      </div>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { reactive, watch } from 'vue';
+import { Plus, Trash2 } from 'lucide-vue-next';
+import Md3Button from '@/components/Md3Button.vue';
+
+interface QuizOptionState {
+  id: string;
+  text: string;
+  correct: boolean;
+  explanation: string;
+}
+
+interface QuizBlockState {
+  type?: string;
+  title: string;
+  question: string;
+  multiple: boolean;
+  shuffle: boolean;
+  allowRetry: boolean;
+  feedback: {
+    correct: string;
+    incorrect: string;
+  };
+  options: QuizOptionState[];
+}
+
+interface QuizBlockInput {
+  type?: string;
+  title?: string;
+  question?: string;
+  multiple?: boolean;
+  shuffle?: boolean;
+  allowRetry?: boolean;
+  feedback?: { correct?: string; incorrect?: string };
+  options?: Array<{ id?: string; text?: string; correct?: boolean; explanation?: string }>;
+}
+
+const props = defineProps<{ block: QuizBlockInput }>();
+const emit = defineEmits<{ (event: 'update:block', value: QuizBlockInput): void }>();
+
+function createKey(prefix = 'option'): string {
+  const globalCrypto =
+    typeof globalThis !== 'undefined' ? (globalThis.crypto as Crypto | undefined) : undefined;
+  if (globalCrypto && typeof globalCrypto.randomUUID === 'function') {
+    return `${prefix}-${globalCrypto.randomUUID()}`;
+  }
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function normalizeOptions(block: QuizBlockInput): QuizOptionState[] {
+  const raw = Array.isArray(block?.options) ? block.options : [];
+  if (raw.length >= 2) {
+    return raw.map((option, index) => ({
+      id: option?.id ? String(option.id) : createKey(`option-${index + 1}`),
+      text: typeof option?.text === 'string' ? option.text : '',
+      correct: Boolean(option?.correct),
+      explanation: typeof option?.explanation === 'string' ? option.explanation : '',
+    }));
+  }
+  return [createOption(true), createOption(false)];
+}
+
+function createOption(correct = false): QuizOptionState {
+  return {
+    id: createKey(),
+    text: '',
+    correct,
+    explanation: '',
+  };
+}
+
+function normalizeState(block: QuizBlockInput): QuizBlockState {
+  return {
+    type: typeof block?.type === 'string' ? block.type : 'quiz',
+    title: typeof block?.title === 'string' ? block.title : '',
+    question: typeof block?.question === 'string' ? block.question : '',
+    multiple: Boolean(block?.multiple),
+    shuffle: block?.shuffle !== false,
+    allowRetry: block?.allowRetry !== false,
+    feedback: {
+      correct: typeof block?.feedback?.correct === 'string' ? block.feedback!.correct : '',
+      incorrect: typeof block?.feedback?.incorrect === 'string' ? block.feedback!.incorrect : '',
+    },
+    options: normalizeOptions(block),
+  };
+}
+
+const state = reactive<QuizBlockState>(normalizeState(props.block));
+
+let syncing = false;
+
+watch(
+  () => props.block,
+  (value) => {
+    syncing = true;
+    const next = normalizeState(value ?? {});
+    state.type = next.type;
+    state.title = next.title;
+    state.question = next.question;
+    state.multiple = next.multiple;
+    state.shuffle = next.shuffle;
+    state.allowRetry = next.allowRetry;
+    state.feedback.correct = next.feedback.correct;
+    state.feedback.incorrect = next.feedback.incorrect;
+    state.options = next.options;
+    syncing = false;
+  },
+  { deep: true }
+);
+
+watch(
+  state,
+  () => {
+    if (syncing) return;
+    emit('update:block', {
+      type: state.type || 'quiz',
+      title: state.title,
+      question: state.question,
+      multiple: state.multiple || undefined,
+      shuffle: state.shuffle,
+      allowRetry: state.allowRetry,
+      feedback: {
+        correct: state.feedback.correct,
+        incorrect: state.feedback.incorrect,
+      },
+      options: state.options.map((option, index) => ({
+        id: option.id,
+        text: option.text,
+        correct: state.multiple ? option.correct : index === getSingleCorrectIndex(),
+        explanation: option.explanation || undefined,
+      })),
+    });
+  },
+  { deep: true }
+);
+
+function getSingleCorrectIndex(): number {
+  const index = state.options.findIndex((option) => option.correct);
+  return index >= 0 ? index : 0;
+}
+
+function addOption() {
+  state.options = [...state.options, createOption(false)];
+}
+
+function removeOption(index: number) {
+  if (state.options.length <= 2) return;
+  state.options = state.options.filter((_, i) => i !== index);
+}
+
+function setSingleCorrect(index: number) {
+  state.options = state.options.map((option, currentIndex) => ({
+    ...option,
+    correct: currentIndex === index,
+  }));
+}
+
+function handleMultipleChange() {
+  if (!state.multiple) {
+    const index = getSingleCorrectIndex();
+    setSingleCorrect(index);
+  }
+}
+</script>

--- a/src/components/authoring/blocks/ResourceGalleryEditor.vue
+++ b/src/components/authoring/blocks/ResourceGalleryEditor.vue
@@ -1,0 +1,307 @@
+<template>
+  <section class="md-stack md-stack-4">
+    <header class="md-stack md-stack-1">
+      <h3 class="md-typescale-title-medium font-semibold text-on-surface">Galeria de recursos</h3>
+      <p class="text-sm text-on-surface-variant">
+        Curadoria de materiais complementares como artigos, vídeos e datasets. Cada item pode
+        incluir metadados como autor, fonte e licença.
+      </p>
+    </header>
+
+    <div class="grid gap-4 md:grid-cols-2">
+      <label class="flex flex-col gap-2">
+        <span class="md-typescale-label-large text-on-surface">Título</span>
+        <input
+          v-model="state.title"
+          type="text"
+          class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          autofocus
+        />
+      </label>
+      <label class="flex flex-col gap-2">
+        <span class="md-typescale-label-large text-on-surface">Descrição</span>
+        <textarea
+          v-model="state.description"
+          rows="3"
+          class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          placeholder="Contextualize os materiais selecionados"
+        ></textarea>
+      </label>
+      <label class="md:col-span-2 flex flex-col gap-2">
+        <span class="md-typescale-label-large text-on-surface">Fonte externa (JSON)</span>
+        <input
+          v-model="state.src"
+          type="url"
+          class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          placeholder="URL opcional com { items: [...] }"
+        />
+      </label>
+    </div>
+
+    <section
+      class="rounded-3xl border border-outline bg-surface-container-high p-4 md-stack md-stack-3"
+    >
+      <header class="flex items-center justify-between">
+        <div>
+          <h4 class="text-title-small font-semibold text-on-surface">Itens cadastrados</h4>
+          <p class="text-sm text-on-surface-variant">
+            Cadastre links verificados para consulta rápida dos estudantes.
+          </p>
+        </div>
+        <Md3Button type="button" variant="tonal" @click="addItem">
+          <template #leading>
+            <Plus class="md-icon md-icon--sm" aria-hidden="true" />
+          </template>
+          Adicionar recurso
+        </Md3Button>
+      </header>
+
+      <div v-if="state.items.length" class="flex flex-col gap-4">
+        <article
+          v-for="(item, index) in state.items"
+          :key="item.id"
+          class="rounded-3xl border border-outline bg-surface p-4 md-stack md-stack-3"
+        >
+          <header class="flex items-center justify-between gap-3">
+            <h5 class="text-title-small font-semibold text-on-surface">Recurso {{ index + 1 }}</h5>
+            <Md3Button
+              v-if="state.items.length > 1"
+              type="button"
+              variant="text"
+              class="text-error"
+              @click="removeItem(index)"
+            >
+              <template #leading>
+                <Trash2 class="md-icon md-icon--sm" aria-hidden="true" />
+              </template>
+              Remover
+            </Md3Button>
+          </header>
+
+          <div class="grid gap-3 md:grid-cols-2">
+            <label class="flex flex-col gap-2">
+              <span class="md-typescale-label-large text-on-surface">Tipo</span>
+              <select
+                v-model="item.type"
+                class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              >
+                <option v-for="option in resourceTypes" :key="option.value" :value="option.value">
+                  {{ option.label }}
+                </option>
+              </select>
+            </label>
+            <label class="flex flex-col gap-2">
+              <span class="md-typescale-label-large text-on-surface">Título</span>
+              <input
+                v-model="item.title"
+                type="text"
+                class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              />
+            </label>
+            <label class="md:col-span-2 flex flex-col gap-2">
+              <span class="md-typescale-label-large text-on-surface">Link</span>
+              <input
+                v-model="item.url"
+                type="url"
+                class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                placeholder="https://"
+              />
+            </label>
+            <label class="flex flex-col gap-2">
+              <span class="md-typescale-label-large text-on-surface">Autor</span>
+              <input
+                v-model="item.author"
+                type="text"
+                class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                placeholder="Opcional"
+              />
+            </label>
+            <label class="flex flex-col gap-2">
+              <span class="md-typescale-label-large text-on-surface">Fonte</span>
+              <input
+                v-model="item.source"
+                type="text"
+                class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                placeholder="Portal, coletânea, etc."
+              />
+            </label>
+            <label class="flex flex-col gap-2">
+              <span class="md-typescale-label-large text-on-surface">Licença</span>
+              <input
+                v-model="item.license"
+                type="text"
+                class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                placeholder="Creative Commons, domínio público..."
+              />
+            </label>
+            <label class="flex flex-col gap-2">
+              <span class="md-typescale-label-large text-on-surface">Link da licença</span>
+              <input
+                v-model="item.licenseUrl"
+                type="url"
+                class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                placeholder="https://"
+              />
+            </label>
+            <label class="md:col-span-2 flex flex-col gap-2">
+              <span class="md-typescale-label-large text-on-surface">Thumbnail</span>
+              <input
+                v-model="item.thumbnail"
+                type="url"
+                class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                placeholder="URL da imagem (opcional)"
+              />
+            </label>
+          </div>
+        </article>
+      </div>
+      <p v-else class="rounded-3xl bg-surface p-4 text-sm text-on-surface-variant">
+        Adicione pelo menos um recurso para exibir a galeria na aula.
+      </p>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { reactive, watch } from 'vue';
+import { Plus, Trash2 } from 'lucide-vue-next';
+import Md3Button from '@/components/Md3Button.vue';
+
+type ResourceType = 'article' | 'image' | 'video' | 'audio' | 'dataset' | 'interactive';
+
+interface ResourceItemState {
+  id: string;
+  type: ResourceType;
+  title: string;
+  url: string;
+  author: string;
+  source: string;
+  license: string;
+  licenseUrl: string;
+  thumbnail: string;
+}
+
+interface ResourceGalleryInput {
+  type?: string;
+  title?: string;
+  description?: string;
+  src?: string;
+  items?: Array<Partial<ResourceItemState> & { type?: ResourceType }>;
+}
+
+const resourceTypes: Array<{ value: ResourceType; label: string }> = [
+  { value: 'article', label: 'Artigo' },
+  { value: 'image', label: 'Imagem' },
+  { value: 'video', label: 'Vídeo' },
+  { value: 'audio', label: 'Áudio' },
+  { value: 'dataset', label: 'Dataset' },
+  { value: 'interactive', label: 'Interativo' },
+];
+
+const props = defineProps<{ block: ResourceGalleryInput }>();
+const emit = defineEmits<{ (event: 'update:block', value: ResourceGalleryInput): void }>();
+
+function createKey(prefix = 'resource'): string {
+  const globalCrypto =
+    typeof globalThis !== 'undefined' ? (globalThis.crypto as Crypto | undefined) : undefined;
+  if (globalCrypto && typeof globalCrypto.randomUUID === 'function') {
+    return `${prefix}-${globalCrypto.randomUUID()}`;
+  }
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function normalizeItems(block: ResourceGalleryInput): ResourceItemState[] {
+  const raw = Array.isArray(block?.items) ? block.items : [];
+  if (!raw.length) {
+    return [createItem()];
+  }
+  return raw.map((item, index) => ({
+    id: item?.id ? String(item.id) : createKey(`resource-${index + 1}`),
+    type: (item?.type as ResourceType) ?? 'article',
+    title: typeof item?.title === 'string' ? item.title : '',
+    url: typeof item?.url === 'string' ? item.url : '',
+    author: typeof item?.author === 'string' ? item.author : '',
+    source: typeof item?.source === 'string' ? item.source : '',
+    license: typeof item?.license === 'string' ? item.license : '',
+    licenseUrl: typeof item?.licenseUrl === 'string' ? item.licenseUrl : '',
+    thumbnail: typeof item?.thumbnail === 'string' ? item.thumbnail : '',
+  }));
+}
+
+function createItem(): ResourceItemState {
+  return {
+    id: createKey(),
+    type: 'article',
+    title: '',
+    url: '',
+    author: '',
+    source: '',
+    license: '',
+    licenseUrl: '',
+    thumbnail: '',
+  };
+}
+
+function normalizeState(block: ResourceGalleryInput) {
+  return {
+    type: typeof block?.type === 'string' ? block.type : 'resourceGallery',
+    title: typeof block?.title === 'string' ? block.title : '',
+    description: typeof block?.description === 'string' ? block.description : '',
+    src: typeof block?.src === 'string' ? block.src : '',
+    items: normalizeItems(block),
+  };
+}
+
+const state = reactive(normalizeState(props.block));
+
+let syncing = false;
+
+watch(
+  () => props.block,
+  (value) => {
+    syncing = true;
+    const next = normalizeState(value ?? {});
+    state.type = next.type;
+    state.title = next.title;
+    state.description = next.description;
+    state.src = next.src;
+    state.items = next.items;
+    syncing = false;
+  },
+  { deep: true }
+);
+
+watch(
+  state,
+  () => {
+    if (syncing) return;
+    emit('update:block', {
+      type: state.type || 'resourceGallery',
+      title: state.title,
+      description: state.description,
+      src: state.src || undefined,
+      items: state.items.map((item) => ({
+        id: item.id,
+        type: item.type,
+        title: item.title,
+        url: item.url,
+        author: item.author || undefined,
+        source: item.source || undefined,
+        license: item.license || undefined,
+        licenseUrl: item.licenseUrl || undefined,
+        thumbnail: item.thumbnail || undefined,
+      })),
+    });
+  },
+  { deep: true }
+);
+
+function addItem() {
+  state.items = [...state.items, createItem()];
+}
+
+function removeItem(index: number) {
+  if (state.items.length <= 1) return;
+  state.items = state.items.filter((_, i) => i !== index);
+}
+</script>

--- a/src/components/authoring/blocks/RoadmapEditor.vue
+++ b/src/components/authoring/blocks/RoadmapEditor.vue
@@ -1,0 +1,154 @@
+<template>
+  <section class="md-stack md-stack-4">
+    <header class="md-stack md-stack-1">
+      <h3 class="md-typescale-title-medium font-semibold text-on-surface">Roteiro da aula</h3>
+      <p class="text-sm text-on-surface-variant">
+        Organize a sequência de etapas que os participantes irão percorrer ao longo da aula.
+      </p>
+    </header>
+
+    <div class="flex flex-col gap-3">
+      <article
+        v-for="(step, index) in state.steps"
+        :key="step.__key"
+        class="rounded-3xl border border-outline bg-surface-container-high p-4 md-stack md-stack-3"
+      >
+        <header class="flex items-center justify-between">
+          <h4 class="text-title-small font-semibold text-on-surface">Passo {{ index + 1 }}</h4>
+          <div class="flex gap-2">
+            <Md3Button
+              v-if="state.steps.length > 1"
+              type="button"
+              variant="text"
+              class="text-error"
+              @click="removeStep(index)"
+            >
+              <template #leading>
+                <Trash2 class="md-icon md-icon--sm" aria-hidden="true" />
+              </template>
+              Remover
+            </Md3Button>
+          </div>
+        </header>
+
+        <label class="flex flex-col gap-2">
+          <span class="md-typescale-label-large text-on-surface">Título</span>
+          <input
+            v-model="step.title"
+            type="text"
+            class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            :autofocus="index === 0"
+          />
+        </label>
+
+        <label class="flex flex-col gap-2">
+          <span class="md-typescale-label-large text-on-surface">Descrição</span>
+          <textarea
+            v-model="step.description"
+            rows="3"
+            class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            placeholder="Opcional"
+          ></textarea>
+        </label>
+      </article>
+    </div>
+
+    <Md3Button type="button" variant="tonal" class="self-start" @click="addStep">
+      <template #leading>
+        <Plus class="md-icon md-icon--sm" aria-hidden="true" />
+      </template>
+      Adicionar passo
+    </Md3Button>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { reactive, watch } from 'vue';
+import { Plus, Trash2 } from 'lucide-vue-next';
+import Md3Button from '@/components/Md3Button.vue';
+
+type RoadmapStep = {
+  __key: string;
+  title: string;
+  description: string;
+};
+
+interface RoadmapBlock {
+  type?: string;
+  steps?: Array<{ title?: string; description?: string }>;
+}
+
+const props = defineProps<{ block: RoadmapBlock }>();
+const emit = defineEmits<{ (event: 'update:block', value: RoadmapBlock): void }>();
+
+function cloneSteps(block: RoadmapBlock, previous: RoadmapStep[] = []): RoadmapStep[] {
+  const raw = Array.isArray(block?.steps) ? block.steps : [];
+  if (!raw.length) {
+    return [createStep()];
+  }
+  return raw.map((step, index) => ({
+    __key: previous[index]?.__key ?? createKey(),
+    title: typeof step?.title === 'string' ? step.title : '',
+    description: typeof step?.description === 'string' ? step.description : '',
+  }));
+}
+
+function createKey() {
+  const globalCrypto =
+    typeof globalThis !== 'undefined' ? (globalThis.crypto as Crypto | undefined) : undefined;
+  if (globalCrypto && typeof globalCrypto.randomUUID === 'function') {
+    return globalCrypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2, 11);
+}
+
+function createStep(): RoadmapStep {
+  return {
+    __key: createKey(),
+    title: '',
+    description: '',
+  };
+}
+
+const state = reactive({
+  type: typeof props.block?.type === 'string' ? props.block.type : 'roadmap',
+  steps: cloneSteps(props.block),
+});
+
+let syncing = false;
+
+watch(
+  () => props.block,
+  (value) => {
+    syncing = true;
+    state.type = typeof value?.type === 'string' ? value.type : 'roadmap';
+    state.steps = cloneSteps(value ?? {}, state.steps);
+    syncing = false;
+  },
+  { deep: true }
+);
+
+watch(
+  state,
+  () => {
+    if (syncing) return;
+    emit('update:block', {
+      type: state.type || 'roadmap',
+      steps: state.steps.map((step) => ({
+        title: step.title ?? '',
+        description: step.description ?? '',
+      })),
+    });
+  },
+  { deep: true }
+);
+
+function addStep() {
+  state.steps = [...state.steps, createStep()];
+}
+
+function removeStep(index: number) {
+  if (state.steps.length <= 1) return;
+  state.steps = state.steps.filter((_, i) => i !== index);
+}
+</script>

--- a/src/components/authoring/blocks/TabsBlockEditor.vue
+++ b/src/components/authoring/blocks/TabsBlockEditor.vue
@@ -1,0 +1,276 @@
+<template>
+  <section class="md-stack md-stack-4">
+    <header class="md-stack md-stack-1">
+      <h3 class="md-typescale-title-medium font-semibold text-on-surface">Conjunto de abas</h3>
+      <p class="text-sm text-on-surface-variant">
+        Agrupe conteúdos relacionados em abas. Cada aba pode conter texto formatado ou um trecho de
+        código destacado.
+      </p>
+    </header>
+
+    <label class="flex flex-col gap-2">
+      <span class="md-typescale-label-large text-on-surface">Título do bloco</span>
+      <input
+        v-model="state.title"
+        type="text"
+        class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+        autofocus
+      />
+    </label>
+
+    <section
+      class="rounded-3xl border border-outline bg-surface-container-high p-4 md-stack md-stack-3"
+    >
+      <header class="flex items-center justify-between">
+        <div>
+          <h4 class="text-title-small font-semibold text-on-surface">Abas</h4>
+          <p class="text-sm text-on-surface-variant">
+            Defina o rótulo e o conteúdo apresentado em cada aba.
+          </p>
+        </div>
+        <Md3Button type="button" variant="tonal" @click="addTab">
+          <template #leading>
+            <Plus class="md-icon md-icon--sm" aria-hidden="true" />
+          </template>
+          Nova aba
+        </Md3Button>
+      </header>
+
+      <div v-if="state.tabs.length" class="flex flex-col gap-4">
+        <article
+          v-for="(tab, index) in state.tabs"
+          :key="tab.id"
+          class="rounded-3xl border border-outline bg-surface p-4 md-stack md-stack-3"
+        >
+          <header class="flex items-center justify-between gap-3">
+            <h5 class="text-title-small font-semibold text-on-surface">Aba {{ index + 1 }}</h5>
+            <Md3Button
+              v-if="state.tabs.length > 1"
+              type="button"
+              variant="text"
+              class="text-error"
+              @click="removeTab(index)"
+            >
+              <template #leading>
+                <Trash2 class="md-icon md-icon--sm" aria-hidden="true" />
+              </template>
+              Remover
+            </Md3Button>
+          </header>
+
+          <label class="flex flex-col gap-2">
+            <span class="md-typescale-label-large text-on-surface">Rótulo</span>
+            <input
+              v-model="tab.label"
+              type="text"
+              class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            />
+          </label>
+
+          <label class="flex flex-col gap-2">
+            <span class="md-typescale-label-large text-on-surface">Tipo de conteúdo</span>
+            <select
+              v-model="tab.mode"
+              class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            >
+              <option value="text">Texto formatado (HTML)</option>
+              <option value="code">Trecho de código</option>
+            </select>
+          </label>
+
+          <template v-if="tab.mode === 'code'">
+            <label class="flex flex-col gap-2">
+              <span class="md-typescale-label-large text-on-surface">Linguagem</span>
+              <input
+                v-model="tab.language"
+                type="text"
+                class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                placeholder="ex.: javascript, python, plaintext"
+              />
+            </label>
+            <label class="flex flex-col gap-2">
+              <span class="md-typescale-label-large text-on-surface">Código</span>
+              <textarea
+                v-model="tab.content"
+                rows="6"
+                class="rounded-3xl border border-outline bg-surface p-3 font-mono text-sm text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                placeholder="Cole o trecho que será exibido"
+              ></textarea>
+            </label>
+          </template>
+          <template v-else>
+            <label class="flex flex-col gap-2">
+              <span class="md-typescale-label-large text-on-surface"
+                >Conteúdo (HTML permitido)</span
+              >
+              <textarea
+                v-model="tab.content"
+                rows="5"
+                class="rounded-3xl border border-outline bg-surface p-3 text-on-surface shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                placeholder="Parágrafos, listas ou outros elementos HTML simples"
+              ></textarea>
+            </label>
+          </template>
+        </article>
+      </div>
+      <p v-else class="rounded-3xl bg-surface p-4 text-sm text-on-surface-variant">
+        Adicione ao menos uma aba para exibir este bloco na aula.
+      </p>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { reactive, watch } from 'vue';
+import { Plus, Trash2 } from 'lucide-vue-next';
+import Md3Button from '@/components/Md3Button.vue';
+
+type TabMode = 'text' | 'code';
+
+interface EditableTab {
+  id: string;
+  label: string;
+  mode: TabMode;
+  content: string;
+  language: string;
+}
+
+interface TabsBlockInput {
+  type?: string;
+  title?: string;
+  tabs?: Array<
+    | string
+    | {
+        id?: string;
+        label?: string;
+        title?: string;
+        content?: string;
+        html?: string;
+        code?: string;
+        language?: string;
+      }
+  >;
+}
+
+const props = defineProps<{ block: TabsBlockInput }>();
+const emit = defineEmits<{ (event: 'update:block', value: TabsBlockInput): void }>();
+
+function createKey(prefix = 'tab'): string {
+  const globalCrypto =
+    typeof globalThis !== 'undefined' ? (globalThis.crypto as Crypto | undefined) : undefined;
+  if (globalCrypto && typeof globalCrypto.randomUUID === 'function') {
+    return `${prefix}-${globalCrypto.randomUUID()}`;
+  }
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function createTab(): EditableTab {
+  return {
+    id: createKey(),
+    label: 'Nova aba',
+    mode: 'text',
+    content: '',
+    language: '',
+  };
+}
+
+function normalizeTabs(block: TabsBlockInput): EditableTab[] {
+  const raw = Array.isArray(block?.tabs) ? block.tabs : [];
+  if (!raw.length) {
+    return [createTab()];
+  }
+  return raw.map((entry, index) => {
+    if (typeof entry === 'string') {
+      return {
+        id: createKey(`tab-${index + 1}`),
+        label: entry,
+        mode: 'text',
+        content: '',
+        language: '',
+      };
+    }
+    const label =
+      typeof entry?.label === 'string' && entry.label.trim()
+        ? entry.label
+        : typeof entry?.title === 'string'
+          ? entry.title
+          : '';
+    const code = typeof entry?.code === 'string' ? entry.code : '';
+    const html =
+      typeof entry?.html === 'string'
+        ? entry.html
+        : typeof entry?.content === 'string'
+          ? entry.content
+          : '';
+    const hasCode = code.trim().length > 0;
+    return {
+      id: entry?.id ? String(entry.id) : createKey(`tab-${index + 1}`),
+      label,
+      mode: hasCode ? 'code' : 'text',
+      content: hasCode ? code : html,
+      language: hasCode && typeof entry?.language === 'string' ? entry.language : '',
+    };
+  });
+}
+
+function normalizeState(block: TabsBlockInput) {
+  return {
+    type: typeof block?.type === 'string' ? block.type : 'tabs',
+    title: typeof block?.title === 'string' ? block.title : '',
+    tabs: normalizeTabs(block),
+  };
+}
+
+const state = reactive(normalizeState(props.block));
+
+let syncing = false;
+
+watch(
+  () => props.block,
+  (value) => {
+    syncing = true;
+    const next = normalizeState(value ?? {});
+    state.type = next.type;
+    state.title = next.title;
+    state.tabs = next.tabs;
+    syncing = false;
+  },
+  { deep: true }
+);
+
+watch(
+  state,
+  () => {
+    if (syncing) return;
+    emit('update:block', {
+      type: state.type || 'tabs',
+      title: state.title,
+      tabs: state.tabs.map((tab) => {
+        if (tab.mode === 'code') {
+          return {
+            id: tab.id,
+            label: tab.label,
+            code: tab.content,
+            language: tab.language || undefined,
+          };
+        }
+        return {
+          id: tab.id,
+          label: tab.label,
+          content: tab.content,
+        };
+      }),
+    });
+  },
+  { deep: true }
+);
+
+function addTab() {
+  state.tabs = [...state.tabs, createTab()];
+}
+
+function removeTab(index: number) {
+  if (state.tabs.length <= 1) return;
+  state.tabs = state.tabs.filter((_, i) => i !== index);
+}
+</script>

--- a/src/components/authoring/blocks/__tests__/LessonBlockEditors.test.ts
+++ b/src/components/authoring/blocks/__tests__/LessonBlockEditors.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import QuizBlockEditor from '../QuizBlockEditor.vue';
+import ResourceGalleryEditor from '../ResourceGalleryEditor.vue';
+import TabsBlockEditor from '../TabsBlockEditor.vue';
+import RoadmapEditor from '../RoadmapEditor.vue';
+import KnowledgeCheckEditor from '../KnowledgeCheckEditor.vue';
+
+const Md3ButtonStub = {
+  template:
+    '<button type="button" v-bind="$attrs" @click="$emit(\'click\', $event)"><slot name="leading" /><slot /></button>',
+};
+
+const stubs = {
+  Md3Button: Md3ButtonStub,
+  Plus: { template: '<span />' },
+  Trash2: { template: '<span />' },
+};
+
+describe('Lesson block dedicated editors', () => {
+  it('emits update:block when quiz question is alterada', async () => {
+    const wrapper = mount(QuizBlockEditor, {
+      props: {
+        block: {
+          type: 'quiz',
+          title: 'Revisão',
+          question: 'Pergunta original',
+          options: [
+            { id: 'a', text: 'Opção A', correct: true },
+            { id: 'b', text: 'Opção B', correct: false },
+          ],
+          allowRetry: true,
+          feedback: { correct: '', incorrect: '' },
+        },
+      },
+      global: { stubs },
+    });
+
+    const [questionField] = wrapper.findAll('textarea');
+    await questionField.setValue('Qual é a capital do Brasil?');
+
+    const events = wrapper.emitted('update:block');
+    expect(events).toBeTruthy();
+    const payload = events?.at(-1)?.[0] as Record<string, unknown>;
+    expect(payload).toMatchObject({ question: 'Qual é a capital do Brasil?' });
+    expect(Array.isArray(payload?.options)).toBe(true);
+    expect((payload?.options as unknown[]).length).toBe(2);
+  });
+
+  it('emits update:block quando a galeria recebe novo título e tipo', async () => {
+    const wrapper = mount(ResourceGalleryEditor, {
+      props: {
+        block: {
+          type: 'resourceGallery',
+          title: 'Recursos',
+          description: '',
+          items: [{ id: 'item-1', type: 'article', title: 'Guia', url: 'https://example.com' }],
+        },
+      },
+      global: { stubs },
+    });
+
+    const titleInput = wrapper.find('input[type="text"]');
+    await titleInput.setValue('Materiais de apoio');
+
+    const typeSelect = wrapper.find('select');
+    await typeSelect.setValue('video');
+
+    const events = wrapper.emitted('update:block');
+    expect(events).toBeTruthy();
+    const payload = events?.at(-1)?.[0] as Record<string, unknown>;
+    expect(payload).toMatchObject({ title: 'Materiais de apoio' });
+    const items = payload?.items as Array<Record<string, unknown>>;
+    expect(items?.[0]?.type).toBe('video');
+  });
+
+  it('emits update:block ao editar conteúdo de abas', async () => {
+    const wrapper = mount(TabsBlockEditor, {
+      props: {
+        block: {
+          type: 'tabs',
+          title: 'Aba original',
+          tabs: [{ id: 'tab-1', label: 'Introdução', content: 'Conteúdo inicial' }],
+        },
+      },
+      global: { stubs },
+    });
+
+    const textInputs = wrapper.findAll('input[type="text"]');
+    await textInputs[1].setValue('Contexto');
+
+    const contentArea = wrapper.find('textarea');
+    await contentArea.setValue('Descrição atualizada');
+
+    const events = wrapper.emitted('update:block');
+    expect(events).toBeTruthy();
+    const payload = events?.at(-1)?.[0] as Record<string, unknown>;
+    expect(payload).toMatchObject({ title: 'Aba original' });
+    const tabs = payload?.tabs as Array<Record<string, unknown>>;
+    expect(tabs?.[0]).toMatchObject({ label: 'Contexto', content: 'Descrição atualizada' });
+  });
+
+  it('emits update:block ao ajustar passos do roadmap', async () => {
+    const wrapper = mount(RoadmapEditor, {
+      props: {
+        block: {
+          type: 'roadmap',
+          steps: [
+            { title: 'Explorar', description: 'Analise o problema' },
+            { title: 'Construir', description: 'Implemente a solução' },
+          ],
+        },
+      },
+      global: { stubs },
+    });
+
+    const firstInput = wrapper.find('input[type="text"]');
+    await firstInput.setValue('Diagnosticar');
+
+    const events = wrapper.emitted('update:block');
+    expect(events).toBeTruthy();
+    const payload = events?.at(-1)?.[0] as Record<string, unknown>;
+    const steps = payload?.steps as Array<Record<string, unknown>>;
+    expect(steps?.[0]).toMatchObject({ title: 'Diagnosticar' });
+  });
+
+  it('emits update:block ao configurar checagem de conhecimento', async () => {
+    const wrapper = mount(KnowledgeCheckEditor, {
+      props: {
+        block: {
+          type: 'knowledgeCheck',
+          prompt: 'Selecione os pilares da OO',
+          options: [
+            { id: 'op1', text: 'Encapsulamento' },
+            { id: 'op2', text: 'Banco de dados' },
+          ],
+        },
+      },
+      global: { stubs },
+    });
+
+    const explanationField = wrapper.findAll('textarea')[1];
+    await explanationField.setValue('Encapsulamento, herança e polimorfismo.');
+
+    const events = wrapper.emitted('update:block');
+    expect(events).toBeTruthy();
+    const payload = events?.at(-1)?.[0] as Record<string, unknown>;
+    expect(payload).toMatchObject({ explanation: 'Encapsulamento, herança e polimorfismo.' });
+    const options = payload?.options as Array<Record<string, unknown>>;
+    expect(options?.length).toBe(2);
+  });
+});

--- a/src/composables/useLessonEditorModel.ts
+++ b/src/composables/useLessonEditorModel.ts
@@ -45,6 +45,21 @@ const CardGridEditor = defineAsyncComponent(
 const ContentBlockEditor = defineAsyncComponent(
   () => import('@/components/authoring/blocks/ContentBlockEditor.vue')
 );
+const QuizBlockEditor = defineAsyncComponent(
+  () => import('@/components/authoring/blocks/QuizBlockEditor.vue')
+);
+const ResourceGalleryEditor = defineAsyncComponent(
+  () => import('@/components/authoring/blocks/ResourceGalleryEditor.vue')
+);
+const TabsBlockEditor = defineAsyncComponent(
+  () => import('@/components/authoring/blocks/TabsBlockEditor.vue')
+);
+const RoadmapEditor = defineAsyncComponent(
+  () => import('@/components/authoring/blocks/RoadmapEditor.vue')
+);
+const KnowledgeCheckEditor = defineAsyncComponent(
+  () => import('@/components/authoring/blocks/KnowledgeCheckEditor.vue')
+);
 const GenericJsonBlockEditor = defineAsyncComponent(
   () => import('@/components/authoring/blocks/UnsupportedBlockEditor.vue')
 );
@@ -54,6 +69,11 @@ const blockEditorRegistry = Object.freeze({
   callout: CalloutEditor,
   cardGrid: CardGridEditor,
   contentBlock: ContentBlockEditor,
+  quiz: QuizBlockEditor,
+  resourceGallery: ResourceGalleryEditor,
+  tabs: TabsBlockEditor,
+  roadmap: RoadmapEditor,
+  knowledgeCheck: KnowledgeCheckEditor,
 });
 
 type BlockEditorRegistry = typeof blockEditorRegistry;


### PR DESCRIPTION
## Summary
- add authoring editors for quiz, resource gallery, tabs, roadmap and knowledge check blocks with structured forms and update:block emission
- register the new editors in the lesson editor registry so the authoring panel resolves the correct component
- add unit tests covering the new editors to confirm they emit valid block payloads

## Testing
- npx vitest run src/components/authoring/blocks/__tests__/LessonBlockEditors.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e29bac8848832c896ffe51f4c1e9c6