### PR TITLE
Hide authoring workspace when teacher mode is disabled

### DIFF
--- a/src/pages/ExerciseView.vue
+++ b/src/pages/ExerciseView.vue
@@ -17,6 +17,7 @@
     </nav>
 
     <TeacherAuthoringWorkspace
+      v-if="showTeacherWorkspace"
       v-model:view="workspaceView"
       class="exercise-view__workspace"
       :editor-enabled="showAuthoringPanel"
@@ -92,6 +93,34 @@
         </div>
       </template>
     </TeacherAuthoringWorkspace>
+
+    <div v-else class="teacher-preview-shell">
+      <article class="card max-w-none md-stack md-stack-6 p-8">
+        <header class="md-stack md-stack-3">
+          <div class="md-stack md-stack-2">
+            <p
+              class="text-label-medium uppercase tracking-[0.2em] text-on-surface-variant opacity-80"
+            >
+              Exercício
+            </p>
+            <h2 class="text-headline-medium font-semibold text-on-surface">
+              {{ exerciseTitle }}
+            </h2>
+            <p v-if="exerciseSummary" class="text-body-large !mt-4">{{ exerciseSummary }}</p>
+          </div>
+        </header>
+        <div class="divider" role="presentation"></div>
+
+        <component
+          v-if="exerciseComponent"
+          :is="exerciseComponent"
+          class="lesson-content prose max-w-none dark:prose-invert"
+        />
+        <p v-else class="text-body-medium text-on-surface-variant">
+          Conteúdo deste exercício ainda não está disponível.
+        </p>
+      </article>
+    </div>
   </section>
 </template>
 
@@ -306,7 +335,7 @@ const workspaceView = ref<WorkspaceView>('editor');
 const controller = useExerciseViewController();
 
 const exerciseEditor = useLessonEditorModel();
-const { teacherMode } = useTeacherMode();
+const { isAuthoringEnabled } = useTeacherMode();
 
 const exerciseManifestEntry = ref<ExerciseManifestEntry | null>(null);
 
@@ -589,9 +618,11 @@ const statusIconClass = computed(() =>
 );
 
 const authoringExercise = computed(() => exerciseEditor.lessonModel.value);
+const showTeacherWorkspace = computed(() => isAuthoringEnabled.value);
+
 const showAuthoringPanel = computed(
   () =>
-    teacherMode.value &&
+    isAuthoringEnabled.value &&
     exerciseContentSync.serviceAvailable &&
     exerciseManifestSync.serviceAvailable
 );

--- a/src/pages/LessonView.vue
+++ b/src/pages/LessonView.vue
@@ -17,6 +17,7 @@
     </nav>
 
     <TeacherAuthoringWorkspace
+      v-if="showTeacherWorkspace"
       v-model:view="workspaceView"
       class="lesson-view__workspace"
       :editor-enabled="showAuthoringPanel"
@@ -106,6 +107,47 @@
         </div>
       </template>
     </TeacherAuthoringWorkspace>
+
+    <div v-else class="teacher-preview-shell">
+      <article v-if="lessonContent" class="card max-w-none md-stack md-stack-6 p-8">
+        <header class="md-stack md-stack-2">
+          <p
+            class="text-label-medium uppercase tracking-[0.2em] text-on-surface-variant opacity-80"
+          >
+            Conteúdo da aula
+          </p>
+          <h2 class="text-headline-medium font-semibold text-on-surface">
+            {{ lessonTitle }}
+          </h2>
+          <p v-if="lessonObjective" class="text-body-large !mt-4">{{ lessonObjective }}</p>
+          <LessonOverview
+            :summary="lessonSummary"
+            :duration="lessonDuration"
+            :modality="lessonModality"
+            :tags="lessonTags"
+          />
+        </header>
+
+        <LessonReadiness
+          :skills="lessonSkills"
+          :outcomes="lessonOutcomes"
+          :prerequisites="lessonPrerequisites"
+        />
+
+        <div class="divider" role="presentation"></div>
+
+        <div ref="lessonContentRoot" class="lesson-content prose max-w-none dark:prose-invert">
+          <LessonRenderer :data="lessonContent" />
+        </div>
+      </article>
+
+      <article
+        v-else
+        class="card max-w-none md-stack md-stack-3 p-8 text-center text-body-medium text-on-surface-variant"
+      >
+        Não foi possível carregar esta aula.
+      </article>
+    </div>
   </section>
 </template>
 
@@ -680,7 +722,7 @@ const controller = useLessonViewController({
 });
 
 const lessonEditor = useLessonEditorModel();
-const { teacherMode } = useTeacherMode();
+const { isAuthoringEnabled } = useTeacherMode();
 
 const lessonContentPath = computed(() => {
   const file = controller.lessonContentFile.value;
@@ -828,9 +870,13 @@ const lessonContent = computed<LessonRendererContent | null>(() => {
   return normalized;
 });
 
+const showTeacherWorkspace = computed(() => isAuthoringEnabled.value);
+
 const showAuthoringPanel = computed(
   () =>
-    teacherMode.value && lessonContentSync.serviceAvailable && lessonManifestSync.serviceAvailable
+    isAuthoringEnabled.value &&
+    lessonContentSync.serviceAvailable &&
+    lessonManifestSync.serviceAvailable
 );
 
 watch(lessonBlocks, (current) => {

--- a/src/pages/__tests__/ExerciseView.component.test.ts
+++ b/src/pages/__tests__/ExerciseView.component.test.ts
@@ -638,8 +638,9 @@ describe('ExerciseView component', () => {
       },
     });
 
+    expect(wrapper.find('.teacher-authoring-workspace').exists()).toBe(false);
     expect(wrapper.find('.exercise-block-editor').exists()).toBe(false);
-    expect(wrapper.find('.lesson-content').exists()).toBe(false);
+    expect(wrapper.text()).toContain('Título');
   });
 
   it('aplica layout expandido de professor quando automação está disponível', async () => {

--- a/src/pages/__tests__/LessonView.component.test.ts
+++ b/src/pages/__tests__/LessonView.component.test.ts
@@ -453,6 +453,7 @@ describe('LessonView component', () => {
 
     const wrapper = mountComponent();
 
+    expect(wrapper.find('.teacher-authoring-workspace').exists()).toBe(false);
     expect(wrapper.find('.lesson-block-editor').exists()).toBe(false);
     expect(wrapper.find('.lesson-content').exists()).toBe(true);
   });


### PR DESCRIPTION
## Summary
- render the authoring workspace only when teacher mode is enabled in lesson and exercise pages
- keep the lesson and exercise previews available outside of the authoring UI for non-teacher sessions
- refresh the component tests to cover the new teacher mode visibility rules

## Testing
- npm run test -- src/pages/__tests__/LessonView.component.test.ts src/pages/__tests__/ExerciseView.component.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e2d9d555b8832ca46079e4adfc435c