### PR TITLE
Filter course stats to published content

### DIFF
--- a/docs/design-system/layout.md
+++ b/docs/design-system/layout.md
@@ -38,6 +38,7 @@ Os layouts principais foram atualizados com variantes e componentes alinhados ao
 - **Slots adicionais**: `brand`, `actions`, `top-supporting`, `drawer-header/footer`, `rail-header/footer` e `secondary` para conteúdos contextuais do painel docente.
 - **Acessibilidade**: encerra o drawer modal com scrim, propaga labels ARIA e mantém o `aria-current` sincronizado entre rail, drawer e bottom bar.
 - **Integração**: já alimenta o layout de cursos (`CourseLayout.vue`) com breadcrumbs, busca contextual e contagens dinâmicas de aulas/exercícios.
+- **Indicadores publicados**: as contagens exibidas no cabeçalho do curso consideram apenas aulas e exercícios com `available !== false`. No caso dos exercícios, o item também precisa expor um `file` ou `link` válido para ser computado, garantindo que o total reflita somente materiais liberados aos estudantes.
 
 ## Storybook
 

--- a/src/pages/CourseLayout.logic.ts
+++ b/src/pages/CourseLayout.logic.ts
@@ -12,11 +12,17 @@ interface CourseMeta {
 interface LessonSummary {
   id: string;
   title: string;
+  available?: boolean;
+  file?: string;
+  link?: string;
 }
 
 interface ExerciseSummary {
   id: string;
   title: string;
+  available?: boolean;
+  file?: string;
+  link?: string;
 }
 
 export interface CourseLayoutController {
@@ -58,8 +64,15 @@ export function useCourseLayoutController(
   const exercises = ref<ExerciseSummary[]>([]);
   const metaLoaded = ref(false);
 
-  const lessonsCount = computed(() => lessons.value.length);
-  const exercisesCount = computed(() => exercises.value.length);
+  const lessonsCount = computed(
+    () => lessons.value.filter((lesson) => lesson.available !== false).length
+  );
+  const exercisesCount = computed(
+    () =>
+      exercises.value.filter(
+        (exercise) => exercise.available !== false && Boolean(exercise.file || exercise.link)
+      ).length
+  );
 
   async function loadMeta(id: string) {
     try {
@@ -84,7 +97,13 @@ export function useCourseLayoutController(
       const { entries } = normalizeManifest<LessonSummary>(module, {
         context: `CourseLayout:lessons:${id}`,
       });
-      lessons.value = entries.map((lesson) => ({ id: lesson.id, title: lesson.title }));
+      lessons.value = entries.map((lesson) => ({
+        id: lesson.id,
+        title: lesson.title,
+        available: lesson.available,
+        file: lesson.file,
+        link: lesson.link,
+      }));
     } catch (error) {
       console.error('[CourseLayout] Failed to load lessons.json', error);
       lessons.value = [];
@@ -100,7 +119,13 @@ export function useCourseLayoutController(
       const { entries } = normalizeManifest<ExerciseSummary>(module, {
         context: `CourseLayout:exercises:${id}`,
       });
-      exercises.value = entries.map((exercise) => ({ id: exercise.id, title: exercise.title }));
+      exercises.value = entries.map((exercise) => ({
+        id: exercise.id,
+        title: exercise.title,
+        available: exercise.available,
+        file: exercise.file,
+        link: exercise.link,
+      }));
     } catch (error) {
       exercises.value = [];
     }

--- a/src/pages/__tests__/CourseLayout.component.test.ts
+++ b/src/pages/__tests__/CourseLayout.component.test.ts
@@ -6,12 +6,25 @@ import type { CourseLayoutController } from '../CourseLayout.logic';
 type Controller = CourseLayoutController;
 
 const controllerMock: Controller = {
-  meta: { value: { id: 'demo', title: 'Curso Demo', institution: 'Unichristus' } } as any,
-  lessons: { value: [] } as any,
-  exercises: { value: [] } as any,
+  meta: {
+    value: { id: 'demo', title: 'Curso Demo', institution: 'Unichristus' },
+  } as any,
+  lessons: {
+    value: [
+      { id: 'lesson-01', title: 'Aula 1', available: true },
+      { id: 'lesson-02', title: 'Aula 2', available: false },
+    ],
+  } as any,
+  exercises: {
+    value: [
+      { id: 'exercise-01', title: 'Atividade', available: true, file: 'atividade.pdf' },
+      { id: 'exercise-02', title: 'Quiz remoto', link: 'https://example.com/quiz' },
+      { id: 'exercise-03', title: 'Rascunho', available: false, file: 'rascunho.pdf' },
+    ],
+  } as any,
   metaLoaded: { value: true } as any,
-  lessonsCount: { value: 2 } as any,
-  exercisesCount: { value: 1 } as any,
+  lessonsCount: { value: 1 } as any,
+  exercisesCount: { value: 2 } as any,
   refreshCourse: vi.fn(),
   courseId: { value: 'demo' } as any,
   route: { params: {}, query: {}, fullPath: '/demo' } as any,
@@ -45,8 +58,9 @@ describe('CourseLayout component', () => {
 
     expect(wrapper.attributes('aria-busy')).toBe('false');
     expect(wrapper.text()).toContain('Curso Demo');
-    expect(wrapper.text()).toContain('2');
-    expect(wrapper.text()).toContain('1');
+    const stats = wrapper.findAll('.course-page__stats dd');
+    expect(stats[1].text()).toBe('1');
+    expect(stats[2].text()).toBe('2');
   });
 
   it('exibe skeleton quando meta ainda não carregou', () => {

--- a/src/pages/__tests__/CourseLayout.integration.test.ts
+++ b/src/pages/__tests__/CourseLayout.integration.test.ts
@@ -27,16 +27,28 @@ function createController(): CourseLayoutController {
     institution: 'Unichristus',
     description: 'Descrição',
   });
-  const lessons = ref([{ id: 'lesson-01', title: 'Aula 1' }]);
-  const exercises = ref([{ id: 'exercise-01', title: 'Atividade' }]);
+  const lessons = ref([
+    { id: 'lesson-01', title: 'Aula 1', available: true },
+    { id: 'lesson-02', title: 'Aula 2', available: false },
+  ]);
+  const exercises = ref([
+    { id: 'exercise-01', title: 'Atividade', available: true, file: 'atividade.pdf' },
+    { id: 'exercise-02', title: 'Rascunho', available: false, file: 'rascunho.pdf' },
+    { id: 'exercise-03', title: 'Quiz remoto', link: 'https://example.com/quiz' },
+  ]);
 
   return {
     meta,
     lessons,
     exercises,
     metaLoaded,
-    lessonsCount: computed(() => lessons.value.length),
-    exercisesCount: computed(() => exercises.value.length),
+    lessonsCount: computed(() => lessons.value.filter((item) => item.available !== false).length),
+    exercisesCount: computed(
+      () =>
+        exercises.value.filter(
+          (item) => item.available !== false && Boolean(item.file || item.link)
+        ).length
+    ),
     refreshCourse: vi.fn(),
     courseId: computed(() => 'demo'),
     route: router.currentRoute.value,
@@ -68,7 +80,9 @@ describe('CourseLayout integration', () => {
 
     expect(wrapper.attributes('aria-busy')).toBe('false');
     expect(wrapper.text()).toContain('Curso Demo');
-    expect(wrapper.text()).toContain('1');
+    const stats = wrapper.findAll('.course-page__stats dd');
+    expect(stats[1].text()).toBe('1');
+    expect(stats[2].text()).toBe('2');
   });
 
   it('exibe loading quando meta não carregou', () => {

--- a/src/pages/__tests__/CourseLayout.logic.test.ts
+++ b/src/pages/__tests__/CourseLayout.logic.test.ts
@@ -19,13 +19,19 @@ const metaEntry = vi.hoisted(() => ({
 
 const lessonsManifest = vi.hoisted(() => ({
   entries: [
-    { id: 'lesson-01', title: 'Introdução' },
-    { id: 'lesson-02', title: 'Capítulo 2' },
+    { id: 'lesson-01', title: 'Introdução', available: true },
+    { id: 'lesson-02', title: 'Capítulo 2', available: false },
+    { id: 'lesson-03', title: 'Encerramento' },
   ],
 }));
 
 const exercisesManifest = vi.hoisted(() => ({
-  entries: [{ id: 'exercise-01', title: 'Projeto inicial' }],
+  entries: [
+    { id: 'exercise-01', title: 'Projeto inicial', available: true, file: 'exercise-01.md' },
+    { id: 'exercise-02', title: 'Checklist', link: 'https://example.com/checklist' },
+    { id: 'exercise-03', title: 'Rascunho', available: false, file: 'exercise-03.md' },
+    { id: 'exercise-04', title: 'Sem recurso', available: true },
+  ],
 }));
 
 function createController() {
@@ -54,8 +60,16 @@ describe('CourseLayout logic', () => {
 
     expect(controller.metaLoaded.value).toBe(true);
     expect(controller.meta.value?.title).toBe('Curso Demo');
+    expect(controller.lessons.value).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: 'lesson-02', available: false })])
+    );
+    expect(controller.exercises.value).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'exercise-02', link: 'https://example.com/checklist' }),
+      ])
+    );
     expect(controller.lessonsCount.value).toBe(2);
-    expect(controller.exercisesCount.value).toBe(1);
+    expect(controller.exercisesCount.value).toBe(2);
   });
 
   it('reseta estado ao receber id vazio', async () => {


### PR DESCRIPTION
## Summary
- preserve availability metadata when loading course manifests and filter lessons/exercises counts to published content
- ensure the CourseLayout header and component tests reflect totals based only on accessible materials
- document that course indicators only include released lessons and exercises

## Testing
- npx vitest run src/pages/__tests__/CourseLayout.logic.test.ts src/pages/__tests__/CourseLayout.integration.test.ts src/pages/__tests__/CourseLayout.component.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e2b7b76570832cbf8461e6c8717ded