### PR TITLE
Fix sidebar visibility in preview mode

### DIFF
--- a/src/components/teacher/TeacherAuthoringWorkspace.vue
+++ b/src/components/teacher/TeacherAuthoringWorkspace.vue
@@ -70,7 +70,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch, useSlots } from 'vue';
+import { Comment, computed, ref, watch, useSlots } from 'vue';
 
 type WorkspaceView = 'editor' | 'preview';
 
@@ -103,7 +103,14 @@ const previewEnabled = computed(() => props.previewEnabled);
 
 const showViewSelector = computed(() => editorEnabled.value && previewEnabled.value);
 const slots = useSlots();
-const hasSidebar = computed(() => Boolean(slots.sidebar));
+const hasSidebar = computed(() => {
+  const sidebarSlot = slots.sidebar?.();
+  if (!sidebarSlot) {
+    return false;
+  }
+
+  return sidebarSlot.some((node) => node.type !== Comment);
+});
 
 watch(
   () => props.view,


### PR DESCRIPTION
## Summary
- ensure the teacher authoring sidebar is hidden when no sidebar content is provided
- treat empty sidebar slots as absent so the preview layout no longer renders the empty sidebar frame in preview mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2d805748c832c9a4de60126f3e42b