### PR TITLE
Replace unavailable TGS lesson 17 videos

### DIFF
--- a/src/content/courses/tgs/lessons/lesson-17.json
+++ b/src/content/courses/tgs/lessons/lesson-17.json
@@ -634,18 +634,18 @@
       "title": "Para aprofundar",
       "videos": [
         {
-          "url": "https://www.youtube.com/watch?v=2zNHdS6Gs6Y",
-          "title": "Webinar FGV – Business Intelligence no setor público",
-          "caption": "Discussão em português sobre fundamentos de BI aplicados à gestão pública e tomada de decisão integrada.",
-          "author": "FGV Conhecimento",
-          "source": "YouTube"
+          "url": "https://www.ted.com/talks/david_mccandless_the_beauty_of_data_visualization",
+          "title": "David McCandless – The beauty of data visualization",
+          "caption": "Como histórias visuais transformam indicadores em narrativas acionáveis; possui legendas em português.",
+          "author": "David McCandless",
+          "source": "TED"
         },
         {
-          "url": "https://www.youtube.com/watch?v=qb4n2ymlk4U",
-          "title": "Sebrae – Como usar Business Intelligence no seu negócio",
-          "caption": "Vídeo em português que apresenta conceitos de BI, indicadores e exemplos de dashboards acessíveis.",
-          "author": "Sebrae",
-          "source": "YouTube"
+          "url": "https://www.ted.com/talks/hans_rosling_the_best_stats_you_ve_ever_seen",
+          "title": "Hans Rosling – The best stats you've ever seen",
+          "caption": "Demonstra como interpretar dados com recortes territoriais e feedbacks, conectando BI à visão sistêmica.",
+          "author": "Hans Rosling",
+          "source": "TED"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- replace broken Business Intelligence video links in TGS lesson 17 with accessible TED talks on data visualization and interpretation
- keep contextual captions emphasizing systemic reading of dashboards and availability of Portuguese subtitles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f15fd9bbf4832cb97797be5335a41d