### PR TITLE
Ensure manifest entry reactivity and cover edits

### DIFF
--- a/src/pages/ExerciseView.vue
+++ b/src/pages/ExerciseView.vue
@@ -26,7 +26,7 @@
         <ExerciseAuthoringSidebar
           v-if="showAuthoringPanel"
           :exercise-model="exerciseEditor.lessonModel"
-          :manifest-entry="exerciseManifestEntry"
+          v-model:manifest-entry="exerciseManifestEntry"
           :tags-field="exerciseEditor.tagsField"
           :blocks="exerciseBlocks"
           :draggable-blocks="displayedBlocks"
@@ -96,7 +96,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, shallowRef, watch, useId } from 'vue';
+import { computed, ref, watch, useId } from 'vue';
 import { RouterLink } from 'vue-router';
 import {
   AlertCircle,
@@ -315,7 +315,7 @@ const controller = useExerciseViewController();
 const exerciseEditor = useLessonEditorModel();
 const { teacherMode } = useTeacherMode();
 
-const exerciseManifestEntry = shallowRef<ExerciseManifestEntry | null>(null);
+const exerciseManifestEntry = ref<ExerciseManifestEntry | null>(null);
 
 const exerciseManifestPath = computed(() => `courses/${controller.courseId.value}/exercises.json`);
 

--- a/src/pages/LessonView.vue
+++ b/src/pages/LessonView.vue
@@ -26,7 +26,7 @@
         <LessonAuthoringSidebar
           v-if="showAuthoringPanel"
           :lesson-model="lessonEditor.lessonModel"
-          :manifest-entry="lessonManifestEntry"
+          v-model:manifest-entry="lessonManifestEntry"
           :tags-field="lessonEditor.tagsField"
           :create-array-field="lessonEditor.useArrayField"
           :blocks="lessonBlocks"
@@ -698,7 +698,7 @@ const lessonContentPath = computed(() => {
 
 const lessonManifestPath = computed(() => `courses/${controller.courseId.value}/lessons.json`);
 
-const lessonManifestEntry = shallowRef<LessonManifestEntry | null>(null);
+const lessonManifestEntry = ref<LessonManifestEntry | null>(null);
 
 const lessonManifestSync = useTeacherContentEditor<LessonManifestEntry | null, LessonManifestFile>({
   path: lessonManifestPath,


### PR DESCRIPTION
## Summary
- switch the lesson and exercise manifest entry refs to be deeply reactive and wire the sidebars through v-model bindings
- rework the authoring sidebars to emit manifest entry updates and reassign objects when fields change to preserve reactivity
- extend the lesson and exercise view tests to cover manifest edits and pending-change tracking

## Testing
- `npx vitest run src/pages/__tests__/LessonView.component.test.ts src/pages/__tests__/ExerciseView.component.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e2b23fa968832c8f45db7a592f222d