### PR TITLE
Add manifest editor syncing and tests

### DIFF
--- a/src/components/exercise/ExerciseAuthoringSidebar.vue
+++ b/src/components/exercise/ExerciseAuthoringSidebar.vue
@@ -103,6 +103,92 @@
         </div>
       </section>
 
+      <section
+        v-if="hasManifestEntry"
+        class="exercise-authoring-sidebar__section exercise-authoring-sidebar__section--manifest"
+      >
+        <header class="exercise-authoring-sidebar__section-header">
+          <h3 class="md-typescale-title-medium font-semibold text-on-surface">
+            Configurações de publicação
+          </h3>
+        </header>
+
+        <label
+          class="flex items-center gap-2 rounded-xl border border-outline/60 bg-surface-container p-3"
+        >
+          <input
+            id="exercise-manifest-available"
+            data-testid="exercise-availability-toggle"
+            type="checkbox"
+            class="h-4 w-4 rounded border border-outline"
+            v-model="manifestAvailable"
+          />
+          <span class="text-sm text-on-surface">Disponibilizar aos estudantes</span>
+        </label>
+
+        <label class="flex flex-col gap-1">
+          <span class="md-typescale-label-large text-on-surface">Link alternativo</span>
+          <input
+            v-model="manifestLink"
+            type="url"
+            inputmode="url"
+            autocomplete="off"
+            placeholder="https://exemplo.com/exercicio"
+            class="md-shape-extra-large border border-outline bg-surface p-3 text-sm text-on-surface focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          />
+        </label>
+
+        <label class="flex flex-col gap-1">
+          <span class="md-typescale-label-large text-on-surface">Tipo do recurso</span>
+          <select
+            v-model="manifestType"
+            class="md-shape-extra-large border border-outline bg-surface p-3 text-sm text-on-surface focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          >
+            <option
+              v-for="option in exerciseManifestTypeOptions"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </option>
+          </select>
+        </label>
+
+        <fieldset
+          class="md-stack md-stack-2 rounded-xl border border-outline/60 bg-surface-container p-3"
+        >
+          <legend class="px-1 text-sm font-semibold text-on-surface">Metadados de geração</legend>
+          <label class="flex flex-col gap-1">
+            <span class="md-typescale-label-large text-on-surface">Gerado por</span>
+            <input
+              v-model="manifestGeneratedBy"
+              type="text"
+              autocomplete="off"
+              class="md-shape-extra-large border border-outline bg-surface p-3 text-sm text-on-surface focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            />
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="md-typescale-label-large text-on-surface">Modelo</span>
+            <input
+              v-model="manifestModel"
+              type="text"
+              autocomplete="off"
+              class="md-shape-extra-large border border-outline bg-surface p-3 text-sm text-on-surface focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            />
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="md-typescale-label-large text-on-surface">Timestamp</span>
+            <input
+              v-model="manifestTimestamp"
+              type="text"
+              autocomplete="off"
+              placeholder="2025-01-31T12:00:00Z"
+              class="md-shape-extra-large border border-outline bg-surface p-3 text-sm text-on-surface focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            />
+          </label>
+        </fieldset>
+      </section>
+
       <section class="md-stack md-stack-3">
         <div class="flex items-center justify-between">
           <h3 class="md-typescale-title-medium font-semibold text-on-surface">
@@ -222,8 +308,16 @@ import type { LessonAuthoringBlock } from '@/composables/useAuthoringBlockKeys';
 
 type DragEndEvent = { oldIndex?: number | null; newIndex?: number | null };
 
+type ExerciseManifestEntry = Record<string, unknown> & {
+  available?: boolean;
+  link?: string;
+  type?: string;
+  metadata?: Record<string, unknown> | null;
+};
+
 const props = defineProps<{
   exerciseModel: Ref<LessonEditorModel | null>;
+  manifestEntry?: Ref<ExerciseManifestEntry | null>;
   tagsField: WritableComputedRef<string>;
   blocks: LessonAuthoringBlock[];
   draggableBlocks: LessonAuthoringBlock[];
@@ -252,6 +346,8 @@ const exerciseModel = props.exerciseModel;
 const hasExerciseModel = computed(() => exerciseModel.value !== null);
 const isMetadataEditing = ref(false);
 const metadataSectionId = 'exercise-metadata-editor';
+
+const hasManifestEntry = computed(() => Boolean(props.manifestEntry?.value));
 
 watch(exerciseModel, (value) => {
   if (!value) {
@@ -325,6 +421,116 @@ const metadataSummaryItems = computed<ExerciseMetadataSummaryItem[]>(() => {
 const metadataActionLabel = computed(() =>
   isMetadataEditing.value ? 'Fechar metadados' : 'Editar metadados'
 );
+
+const exerciseManifestTypeOptions = [
+  { value: '', label: 'Sem classificação' },
+  { value: 'worksheet', label: 'Lista de exercícios' },
+  { value: 'project', label: 'Projeto guiado' },
+  { value: 'assessment', label: 'Avaliação' },
+  { value: 'quiz', label: 'Quiz' },
+  { value: 'lab', label: 'Laboratório' },
+] as const;
+
+function ensureManifestEntry(): ExerciseManifestEntry | null {
+  return props.manifestEntry?.value ?? null;
+}
+
+function sanitizeManifestInput(value: string): string {
+  return value.trim();
+}
+
+function updateManifestMetadataField(key: string, value: string) {
+  const entry = ensureManifestEntry();
+  if (!entry) return;
+  const normalized = sanitizeManifestInput(value);
+  const metadata =
+    entry.metadata && typeof entry.metadata === 'object'
+      ? (entry.metadata as Record<string, unknown>)
+      : {};
+
+  if (normalized) {
+    metadata[key] = normalized;
+    entry.metadata = { ...metadata };
+  } else {
+    if (metadata[key] !== undefined) {
+      delete metadata[key];
+    }
+    entry.metadata = Object.keys(metadata).length ? { ...metadata } : undefined;
+  }
+}
+
+function readManifestMetadataField(key: string): string {
+  const entry = ensureManifestEntry();
+  if (!entry || !entry.metadata || typeof entry.metadata !== 'object') {
+    return '';
+  }
+  const value = (entry.metadata as Record<string, unknown>)[key];
+  return typeof value === 'string' ? value : '';
+}
+
+const manifestAvailable = computed({
+  get: () => {
+    const entry = ensureManifestEntry();
+    if (!entry) return true;
+    return entry.available !== false;
+  },
+  set: (value: boolean) => {
+    const entry = ensureManifestEntry();
+    if (!entry) return;
+    entry.available = Boolean(value);
+  },
+});
+
+const manifestLink = computed({
+  get: () => {
+    const entry = ensureManifestEntry();
+    if (!entry) return '';
+    return typeof entry.link === 'string' ? entry.link : '';
+  },
+  set: (value: string) => {
+    const entry = ensureManifestEntry();
+    if (!entry) return;
+    const normalized = sanitizeManifestInput(value);
+    if (normalized) {
+      entry.link = normalized;
+    } else {
+      delete entry.link;
+    }
+  },
+});
+
+const manifestType = computed({
+  get: () => {
+    const entry = ensureManifestEntry();
+    if (!entry) return '';
+    return typeof entry.type === 'string' ? entry.type : '';
+  },
+  set: (value: string) => {
+    const entry = ensureManifestEntry();
+    if (!entry) return;
+    const normalized = sanitizeManifestInput(value);
+    if (normalized) {
+      entry.type = normalized;
+    } else {
+      delete entry.type;
+    }
+  },
+});
+
+const manifestGeneratedBy = computed({
+  get: () => readManifestMetadataField('generatedBy'),
+  set: (value: string) => updateManifestMetadataField('generatedBy', value),
+});
+
+const manifestModel = computed({
+  get: () => readManifestMetadataField('model'),
+  set: (value: string) => updateManifestMetadataField('model', value),
+});
+
+const manifestTimestamp = computed({
+  get: () => readManifestMetadataField('timestamp'),
+  set: (value: string) => updateManifestMetadataField('timestamp', value),
+});
 
 function useWritableFieldProxy(field: WritableComputedRef<string>) {
   return computed({

--- a/src/pages/ExerciseView.logic.ts
+++ b/src/pages/ExerciseView.logic.ts
@@ -32,6 +32,11 @@ export interface ExerciseViewController {
   exerciseComponent: ReturnType<typeof shallowRef<any | null>>;
   exerciseFile: ReturnType<typeof ref<string>>;
   loadExercise: () => Promise<void>;
+  exerciseAvailable: ReturnType<typeof ref<boolean>>;
+  exerciseLink: ReturnType<typeof ref<string>>;
+  exerciseType: ReturnType<typeof ref<string>>;
+  exerciseMetadata: ReturnType<typeof shallowRef<GenerationMetadata | null>>;
+  setManifestEntry: (entry: ExerciseManifest | null) => void;
   route: RouteLocationNormalizedLoaded;
 }
 
@@ -65,6 +70,46 @@ export function useExerciseViewController(
   const exerciseSummary = ref('');
   const exerciseComponent = shallowRef<any | null>(null);
   const exerciseFile = ref('');
+  const exerciseAvailable = ref(false);
+  const exerciseLink = ref('');
+  const exerciseType = ref('');
+  const exerciseMetadata = shallowRef<GenerationMetadata | null>(null);
+
+  function applyManifestEntry(entry: ExerciseManifest | null) {
+    if (!entry) {
+      exerciseAvailable.value = false;
+      exerciseLink.value = '';
+      exerciseType.value = '';
+      exerciseMetadata.value = null;
+      return;
+    }
+
+    exerciseAvailable.value = entry.available ?? false;
+    exerciseLink.value = typeof entry.link === 'string' ? entry.link : '';
+    exerciseType.value = typeof entry.type === 'string' ? entry.type : '';
+    exerciseMetadata.value = entry.metadata ? { ...entry.metadata } : null;
+
+    if (typeof entry.title === 'string' && entry.title.length) {
+      exerciseTitle.value = entry.title;
+    }
+    if (typeof entry.summary === 'string' && entry.summary.length) {
+      exerciseSummary.value = entry.summary;
+    }
+  }
+
+  function setManifestEntry(entry: ExerciseManifest | null) {
+    if (!entry) {
+      applyManifestEntry(null);
+      return;
+    }
+
+    const snapshot: ExerciseManifest = {
+      ...entry,
+      metadata: entry.metadata ? { ...entry.metadata } : undefined,
+    };
+
+    applyManifestEntry(snapshot);
+  }
 
   async function loadExercise() {
     exerciseComponent.value = null;
@@ -86,6 +131,8 @@ export function useExerciseViewController(
       });
       const entry = index.find((item) => item.id === currentExercise);
       if (!entry) throw new Error(`Exercise ${currentExercise} not found`);
+
+      setManifestEntry(entry);
 
       exerciseTitle.value = entry.title;
       exerciseSummary.value = entry.summary ?? entry.description ?? '';
@@ -114,6 +161,7 @@ export function useExerciseViewController(
       exerciseTitle.value = 'Erro ao carregar exercício';
       exerciseSummary.value = 'Não foi possível localizar o material solicitado.';
       exerciseFile.value = '';
+      setManifestEntry(null);
     }
   }
 
@@ -133,6 +181,11 @@ export function useExerciseViewController(
     exerciseComponent,
     exerciseFile,
     loadExercise,
+    exerciseAvailable,
+    exerciseLink,
+    exerciseType,
+    exerciseMetadata,
+    setManifestEntry,
     route,
   };
 }

--- a/src/pages/__tests__/ExerciseView.component.test.ts
+++ b/src/pages/__tests__/ExerciseView.component.test.ts
@@ -35,6 +35,10 @@ const createController = () => {
   const exerciseSummary = ref('Resumo');
   const exerciseComponent = shallowRef<any | null>({ render: () => null });
   const exerciseFile = ref('exercise.vue');
+  const exerciseAvailable = ref(true);
+  const exerciseLink = ref('');
+  const exerciseType = ref('worksheet');
+  const exerciseMetadata = shallowRef<Record<string, unknown> | null>(null);
 
   return {
     courseId: computed(() => 'demo'),
@@ -44,6 +48,13 @@ const createController = () => {
     exerciseComponent,
     exerciseFile,
     loadExercise: vi.fn(),
+    exerciseAvailable,
+    exerciseLink,
+    exerciseType,
+    exerciseMetadata,
+    setManifestEntry: vi.fn((entry?: Record<string, unknown> | null) => {
+      exerciseAvailable.value = Boolean(entry?.available ?? true);
+    }),
     route: { params: { courseId: 'demo', exerciseId: 'exercise-01' }, query: {} } as any,
   } satisfies Controller;
 };
@@ -96,12 +107,27 @@ const contentSyncMock = {
   serviceAvailable: true,
 };
 
-let lastContentEditorOptions: {
-  setModel: (model: unknown) => void;
-} | null = null;
+const manifestSyncMock = {
+  loading: ref(false),
+  saving: ref(false),
+  loadError: ref<string | null>(null),
+  saveError: ref<string | null>(null),
+  successMessage: ref<string | null>(null),
+  hasPendingChanges: ref(false),
+  revertChanges: vi.fn(),
+  refresh: vi.fn(),
+  serviceAvailable: true,
+};
+
+let lastManifestEditorOptions: { setModel: (model: unknown) => void } | null = null;
+let lastContentEditorOptions: { setModel: (model: unknown) => void } | null = null;
 
 vi.mock('@/services/useTeacherContentEditor', () => ({
   useTeacherContentEditor: (options: { setModel: (model: unknown) => void }) => {
+    if (!lastManifestEditorOptions) {
+      lastManifestEditorOptions = options;
+      return manifestSyncMock;
+    }
     lastContentEditorOptions = options;
     return contentSyncMock;
   },
@@ -170,9 +196,16 @@ describe('ExerciseView component', () => {
     contentSyncMock.hasPendingChanges.value = false;
     contentSyncMock.revertChanges.mockReset();
     contentSyncMock.serviceAvailable = true;
+    manifestSyncMock.loadError.value = null;
+    manifestSyncMock.saveError.value = null;
+    manifestSyncMock.successMessage.value = null;
+    manifestSyncMock.hasPendingChanges.value = false;
+    manifestSyncMock.revertChanges.mockReset();
+    manifestSyncMock.serviceAvailable = true;
     teacherModeMock.value = true;
     vi.stubEnv('VITE_TEACHER_MODE_ENABLED', 'true');
     toggleTeacherModeMock.mockReset();
+    lastManifestEditorOptions = null;
     lastContentEditorOptions = null;
     if (typeof HTMLElement !== 'undefined') {
       Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
@@ -289,6 +322,51 @@ describe('ExerciseView component', () => {
     await wrapper.vm.$nextTick();
 
     expect(wrapper.get('.block-editor-stub').text()).toContain('Passo 2');
+  });
+
+  it('atualiza disponibilidade do exercício após salvar o manifesto', async () => {
+    const wrapper = mount(ExerciseView, {
+      global: {
+        stubs: {
+          Md3Button: ButtonStub,
+          RouterLink: { template: '<a><slot /></a>' },
+          MetadataListEditor: MetadataListEditorStub,
+          ChevronRight: { template: '<span />' },
+          ArrowLeft: { template: '<span />' },
+          ArrowDown: { template: '<span />' },
+          ArrowUp: { template: '<span />' },
+          GripVertical: { template: '<span />' },
+          Plus: { template: '<span />' },
+          PenSquare: { template: '<span />' },
+          Trash2: { template: '<span />' },
+        },
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+    lastContentEditorOptions?.setModel?.({ title: 'Título', blocks: [] });
+    await wrapper.vm.$nextTick();
+
+    expect(lastManifestEditorOptions).toBeTruthy();
+    lastManifestEditorOptions?.setModel?.({ id: 'exercise-01', available: true });
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    manifestSyncMock.hasPendingChanges.value = true;
+    await wrapper.vm.$nextTick();
+    manifestSyncMock.saving.value = true;
+    await wrapper.vm.$nextTick();
+    manifestSyncMock.saving.value = false;
+    manifestSyncMock.hasPendingChanges.value = false;
+    await wrapper.vm.$nextTick();
+    lastManifestEditorOptions?.setModel?.({ id: 'exercise-01', available: false });
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    expect(controllerMock.setManifestEntry).toHaveBeenCalled();
+    expect(controllerMock.exerciseAvailable.value).toBe(false);
   });
 
   it('exibe aviso no painel quando exercício não possui componente', async () => {


### PR DESCRIPTION
## Summary
- integrate manifest manifest editing into lesson and exercise views, including controller sync
- expand authoring sidebars with manifest availability/link/type/metadata controls
- update component tests to cover manifest save flow for availability

## Testing
- npx vitest run src/pages/__tests__/LessonView.component.test.ts src/pages/__tests__/ExerciseView.component.test.ts --reporter=default
- npx vitest run --reporter=default *(fails: existing "New lesson content blocks > renders PedagogicalNote when teacher mode is enabled" expectation)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a50b5e44832c90cf517f9eb54c3f